### PR TITLE
Apply RBAC and validation to core routes

### DIFF
--- a/packages/backend/src/routes/dailyReports.ts
+++ b/packages/backend/src/routes/dailyReports.ts
@@ -1,16 +1,18 @@
 import { FastifyInstance } from 'fastify';
 import { PrismaClient } from '@prisma/client';
+import { dailyReportSchema } from './validators.js';
+import { requireRole } from '../services/rbac.js';
 
 const prisma = new PrismaClient();
 
 export async function registerDailyReportRoutes(app: FastifyInstance) {
-  app.post('/daily-reports', async (req) => {
+  app.post('/daily-reports', { schema: dailyReportSchema, preHandler: requireRole(['admin', 'mgmt', 'user']) }, async (req) => {
     const body = req.body as any;
     const report = await prisma.dailyReport.create({ data: body });
     return report;
   });
 
-  app.get('/daily-reports', async () => {
+  app.get('/daily-reports', { preHandler: requireRole(['admin', 'mgmt', 'user']) }, async () => {
     const reports = await prisma.dailyReport.findMany({ orderBy: { reportDate: 'desc' }, take: 50 });
     return { items: reports };
   });

--- a/packages/backend/src/routes/expenses.ts
+++ b/packages/backend/src/routes/expenses.ts
@@ -3,23 +3,24 @@ import { PrismaClient } from '@prisma/client';
 import { createApproval } from '../services/approval.js';
 import { expenseSchema } from './validators.js';
 import { DocStatusValue, FlowTypeValue } from '../types.js';
+import { requireRole } from '../services/rbac.js';
 
 const prisma = new PrismaClient();
 
 export async function registerExpenseRoutes(app: FastifyInstance) {
-  app.post('/expenses', { schema: expenseSchema }, async (req) => {
+  app.post('/expenses', { schema: expenseSchema, preHandler: requireRole(['admin', 'mgmt', 'user']) }, async (req) => {
     const body = req.body as any;
     const expense = await prisma.expense.create({ data: body });
     return expense;
   });
 
-  app.get('/expenses', async (req) => {
+  app.get('/expenses', { preHandler: requireRole(['admin', 'mgmt', 'user']) }, async (req) => {
     const { projectId, userId } = req.query as { projectId?: string; userId?: string };
     const items = await prisma.expense.findMany({ where: { projectId, userId }, orderBy: { incurredOn: 'desc' }, take: 200 });
     return { items };
   });
 
-  app.post('/expenses/:id/submit', async (req) => {
+  app.post('/expenses/:id/submit', { preHandler: requireRole(['admin', 'mgmt']) }, async (req) => {
     const { id } = req.params as { id: string };
     const exp = await prisma.expense.update({ where: { id }, data: { status: DocStatusValue.pending_qa } });
     await createApproval(FlowTypeValue.expense, 'expenses', id, [{ approverGroupId: 'mgmt' }]);

--- a/packages/backend/src/routes/projects.ts
+++ b/packages/backend/src/routes/projects.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from 'fastify';
 import { PrismaClient } from '@prisma/client';
+import { requireRole } from '../services/rbac.js';
 
 const prisma = new PrismaClient();
 
@@ -9,7 +10,7 @@ export async function registerProjectRoutes(app: FastifyInstance) {
     return { items: projects };
   });
 
-  app.post('/projects', async (req) => {
+  app.post('/projects', { preHandler: requireRole(['admin', 'mgmt']) }, async (req) => {
     const body = req.body as any;
     const project = await prisma.project.create({ data: body });
     return project;

--- a/packages/backend/src/routes/timeEntries.ts
+++ b/packages/backend/src/routes/timeEntries.ts
@@ -2,24 +2,25 @@ import { FastifyInstance } from 'fastify';
 import { PrismaClient } from '@prisma/client';
 import { timeEntrySchema } from './validators.js';
 import { TimeStatusValue } from '../types.js';
+import { requireRole } from '../services/rbac.js';
 
 const prisma = new PrismaClient();
 
 export async function registerTimeEntryRoutes(app: FastifyInstance) {
-  app.post('/time-entries', { schema: timeEntrySchema }, async (req) => {
+  app.post('/time-entries', { schema: timeEntrySchema, preHandler: requireRole(['admin', 'mgmt', 'user']) }, async (req) => {
     const body = req.body as any;
     const entry = await prisma.timeEntry.create({ data: body });
     return entry;
   });
 
-  app.patch('/time-entries/:id', { schema: timeEntrySchema }, async (req) => {
+  app.patch('/time-entries/:id', { schema: timeEntrySchema, preHandler: requireRole(['admin', 'mgmt', 'user']) }, async (req) => {
     const { id } = req.params as { id: string };
     const body = req.body as any;
     const entry = await prisma.timeEntry.update({ where: { id }, data: body });
     return entry;
   });
 
-  app.get('/time-entries', async (req) => {
+  app.get('/time-entries', { preHandler: requireRole(['admin', 'mgmt', 'user']) }, async (req) => {
     const { projectId, userId } = req.query as { projectId?: string; userId?: string };
     const entries = await prisma.timeEntry.findMany({
       where: { projectId, userId },
@@ -29,7 +30,7 @@ export async function registerTimeEntryRoutes(app: FastifyInstance) {
     return { items: entries };
   });
 
-  app.post('/time-entries/:id/submit', async (req) => {
+  app.post('/time-entries/:id/submit', { preHandler: requireRole(['admin', 'mgmt']) }, async (req) => {
     const { id } = req.params as { id: string };
     const entry = await prisma.timeEntry.update({ where: { id }, data: { status: TimeStatusValue.submitted } });
     return entry;

--- a/packages/backend/src/routes/validators.ts
+++ b/packages/backend/src/routes/validators.ts
@@ -25,3 +25,80 @@ export const expenseSchema = {
     receiptUrl: Type.Optional(Type.String()),
   }),
 };
+
+export const estimateSchema = {
+  body: Type.Object({
+    lines: Type.Optional(Type.Array(Type.Any())),
+    totalAmount: Type.Number(),
+    currency: Type.Optional(Type.String()),
+    validUntil: Type.Optional(Type.String()),
+    notes: Type.Optional(Type.String()),
+  }),
+};
+
+export const invoiceSchema = {
+  body: Type.Object({
+    estimateId: Type.Optional(Type.String()),
+    milestoneId: Type.Optional(Type.String()),
+    issueDate: Type.Optional(Type.String()),
+    dueDate: Type.Optional(Type.String()),
+    currency: Type.Optional(Type.String()),
+    totalAmount: Type.Number(),
+    lines: Type.Optional(Type.Array(Type.Any())),
+  }),
+};
+
+export const purchaseOrderSchema = {
+  body: Type.Object({
+    vendorId: Type.String(),
+    issueDate: Type.Optional(Type.String()),
+    dueDate: Type.Optional(Type.String()),
+    currency: Type.Optional(Type.String()),
+    totalAmount: Type.Number(),
+    lines: Type.Optional(Type.Array(Type.Any())),
+  }),
+};
+
+export const vendorInvoiceSchema = {
+  body: Type.Object({
+    projectId: Type.String(),
+    vendorId: Type.String(),
+    vendorInvoiceNo: Type.Optional(Type.String()),
+    receivedDate: Type.Optional(Type.String()),
+    dueDate: Type.Optional(Type.String()),
+    currency: Type.Optional(Type.String()),
+    totalAmount: Type.Number(),
+    documentUrl: Type.Optional(Type.String()),
+  }),
+};
+
+export const vendorQuoteSchema = {
+  body: Type.Object({
+    projectId: Type.String(),
+    vendorId: Type.String(),
+    quoteNo: Type.Optional(Type.String()),
+    issueDate: Type.Optional(Type.String()),
+    currency: Type.Optional(Type.String()),
+    totalAmount: Type.Number(),
+    documentUrl: Type.Optional(Type.String()),
+  }),
+};
+
+export const dailyReportSchema = {
+  body: Type.Object({
+    content: Type.String(),
+    reportDate: Type.String(),
+    linkedProjectIds: Type.Optional(Type.Array(Type.String())),
+    status: Type.Optional(Type.String()),
+  }),
+};
+
+export const wellbeingSchema = {
+  body: Type.Object({
+    entryDate: Type.String(),
+    status: Type.String(),
+    notes: Type.Optional(Type.String()),
+    helpRequested: Type.Optional(Type.Boolean()),
+    visibilityGroupId: Type.String(),
+  }),
+};

--- a/packages/backend/src/routes/vendorDocs.ts
+++ b/packages/backend/src/routes/vendorDocs.ts
@@ -2,23 +2,25 @@ import { FastifyInstance } from 'fastify';
 import { PrismaClient } from '@prisma/client';
 import { createApproval } from '../services/approval.js';
 import { FlowTypeValue, DocStatusValue } from '../types.js';
+import { vendorInvoiceSchema, vendorQuoteSchema } from './validators.js';
+import { requireRole } from '../services/rbac.js';
 
 const prisma = new PrismaClient();
 
 export async function registerVendorDocRoutes(app: FastifyInstance) {
-  app.post('/vendor-quotes', async (req) => {
+  app.post('/vendor-quotes', { preHandler: requireRole(['admin', 'mgmt']), schema: vendorQuoteSchema }, async (req) => {
     const body = req.body as any;
     const vendorQuote = await prisma.vendorQuote.create({ data: body });
     return vendorQuote;
   });
 
-  app.post('/vendor-invoices', async (req) => {
+  app.post('/vendor-invoices', { preHandler: requireRole(['admin', 'mgmt']), schema: vendorInvoiceSchema }, async (req) => {
     const body = req.body as any;
     const vi = await prisma.vendorInvoice.create({ data: body });
     return vi;
   });
 
-  app.post('/vendor-invoices/:id/approve', async (req) => {
+  app.post('/vendor-invoices/:id/approve', { preHandler: requireRole(['admin', 'mgmt']) }, async (req) => {
     const { id } = req.params as { id: string };
     const vi = await prisma.vendorInvoice.update({ where: { id }, data: { status: DocStatusValue.pending_qa } });
     await createApproval(FlowTypeValue.vendor_invoice, 'vendor_invoices', id, [{ approverGroupId: 'mgmt' }, { approverGroupId: 'exec' }]);

--- a/packages/backend/src/routes/wellbeing.ts
+++ b/packages/backend/src/routes/wellbeing.ts
@@ -1,16 +1,18 @@
 import { FastifyInstance } from 'fastify';
 import { PrismaClient } from '@prisma/client';
+import { wellbeingSchema } from './validators.js';
+import { requireRole } from '../services/rbac.js';
 
 const prisma = new PrismaClient();
 
 export async function registerWellbeingRoutes(app: FastifyInstance) {
-  app.post('/wellbeing-entries', async (req) => {
+  app.post('/wellbeing-entries', { schema: wellbeingSchema, preHandler: requireRole(['admin', 'mgmt', 'user']) }, async (req) => {
     const body = req.body as any;
     const entry = await prisma.wellbeingEntry.create({ data: body });
     return entry;
   });
 
-  app.get('/wellbeing-entries', async () => {
+  app.get('/wellbeing-entries', { preHandler: requireRole(['hr', 'admin']) }, async () => {
     const items = await prisma.wellbeingEntry.findMany({ orderBy: { entryDate: 'desc' }, take: 50 });
     return { items };
   });


### PR DESCRIPTION
## Summary
- add preHandler RBAC to projects/create, estimates/invoices submit/create, PO/vendor docs, expenses/time/daily/wellbeing
- add TypeBox validation schemas for estimates/invoices/PO/vendor docs/daily/wellbeing
- restrict wellbeing GET to hr/admin
