### PR TITLE
Frontend: alert cards top 5

### DIFF
--- a/packages/frontend/src/sections/Dashboard.tsx
+++ b/packages/frontend/src/sections/Dashboard.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { api } from '../api';
 
-type Alert = { id: string; type: string; message?: string; status: string; triggeredAt?: string };
+type Alert = { id: string; type: string; targetRef?: string; status: string; triggeredAt?: string; sentChannels?: string[] };
 
 export const Dashboard: React.FC = () => {
   const [alerts, setAlerts] = useState<Alert[]>([]);
@@ -13,15 +13,23 @@ export const Dashboard: React.FC = () => {
   return (
     <div>
       <h2>Dashboard</h2>
-      <p className="badge">Alerts</p>
-      <ul className="list">
-        {alerts.map((a) => (
-          <li key={a.id} className="alert">
-            <strong>{a.type}</strong>: {a.message || ''} ({a.status})
-          </li>
+      <p className="badge">Alerts (最新5件)</p>
+      <div className="list" style={{ display: 'grid', gap: 8 }}>
+        {alerts.slice(0, 5).map((a) => (
+          <div key={a.id} className="card" style={{ padding: 12 }}>
+            <div className="row" style={{ justifyContent: 'space-between' }}>
+              <div>
+                <strong>{a.type}</strong> / {a.targetRef || 'N/A'}
+              </div>
+              <span className="badge">{a.status}</span>
+            </div>
+            <div style={{ fontSize: 12, color: '#475569', marginTop: 4 }}>
+              送信: {(a.sentChannels || []).join(', ') || '未送信'} / {a.triggeredAt?.slice(0, 16) || ''}
+            </div>
+          </div>
         ))}
-        {alerts.length === 0 && <li>アラートなし</li>}
-      </ul>
+        {alerts.length === 0 && <div className="card">アラートなし</div>}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
ダッシュボードのアラート表示を強化しました。\n\n- 最新5件のみカード表示し、type/target/status/送信チャネル/時刻を表示\n- アラートが無い場合はプレースホルダカード表示\n\nUIのみの変更です。