### PR TITLE
Annotate enums and FK policy notes

### DIFF
--- a/docs/requirements/schema-prisma-sketch.md
+++ b/docs/requirements/schema-prisma-sketch.md
@@ -18,6 +18,13 @@ enum LeaveStatus { draft pending_manager approved rejected }
 enum FlowType { estimate invoice expense leave time purchase_order vendor_invoice vendor_quote }
 enum AlertType { budget_overrun overtime approval_delay }
 
+// FK/削除ポリシー（案）
+// - Project 起点: child/estimate/invoice/time/expense/PO/VQ/VI は ON DELETE RESTRICT（論理削除で対応）
+// - Estimate→Invoice, Milestone→Invoice: NULL 許容（見積なし請求を許可）、ON DELETE SET NULL
+// - ProjectTask→Time/Billing/Expense: task削除時は参照をNULL（履歴保全）
+// - User参照（userId/ownerUserIdなど）は外部ID想定のためFKなし、値はIDaaS連携時に整合
+// - createdBy/updatedBy はアプリ層で設定し、将来 audit_log と突き合わせ可能にする
+
 // 備考: DocStatus は用途によりサブセットのみを使用（vendor_quote は received/approved/rejected 等）
 
 // マスタ

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,29 +11,29 @@ datasource db {
 }
 
 enum ProjectStatus {
-  draft
-  active
-  on_hold
-  closed
+  draft      // 起案中
+  active     // 進行中
+  on_hold    // 保留
+  closed     // 完了
 }
 
 enum DocStatus {
-  draft
-  pending_qa
-  pending_exec
-  approved
-  rejected
-  sent
-  paid
-  cancelled
-  received
-  acknowledged
+  draft          // 下書き/未送信
+  pending_qa     // 管理部レビュー待ち
+  pending_exec   // 経営承認待ち
+  approved       // 承認済み
+  rejected       // 却下
+  sent           // 送付済み
+  paid           // 支払/入金済み
+  cancelled      // 取り消し
+  received       // 受領済み（仕入/業者系）
+  acknowledged   // 確認済み
 }
 
 enum TimeStatus {
-  submitted
-  approved
-  rejected
+  submitted   // 提出
+  approved    // 承認
+  rejected    // 差戻し
 }
 
 enum LeaveStatus {
@@ -44,20 +44,20 @@ enum LeaveStatus {
 }
 
 enum FlowType {
-  estimate
-  invoice
-  expense
-  leave
-  time
-  purchase_order
-  vendor_invoice
-  vendor_quote
+  estimate         // 見積
+  invoice          // 請求
+  expense          // 経費
+  leave            // 休暇
+  time             // 工数/残業
+  purchase_order   // 発注書
+  vendor_invoice   // 業者請求
+  vendor_quote     // 業者見積
 }
 
 enum AlertType {
-  budget_overrun
-  overtime
-  approval_delay
+  budget_overrun   // 予算超過
+  overtime         // 残業超過
+  approval_delay   // 承認遅延
 }
 
 model Customer {


### PR DESCRIPTION
Prisma/schema 周りの TODO を進めました。\n\n- enum(ProjectStatus/DocStatus/TimeStatus/FlowType/AlertType) に日本語コメントを付与\n- schema-prisma-sketch.md に FK/ON DELETE 方針と createdBy/updatedBy の取り扱いメモを追加\n\nスキーマ構造変更はなく、注釈/ドキュメントのみの更新です。