### PR TITLE
Docs: migration ETL samples and quality checks

### DIFF
--- a/docs/requirements/data-quality-checks.md
+++ b/docs/requirements/data-quality-checks.md
@@ -9,6 +9,8 @@
 - 番号整合: invoice_no/po_no がフォーマット `PYYYY-MM-NNNN` になっているか
 - 重複ID: mapping_* に同一 legacy_id が複数 new_id に紐づいていないか
 - 金額整合: project 単位で invoices.totalAmount と billing_lines の合計が一致するか
+- 欠損: time_entries/expenses で user_id/project_id/currency が null のもの
+- 工数/休暇の整合: 同一日で minutes が 1440 を超えていないか、休暇と重複していないか
 
 ## 出力形式
 - CSV or Markdown レポート: 「種別, 対象ID, 詳細」
@@ -38,6 +40,15 @@ from invoices i
 join billing_lines bl on bl.invoice_id = i.id
 group by i.id, i.total_amount
 having abs(i.total_amount - sum(bl.quantity * bl.unit_price)) > 0.01;
+
+-- 欠損（通貨なし）
+select id from invoices where currency is null or currency = '';
+
+-- 工数の1日合計超過
+select user_id, work_date::date, sum(minutes) as total_min
+from time_entries
+group by user_id, work_date::date
+having sum(minutes) > 1440;
 ```
 
 ## 将来拡張

--- a/docs/requirements/migration-etl-samples.md
+++ b/docs/requirements/migration-etl-samples.md
@@ -1,0 +1,56 @@
+# 移行ETLサンプル（抽出→変換→ロード）
+
+## 抽出SQL（例: PostgreSQL → CSV）
+```sql
+\copy (
+  select project_id, project_code, project_name, status, parent_id
+  from im_projects
+) to 'projects_legacy.csv' with csv header;
+
+\copy (
+  select invoice_id, project_id, invoice_no, total_amount, currency, status, issue_date
+  from im_invoices
+) to 'invoices_legacy.csv' with csv header;
+
+\copy (
+  select user_id, login, email from cc_users
+) to 'users_legacy.csv' with csv header;
+```
+
+## 変換（Python/pandas雛形）
+```python
+import pandas as pd, uuid
+
+proj = pd.read_csv('projects_legacy.csv')
+proj['id'] = [str(uuid.uuid4()) for _ in range(len(proj))]
+proj['code'] = proj['project_code'].str.strip()
+proj['name'] = proj['project_name']
+proj['parentId'] = None  # 親子対応は後でJOIN
+proj[['id','code','name','status']].to_csv('projects_load.csv', index=False)
+
+users = pd.read_csv('users_legacy.csv')
+users['new_id'] = [str(uuid.uuid4()) for _ in range(len(users))]
+users[['user_id','new_id','email']].to_csv('mapping_users.csv', index=False)
+
+inv = pd.read_csv('invoices_legacy.csv')
+mapping_proj = proj[['project_id','id']].rename(columns={'project_id':'legacy'})
+inv = inv.merge(mapping_proj, left_on='project_id', right_on='legacy', how='left')
+inv['invoice_no'] = None  # 新環境で再採番
+inv[['id','project_id','total_amount','currency','status']].to_csv('invoices_load.csv', index=False)
+```
+
+## ロード（PostgreSQL）
+```sql
+-- 依存順にロード
+copy "Project"(id, code, name, status) from 'projects_load.csv' csv header;
+copy mapping_users(legacy_id, new_id, legacy_login) from 'mapping_users.csv' csv header;
+-- 請求は invoice_no を空で入れ、アプリ側で採番 or UPDATE
+copy "Invoice"(id, "projectId", totalAmount, currency, status) from 'invoices_load.csv' csv header;
+```
+
+## 検証チェックリスト
+- [ ] 件数: プロジェクト件数、請求件数が一致
+- [ ] 合計: プロジェクト単位で請求 total_amount の合計が一致
+- [ ] コード重複: project_code/invoice_no に重複なし
+- [ ] 参照切れ: project_id/task_id がNULLや参照なしのレコードがない
+- [ ] 通貨/日付フォーマット: currencyがNULLでない、日付がパース可能


### PR DESCRIPTION
移行関連のTODOを補完しました。\n\n- migration-etl-samples.md を追加（抽出SQL、pandas変換雛形、ロードSQL、検証チェックリスト）\n- data-quality-checks.md に欠損/時間超過のチェッククエリを追加\n\nコード変更なしのドキュメント更新です。