### PR TITLE
Add project-level RBAC for time entries and expenses

### DIFF
--- a/packages/backend/src/services/rbac.ts
+++ b/packages/backend/src/services/rbac.ts
@@ -22,3 +22,16 @@ export function requireRoleOrSelf(allowed: string[], getTargetUserId?: (req: Fas
     }
   };
 }
+
+// 管理ロールは全許可。そうでない場合、projectId がユーザの projectIds に含まれているかをチェック
+export function requireProjectAccess(getProjectId: (req: FastifyRequest) => string | undefined) {
+  return async (req: FastifyRequest, reply: FastifyReply) => {
+    const roles = req.user?.roles || [];
+    if (roles.includes('admin') || roles.includes('mgmt')) return;
+    const userProjects = req.user?.projectIds || [];
+    const targetProject = getProjectId(req);
+    if (targetProject && !userProjects.includes(targetProject)) {
+      return reply.code(403).send({ error: 'forbidden_project' });
+    }
+  };
+}


### PR DESCRIPTION
プロジェクト単位のRBACチェックを追加しました。\n\n- time-entries/expenses の POST/PATCH/GET に projectId のアクセスチェックを追加（admin/mgmt 以外は自身の projectIds に含まれる場合のみ許可）\n- rbacサービスに requireProjectAccess を追加\n\n既存のロールチェックは維持したまま、プロジェクト制約を強化する変更です。