### PR TITLE
Add audit log model and wire key actions

### DIFF
--- a/packages/backend/src/routes/wellbeing.ts
+++ b/packages/backend/src/routes/wellbeing.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from 'fastify';
 import { wellbeingSchema } from './validators.js';
 import { requireRole } from '../services/rbac.js';
 import { prisma } from '../services/db.js';
+import { logAudit } from '../services/audit.js';
 
 export async function registerWellbeingRoutes(app: FastifyInstance) {
   app.post('/wellbeing-entries', { schema: wellbeingSchema, preHandler: requireRole(['admin', 'mgmt', 'user']) }, async (req) => {
@@ -12,6 +13,7 @@ export async function registerWellbeingRoutes(app: FastifyInstance) {
 
   app.get('/wellbeing-entries', { preHandler: requireRole(['hr', 'admin']) }, async () => {
     const items = await prisma.wellbeingEntry.findMany({ orderBy: { entryDate: 'desc' }, take: 50 });
+    await logAudit({ action: 'wellbeing_view', targetTable: 'wellbeing_entries' });
     return { items };
   });
 }

--- a/packages/backend/src/services/audit.ts
+++ b/packages/backend/src/services/audit.ts
@@ -1,0 +1,26 @@
+import { prisma } from './db.js';
+
+type AuditInput = {
+  action: string;
+  userId?: string;
+  targetTable?: string;
+  targetId?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export async function logAudit(entry: AuditInput) {
+  try {
+    await prisma.auditLog.create({
+      data: {
+        action: entry.action,
+        userId: entry.userId,
+        targetTable: entry.targetTable,
+        targetId: entry.targetId,
+        metadata: entry.metadata ? entry.metadata : undefined,
+      },
+    });
+  } catch (err) {
+    // 粗めのスタブ: 失敗してもアプリ処理は継続
+    console.error('[audit log failed]', err);
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,26 +61,26 @@ enum AlertType {
 }
 
 model Customer {
-  id                   String    @id @default(uuid())
-  code                 String    @unique
-  name                 String
+  id                    String    @id @default(uuid())
+  code                  String    @unique
+  name                  String
   invoiceRegistrationId String?
-  taxRegion            String?
-  billingAddress       String?
-  status               String
-  externalSource       String?
-  externalId           String?
-  contacts             Contact[]
-  projects             Project[]
-  createdAt            DateTime  @default(now())
-  createdBy            String?
-  updatedAt            DateTime  @updatedAt
-  updatedBy            String?
+  taxRegion             String?
+  billingAddress        String?
+  status                String
+  externalSource        String?
+  externalId            String?
+  contacts              Contact[]
+  projects              Project[]
+  createdAt             DateTime  @default(now())
+  createdBy             String?
+  updatedAt             DateTime  @updatedAt
+  updatedBy             String?
 }
 
 model Vendor {
-  id             String    @id @default(uuid())
-  code           String    @unique
+  id             String          @id @default(uuid())
+  code           String          @unique
   name           String
   bankInfo       String?
   taxRegion      String?
@@ -91,67 +91,67 @@ model Vendor {
   purchaseOrders PurchaseOrder[]
   vendorQuotes   VendorQuote[]
   vendorInvoices VendorInvoice[]
-  createdAt      DateTime  @default(now())
+  createdAt      DateTime        @default(now())
   createdBy      String?
-  updatedAt      DateTime  @updatedAt
+  updatedAt      DateTime        @updatedAt
   updatedBy      String?
 }
 
 model Contact {
-  id          String   @id @default(uuid())
-  customer    Customer? @relation(fields: [customerId], references: [id])
-  customerId  String?
-  vendor      Vendor?  @relation(fields: [vendorId], references: [id])
-  vendorId    String?
-  name        String
-  email       String?
-  phone       String?
-  role        String?
-  isPrimary   Boolean  @default(false)
-  createdAt   DateTime @default(now())
-  createdBy   String?
-  updatedAt   DateTime @updatedAt
-  updatedBy   String?
+  id         String    @id @default(uuid())
+  customer   Customer? @relation(fields: [customerId], references: [id])
+  customerId String?
+  vendor     Vendor?   @relation(fields: [vendorId], references: [id])
+  vendorId   String?
+  name       String
+  email      String?
+  phone      String?
+  role       String?
+  isPrimary  Boolean   @default(false)
+  createdAt  DateTime  @default(now())
+  createdBy  String?
+  updatedAt  DateTime  @updatedAt
+  updatedBy  String?
 }
 
 model Project {
-  id           String       @id @default(uuid())
-  code         String       @unique
-  name         String
-  status       ProjectStatus @default(draft)
-  projectType  String?
-  parent       Project?     @relation("ProjectToProject", fields: [parentId], references: [id])
-  parentId     String?
-  children     Project[]    @relation("ProjectToProject")
-  customer     Customer?    @relation(fields: [customerId], references: [id])
-  customerId   String?
-  ownerUserId  String?
-  orgUnitId    String?
-  startDate    DateTime?
-  endDate      DateTime?
-  currency     String?
+  id                String                    @id @default(uuid())
+  code              String                    @unique
+  name              String
+  status            ProjectStatus             @default(draft)
+  projectType       String?
+  parent            Project?                  @relation("ProjectToProject", fields: [parentId], references: [id])
+  parentId          String?
+  children          Project[]                 @relation("ProjectToProject")
+  customer          Customer?                 @relation(fields: [customerId], references: [id])
+  customerId        String?
+  ownerUserId       String?
+  orgUnitId         String?
+  startDate         DateTime?
+  endDate           DateTime?
+  currency          String?
   recurringTemplate RecurringProjectTemplate?
-  tasks        ProjectTask[]
-  milestones   ProjectMilestone[]
-  estimates    Estimate[]
-  invoices     Invoice[]
-  timeEntries  TimeEntry[]
-  expenses     Expense[]
-  purchaseOrders PurchaseOrder[]
-  vendorQuotes   VendorQuote[]
-  vendorInvoices VendorInvoice[]
-  rateCards    RateCard[]
-  createdAt    DateTime     @default(now())
-  createdBy    String?
-  updatedAt    DateTime     @updatedAt
-  updatedBy    String?
+  tasks             ProjectTask[]
+  milestones        ProjectMilestone[]
+  estimates         Estimate[]
+  invoices          Invoice[]
+  timeEntries       TimeEntry[]
+  expenses          Expense[]
+  purchaseOrders    PurchaseOrder[]
+  vendorQuotes      VendorQuote[]
+  vendorInvoices    VendorInvoice[]
+  rateCards         RateCard[]
+  createdAt         DateTime                  @default(now())
+  createdBy         String?
+  updatedAt         DateTime                  @updatedAt
+  updatedBy         String?
 }
 
 model ProjectTask {
-  id           String      @id @default(uuid())
-  project      Project     @relation(fields: [projectId], references: [id])
+  id           String        @id @default(uuid())
+  project      Project       @relation(fields: [projectId], references: [id])
   projectId    String
-  parentTask   ProjectTask? @relation("TaskToTask", fields: [parentTaskId], references: [id])
+  parentTask   ProjectTask?  @relation("TaskToTask", fields: [parentTaskId], references: [id])
   parentTaskId String?
   children     ProjectTask[] @relation("TaskToTask")
   name         String
@@ -164,209 +164,210 @@ model ProjectTask {
   actualEnd    DateTime?
   baselineId   String?
   timeEntries  TimeEntry[]
-  createdAt    DateTime    @default(now())
+  createdAt    DateTime      @default(now())
   createdBy    String?
-  updatedAt    DateTime    @updatedAt
+  updatedAt    DateTime      @updatedAt
   updatedBy    String?
 }
 
 model ProjectMilestone {
-  id        String   @id @default(uuid())
-  project   Project  @relation(fields: [projectId], references: [id])
-  projectId String
-  name      String
-  amount    Decimal
-  billUpon  String   // enum候補: date/acceptance/time
-  dueDate   DateTime?
-  taxRate   Decimal?
+  id                String    @id @default(uuid())
+  project           Project   @relation(fields: [projectId], references: [id])
+  projectId         String
+  name              String
+  amount            Decimal
+  billUpon          String // enum候補: date/acceptance/time
+  dueDate           DateTime?
+  taxRate           Decimal?
   invoiceTemplateId String?
-  invoices Invoice[]
-  createdAt DateTime @default(now())
-  createdBy String?
-  updatedAt DateTime @updatedAt
-  updatedBy String?
+  invoices          Invoice[]
+  createdAt         DateTime  @default(now())
+  createdBy         String?
+  updatedAt         DateTime  @updatedAt
+  updatedBy         String?
 }
 
 model RecurringProjectTemplate {
-  id           String   @id @default(uuid())
-  project      Project  @relation(fields: [projectId], references: [id])
-  projectId    String   @unique
-  frequency    String   // monthly/quarterly/semiannual/annual
+  id            String    @id @default(uuid())
+  project       Project   @relation(fields: [projectId], references: [id])
+  projectId     String    @unique
+  frequency     String // monthly/quarterly/semiannual/annual
   defaultAmount Decimal?
   defaultTerms  String?
   nextRunAt     DateTime?
   timezone      String?
-  isActive      Boolean  @default(true)
-  createdAt     DateTime @default(now())
+  isActive      Boolean   @default(true)
+  createdAt     DateTime  @default(now())
   createdBy     String?
-  updatedAt     DateTime @updatedAt
+  updatedAt     DateTime  @updatedAt
   updatedBy     String?
 }
 
 model Estimate {
-  id        String   @id @default(uuid())
-  project   Project  @relation(fields: [projectId], references: [id])
-  projectId String
-  version   Int
-  totalAmount Decimal
-  currency  String
-  status    DocStatus @default(draft)
-  validUntil DateTime?
-  notes     String?
+  id              String         @id @default(uuid())
+  project         Project        @relation(fields: [projectId], references: [id])
+  projectId       String
+  version         Int
+  totalAmount     Decimal
+  currency        String
+  status          DocStatus      @default(draft)
+  validUntil      DateTime?
+  notes           String?
   numberingSerial Int?
-  lines     EstimateLine[]
-  invoices  Invoice[]
-  createdAt DateTime @default(now())
-  createdBy String?
-  updatedAt DateTime @updatedAt
-  updatedBy String?
+  lines           EstimateLine[]
+  invoices        Invoice[]
+  createdAt       DateTime       @default(now())
+  createdBy       String?
+  updatedAt       DateTime       @updatedAt
+  updatedBy       String?
 }
 
 model EstimateLine {
-  id          String    @id @default(uuid())
-  estimate    Estimate  @relation(fields: [estimateId], references: [id])
+  id          String   @id @default(uuid())
+  estimate    Estimate @relation(fields: [estimateId], references: [id])
   estimateId  String
   description String
-  quantity    Decimal   @default(1)
+  quantity    Decimal  @default(1)
   unitPrice   Decimal
   taxRate     Decimal?
   taskId      String?
 }
 
 model Invoice {
-  id        String   @id @default(uuid())
-  project   Project  @relation(fields: [projectId], references: [id])
-  projectId String
-  estimate  Estimate? @relation(fields: [estimateId], references: [id])
-  estimateId String?
-  milestone ProjectMilestone? @relation(fields: [milestoneId], references: [id])
-  milestoneId String?
-  invoiceNo String  @unique
-  issueDate DateTime?
-  dueDate   DateTime?
-  currency  String
-  totalAmount Decimal
-  status    DocStatus @default(draft)
-  pdfUrl    String?
-  emailMessageId String?
+  id              String            @id @default(uuid())
+  project         Project           @relation(fields: [projectId], references: [id])
+  projectId       String
+  estimate        Estimate?         @relation(fields: [estimateId], references: [id])
+  estimateId      String?
+  milestone       ProjectMilestone? @relation(fields: [milestoneId], references: [id])
+  milestoneId     String?
+  invoiceNo       String            @unique
+  issueDate       DateTime?
+  dueDate         DateTime?
+  currency        String
+  totalAmount     Decimal
+  status          DocStatus         @default(draft)
+  pdfUrl          String?
+  emailMessageId  String?
   numberingSerial Int?
-  lines     BillingLine[]
-  createdAt DateTime @default(now())
-  createdBy String?
-  updatedAt DateTime @updatedAt
-  updatedBy String?
+  lines           BillingLine[]
+  createdAt       DateTime          @default(now())
+  createdBy       String?
+  updatedAt       DateTime          @updatedAt
+  updatedBy       String?
 }
 
 model BillingLine {
-  id          String   @id @default(uuid())
-  invoice     Invoice  @relation(fields: [invoiceId], references: [id])
-  invoiceId   String
-  description String
-  quantity    Decimal  @default(1)
-  unitPrice   Decimal
-  taxRate     Decimal?
-  taskId      String?
+  id             String   @id @default(uuid())
+  invoice        Invoice  @relation(fields: [invoiceId], references: [id])
+  invoiceId      String
+  description    String
+  quantity       Decimal  @default(1)
+  unitPrice      Decimal
+  taxRate        Decimal?
+  taskId         String?
   timeEntryRange String?
 }
 
 model PurchaseOrder {
-  id        String   @id @default(uuid())
-  project   Project  @relation(fields: [projectId], references: [id])
-  projectId String
-  vendor    Vendor   @relation(fields: [vendorId], references: [id])
-  vendorId  String
-  poNo      String   @unique
-  issueDate DateTime?
-  dueDate   DateTime?
-  currency  String
-  totalAmount Decimal
-  status    DocStatus @default(draft)
-  pdfUrl    String?
+  id              String              @id @default(uuid())
+  project         Project             @relation(fields: [projectId], references: [id])
+  projectId       String
+  vendor          Vendor              @relation(fields: [vendorId], references: [id])
+  vendorId        String
+  poNo            String              @unique
+  issueDate       DateTime?
+  dueDate         DateTime?
+  currency        String
+  totalAmount     Decimal
+  status          DocStatus           @default(draft)
+  pdfUrl          String?
   numberingSerial Int?
-  lines     PurchaseOrderLine[]
-  createdAt DateTime @default(now())
-  createdBy String?
-  updatedAt DateTime @updatedAt
-  updatedBy String?
+  lines           PurchaseOrderLine[]
+  createdAt       DateTime            @default(now())
+  createdBy       String?
+  updatedAt       DateTime            @updatedAt
+  updatedBy       String?
 }
 
 model PurchaseOrderLine {
-  id        String   @id @default(uuid())
-  purchaseOrder PurchaseOrder @relation(fields: [purchaseOrderId], references: [id])
+  id              String        @id @default(uuid())
+  purchaseOrder   PurchaseOrder @relation(fields: [purchaseOrderId], references: [id])
   purchaseOrderId String
-  description String
-  quantity    Decimal @default(1)
-  unitPrice   Decimal
-  taxRate     Decimal?
-  taskId      String?
-  expenseId   String?
+  description     String
+  quantity        Decimal       @default(1)
+  unitPrice       Decimal
+  taxRate         Decimal?
+  taskId          String?
+  expenseId       String?
 }
 
 model VendorQuote {
-  id        String   @id @default(uuid())
-  project   Project  @relation(fields: [projectId], references: [id])
-  projectId String
-  vendor    Vendor   @relation(fields: [vendorId], references: [id])
-  vendorId  String
-  quoteNo   String?
-  issueDate DateTime?
-  currency  String
+  id          String    @id @default(uuid())
+  project     Project   @relation(fields: [projectId], references: [id])
+  projectId   String
+  vendor      Vendor    @relation(fields: [vendorId], references: [id])
+  vendorId    String
+  quoteNo     String?
+  issueDate   DateTime?
+  currency    String
   totalAmount Decimal
-  status    DocStatus @default(received)
+  status      DocStatus @default(received)
   documentUrl String?
-  createdAt DateTime @default(now())
-  createdBy String?
-  updatedAt DateTime @updatedAt
-  updatedBy String?
+  createdAt   DateTime  @default(now())
+  createdBy   String?
+  updatedAt   DateTime  @updatedAt
+  updatedBy   String?
 }
 
 model VendorInvoice {
-  id        String   @id @default(uuid())
-  project   Project  @relation(fields: [projectId], references: [id])
-  projectId String
-  vendor    Vendor   @relation(fields: [vendorId], references: [id])
-  vendorId  String
+  id              String    @id @default(uuid())
+  project         Project   @relation(fields: [projectId], references: [id])
+  projectId       String
+  vendor          Vendor    @relation(fields: [vendorId], references: [id])
+  vendorId        String
   vendorInvoiceNo String?
-  receivedDate DateTime?
-  dueDate   DateTime?
-  currency  String
-  totalAmount Decimal
-  status    DocStatus @default(received)
-  documentUrl String?
+  receivedDate    DateTime?
+  dueDate         DateTime?
+  currency        String
+  totalAmount     Decimal
+  status          DocStatus @default(received)
+  documentUrl     String?
   numberingSerial Int?
-  createdAt DateTime @default(now())
-  createdBy String?
-  updatedAt DateTime @updatedAt
-  updatedBy String?
+  createdAt       DateTime  @default(now())
+  createdBy       String?
+  updatedAt       DateTime  @updatedAt
+  updatedBy       String?
 }
 
 model TimeEntry {
-  id        String   @id @default(uuid())
-  project   Project  @relation(fields: [projectId], references: [id])
-  projectId String
-  task      ProjectTask? @relation(fields: [taskId], references: [id])
-  taskId    String?
-  userId    String
-  workDate  DateTime
-  minutes   Int
-  workType  String?
-  location  String?
-  notes     String?
-  status    TimeStatus @default(submitted)
+  id         String       @id @default(uuid())
+  project    Project      @relation(fields: [projectId], references: [id])
+  projectId  String
+  task       ProjectTask? @relation(fields: [taskId], references: [id])
+  taskId     String?
+  userId     String
+  workDate   DateTime
+  minutes    Int
+  workType   String?
+  location   String?
+  notes      String?
+  status     TimeStatus   @default(submitted)
   approvedBy String?
   approvedAt DateTime?
-  createdAt DateTime @default(now())
-  createdBy String?
-  updatedAt DateTime @updatedAt
-  updatedBy String?
+  createdAt  DateTime     @default(now())
+  createdBy  String?
+  updatedAt  DateTime     @updatedAt
+  updatedBy  String?
+
   @@index([projectId, workDate])
   @@index([userId, workDate])
   @@index([status])
 }
 
 model RateCard {
-  id        String   @id @default(uuid())
-  project   Project? @relation(fields: [projectId], references: [id])
+  id        String    @id @default(uuid())
+  project   Project?  @relation(fields: [projectId], references: [id])
   projectId String?
   role      String
   workType  String?
@@ -377,28 +378,29 @@ model RateCard {
 }
 
 model Expense {
-  id        String   @id @default(uuid())
-  project   Project  @relation(fields: [projectId], references: [id])
-  projectId String
-  userId    String
-  category  String
-  amount    Decimal
-  currency  String
+  id         String    @id @default(uuid())
+  project    Project   @relation(fields: [projectId], references: [id])
+  projectId  String
+  userId     String
+  category   String
+  amount     Decimal
+  currency   String
   incurredOn DateTime
-  isShared  Boolean  @default(false)
-  status    DocStatus @default(draft)
+  isShared   Boolean   @default(false)
+  status     DocStatus @default(draft)
   receiptUrl String?
-  createdAt DateTime @default(now())
-  createdBy String?
-  updatedAt DateTime @updatedAt
-  updatedBy String?
+  createdAt  DateTime  @default(now())
+  createdBy  String?
+  updatedAt  DateTime  @updatedAt
+  updatedBy  String?
+
   @@index([projectId])
   @@index([userId, incurredOn])
   @@index([status])
 }
 
 model LeaveRequest {
-  id        String   @id @default(uuid())
+  id        String      @id @default(uuid())
   userId    String
   leaveType String
   startDate DateTime
@@ -406,128 +408,146 @@ model LeaveRequest {
   hours     Int?
   status    LeaveStatus @default(draft)
   notes     String?
-  createdAt DateTime @default(now())
+  createdAt DateTime    @default(now())
   createdBy String?
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime    @updatedAt
   updatedBy String?
+
   @@index([userId, startDate])
   @@index([status])
 }
 
 model ApprovalRule {
-  id        String   @id @default(uuid())
-  flowType  FlowType
+  id         String             @id @default(uuid())
+  flowType   FlowType
   conditions Json
-  steps     Json
-  instances ApprovalInstance[]
-  createdAt DateTime @default(now())
-  createdBy String?
-  updatedAt DateTime @updatedAt
-  updatedBy String?
+  steps      Json
+  instances  ApprovalInstance[]
+  createdAt  DateTime           @default(now())
+  createdBy  String?
+  updatedAt  DateTime           @updatedAt
+  updatedBy  String?
 }
 
 model ApprovalInstance {
-  id        String   @id @default(uuid())
-  flowType  FlowType
+  id          String         @id @default(uuid())
+  flowType    FlowType
   targetTable String
-  targetId  String
-  status    DocStatus @default(pending_qa)
+  targetId    String
+  status      DocStatus      @default(pending_qa)
   currentStep Int?
-  rule      ApprovalRule @relation(fields: [ruleId], references: [id])
-  ruleId    String
-  steps     ApprovalStep[]
-  createdAt DateTime @default(now())
-  createdBy String?
-  updatedAt DateTime @updatedAt
-  updatedBy String?
+  rule        ApprovalRule   @relation(fields: [ruleId], references: [id])
+  ruleId      String
+  steps       ApprovalStep[]
+  createdAt   DateTime       @default(now())
+  createdBy   String?
+  updatedAt   DateTime       @updatedAt
+  updatedBy   String?
 }
 
 model ApprovalStep {
-  id        String   @id @default(uuid())
-  instance  ApprovalInstance @relation(fields: [instanceId], references: [id])
-  instanceId String
-  stepOrder Int
+  id              String           @id @default(uuid())
+  instance        ApprovalInstance @relation(fields: [instanceId], references: [id])
+  instanceId      String
+  stepOrder       Int
   approverGroupId String?
   approverUserId  String?
-  status    DocStatus @default(pending_qa)
-  actedBy   String?
-  actedAt   DateTime?
-  createdAt DateTime @default(now())
-  createdBy String?
-  updatedAt DateTime @updatedAt
-  updatedBy String?
+  status          DocStatus        @default(pending_qa)
+  actedBy         String?
+  actedAt         DateTime?
+  createdAt       DateTime         @default(now())
+  createdBy       String?
+  updatedAt       DateTime         @updatedAt
+  updatedBy       String?
+
   @@index([instanceId])
   @@index([status])
 }
 
 model AlertSetting {
-  id        String   @id @default(uuid())
-  type      AlertType
-  threshold Decimal
-  period    String   // day/week/month
+  id             String    @id @default(uuid())
+  type           AlertType
+  threshold      Decimal
+  period         String // day/week/month
   scopeProjectId String?
-  recipients Json   // emails/roles/users
-  channels  Json    // email/dashboard/ext_future
-  isEnabled Boolean @default(true)
-  alerts    Alert[]
-  createdAt DateTime @default(now())
-  createdBy String?
-  updatedAt DateTime @updatedAt
-  updatedBy String?
+  recipients     Json // emails/roles/users
+  channels       Json // email/dashboard/ext_future
+  isEnabled      Boolean   @default(true)
+  alerts         Alert[]
+  createdAt      DateTime  @default(now())
+  createdBy      String?
+  updatedAt      DateTime  @updatedAt
+  updatedBy      String?
 }
 
 model Alert {
-  id        String   @id @default(uuid())
-  setting   AlertSetting @relation(fields: [settingId], references: [id])
-  settingId String
-  targetRef String
-  triggeredAt DateTime @default(now())
-  status    String @default("open")
+  id           String       @id @default(uuid())
+  setting      AlertSetting @relation(fields: [settingId], references: [id])
+  settingId    String
+  targetRef    String
+  triggeredAt  DateTime     @default(now())
+  status       String       @default("open")
   sentChannels Json?
-  sentResult  Json?
-  createdAt DateTime @default(now())
-  createdBy String?
-  updatedAt DateTime @updatedAt
-  updatedBy String?
+  sentResult   Json?
+  createdAt    DateTime     @default(now())
+  createdBy    String?
+  updatedAt    DateTime     @updatedAt
+  updatedBy    String?
+
   @@index([settingId])
 }
 
 model DailyReport {
-  id        String   @id @default(uuid())
-  userId    String
-  reportDate DateTime
-  content   String
+  id               String   @id @default(uuid())
+  userId           String
+  reportDate       DateTime
+  content          String
   linkedProjectIds Json?
-  status    String?
-  createdAt DateTime @default(now())
-  createdBy String?
-  updatedAt DateTime @updatedAt
-  updatedBy String?
+  status           String?
+  createdAt        DateTime @default(now())
+  createdBy        String?
+  updatedAt        DateTime @updatedAt
+  updatedBy        String?
 }
 
 model WellbeingEntry {
-  id        String   @id @default(uuid())
-  userId    String
-  entryDate DateTime
-  status    String   // good/not_good
-  helpRequested Boolean @default(false)
-  notes     String?
+  id                String   @id @default(uuid())
+  userId            String
+  entryDate         DateTime
+  status            String // good/not_good
+  helpRequested     Boolean  @default(false)
+  notes             String?
   visibilityGroupId String
-  createdAt DateTime @default(now())
-  createdBy String?
-  updatedAt DateTime @updatedAt
-  updatedBy String?
+  createdAt         DateTime @default(now())
+  createdBy         String?
+  updatedAt         DateTime @updatedAt
+  updatedBy         String?
+
   @@index([userId, entryDate])
 }
 
 model NumberSequence {
-  id            String  @id @default(uuid())
-  kind          String  // estimate/invoice/delivery/purchase_order/vendor_quote/vendor_invoice
+  id            String   @id @default(uuid())
+  kind          String // estimate/invoice/delivery/purchase_order/vendor_quote/vendor_invoice
   year          Int
   month         Int
   currentSerial Int
-  version       Int     @default(0)
+  version       Int      @default(0)
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
+
   @@unique([kind, year, month])
+}
+
+model AuditLog {
+  id          String   @id @default(uuid())
+  action      String
+  userId      String?
+  targetTable String?
+  targetId    String?
+  metadata    Json?
+  createdAt   DateTime @default(now())
+
+  @@index([targetTable, targetId])
+  @@index([action])
 }


### PR DESCRIPTION
監査ログの土台を追加しました。\n\n- Prismaにモデルを追加（action/userId/targetTable/targetId/metadata, index付き）\n- auditサービスを追加し、失敗しても処理継続するスタブ実装\n- 承認のapprove/reject時に監査ログ記録\n- 工数PATCHで内容変更→再提出になった際に変更フィールドを監査ログに記録\n- ウェルビーイング閲覧(HR/Admin)時に閲覧イベントを監査ログに記録\n\nts build通過済みです。