### PR TITLE
Docs: batch/migration updates and manual checklist

### DIFF
--- a/docs/requirements/manual-test-checklist.md
+++ b/docs/requirements/manual-test-checklist.md
@@ -1,0 +1,19 @@
+# 手動確認チェックリスト（PoC）
+
+## バックエンド API
+- [ ] POST /projects → /projects/:id/estimates → /projects/:id/invoices → /invoices/:id/send のハッピーパスが通る
+- [ ] POST/GET /time-entries （非管理ロールなら自分のデータのみ取得）
+- [ ] POST/GET /expenses （非管理ロールなら自分のデータのみ取得）
+- [ ] /alert-settings CRUD と /jobs/alerts/run で alert が保存される
+- [ ] /approval-rules CRUD のハッピーパス
+- [ ] /wellbeing-entries POST → HR/AdminでGETできる
+
+## フロント PoC
+- [ ] ダッシュボード: アラートカードが最新5件表示される（なければプレースホルダ）
+- [ ] 日報+WB: Good/Not Good 送信、Not Good時タグ/コメント/ヘルプ導線
+- [ ] 工数入力: プロジェクト/タスク/日付/時間/作業種別/場所を入力→一覧に反映
+- [ ] 請求: 作成→送信Stub、詳細モックの表示
+
+## 環境・その他
+- [ ] CI (backend/frontend/lint/lychee) が緑
+- [ ] prisma format/validate が通る（DATABASE_URL ダミー設定でOK）

--- a/docs/requirements/migration-mapping.md
+++ b/docs/requirements/migration-mapping.md
@@ -12,6 +12,7 @@
 - PO: `im_projects` → ERP4: `projects`
   - code/name/status/parent: 直接マッピング。階層は parent_id で5階層まで許容。
   - budget/計画日はあれば `project_milestones`/`project_tasks` に分配。
+  - IDは mapping_projects で UUID を発行し、元IDは legacy_id / legacy_code に保持。
 - PO: `im_proj_phases` → ERP4: `project_milestones`
   - phase名/期間/金額相当をマイルストーンに転記（bill_upon=acceptance をデフォルト）。
 - PO: `im_timesheet_tasks` ほか → ERP4: `project_tasks`
@@ -20,6 +21,7 @@
 ### 見積/請求
 - PO: `im_invoices` → ERP4: `invoices`
   - invoice_no は再発番（PYYYY-MM-NNNN）。旧番号は `external_id` 相当カラムに保持（後で追加）。
+  - project_id は mapping_projects をJOINして新UUIDに置換。
   - ステータス: closed/paid → paid, open → approved/sent, draft → draft。
 - PO: `im_invoice_items` → ERP4: `billing_lines`
   - 課税/非課税は tax_rate で表現。task_id があれば紐付け。


### PR DESCRIPTION
11/21 TODOのドキュメント系を補完しました。\n\n- batch-jobs: 定期案件テンプレ生成シーケンスを追記、アラートでリマインド用の擬似コード補足\n- migration-mapping: プロジェクト/請求のID・番号マッピングの細部を追記\n- manual-test-checklist: PoCの手動確認項目を追加（バックエンド/フロント）\n\nコード変更なしのドキュメント更新です。