### PR TITLE
CI: run prisma generate before backend build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,12 @@ jobs:
         with:
           node-version: 18
       - run: npm install --prefix packages/backend
+      - run: npx prisma generate --schema=prisma/schema.prisma
+        env:
+          DATABASE_URL: postgresql://user:pass@localhost:5432/postgres?schema=public
       - run: npm run build --prefix packages/backend
+        env:
+          DATABASE_URL: postgresql://user:pass@localhost:5432/postgres?schema=public
       - run: npx prisma format --schema=prisma/schema.prisma
       - run: npx prisma validate --schema=prisma/schema.prisma
   frontend:


### PR DESCRIPTION
## Summary
- add prisma generate step with dummy DATABASE_URL
- backend build now has DATABASE_URL set to avoid client missing errors
