### PR TITLE
Add ETL samples and data-quality SQL checks

### DIFF
--- a/docs/requirements/migration-script-sample.md
+++ b/docs/requirements/migration-script-sample.md
@@ -1,6 +1,6 @@
 # 移行スクリプト雛形（サンプル）
 
-Python + CSV で一方向にロードする最小例。実際は FDW/DBT でも可。
+Python + CSV で一方向にロードする最小例。実際は FDW/DBT でも可。SQL 版の雛形も末尾に記載。
 
 ```python
 import csv
@@ -51,9 +51,48 @@ with open('time_entries_load.csv', 'w', newline='') as f:
     writer.writeheader(); writer.writerows(out)
 ```
 
-手順:
-1. legacy DB から CSV 抽出
-2. 上記のような変換スクリプトで新ID発行/マッピング
+## SQL + COPY での変換/ロード例
+PostgreSQL 同士の場合のサンプル。旧DBを`legacy` FDWで参照し、新DBにUUIDとコード正規化を付与する。
+
+```sql
+-- 1) 旧→新のIDマップ用テーブル
+create table if not exists mapping_projects(legacy_id text primary key, new_id uuid not null);
+create table if not exists mapping_users(legacy_id text primary key, new_id uuid not null);
+
+-- 2) IDマッピングを生成
+insert into mapping_projects(legacy_id, new_id)
+select p.project_id, gen_random_uuid()
+from legacy.im_projects p
+on conflict do nothing;
+
+insert into mapping_users(legacy_id, new_id)
+select u.user_id, gen_random_uuid()
+from legacy.cc_users u
+on conflict do nothing;
+
+-- 3) プロジェクトをロード
+insert into "Project"(id, code, name, status, "createdAt")
+select m.new_id, p.project_code, p.project_name, 'active', now()
+from legacy.im_projects p
+join mapping_projects m on m.legacy_id = p.project_id;
+
+-- 4) 工数をロード
+insert into "TimeEntry"(id, "projectId", "userId", "workDate", minutes, status, "createdAt")
+select gen_random_uuid(),
+       mp.new_id,
+       mu.new_id,
+       t.work_date::date,
+       (t.hours * 60)::int,
+       'submitted',
+       now()
+from legacy.im_timesheet t
+join mapping_projects mp on mp.legacy_id = t.project_id
+left join mapping_users mu on mu.legacy_id = t.user_id;
+```
+
+## 手順チェックリスト
+1. legacy DB から CSV 抽出 or FDW で参照
+2. 上記のような変換スクリプトで新ID発行/マッピング（mapping_* テーブルに保持）
 3. `COPY` などで新テーブルにロード
 4. 件数/合計値をプロジェクト単位で突き合わせる
 


### PR DESCRIPTION
移行・品質チェック周りのドキュメントを拡充しました。\n\n- migration-script-sample.md に SQL + COPY ベースのETL雛形とIDマッピングテーブル作成例を追加\n- migration-mapping.md に mapping_projects/users/vendors のDDLサンプルと運用メモを追加\n- data-quality-checks.md に番号フォーマット/金額整合/マッピング重複のSQLチェック例を追加\n\nコード変更なしでドキュメントのみの更新です。