### PR TITLE
Frontend: /me panel and alert toggle

### DIFF
--- a/packages/frontend/src/pages/App.tsx
+++ b/packages/frontend/src/pages/App.tsx
@@ -4,11 +4,13 @@ import { DailyReport } from '../sections/DailyReport';
 import { TimeEntries } from '../sections/TimeEntries';
 import { Invoices } from '../sections/Invoices';
 import { HRAnalytics } from '../sections/HRAnalytics';
+import { CurrentUser } from '../sections/CurrentUser';
 
 export const App: React.FC = () => {
   return (
     <div className="container">
       <h1>ERP4 MVP PoC</h1>
+      <CurrentUser />
       <div className="card"><Dashboard /></div>
       <div className="card"><DailyReport /></div>
       <div className="card"><TimeEntries /></div>

--- a/packages/frontend/src/sections/CurrentUser.tsx
+++ b/packages/frontend/src/sections/CurrentUser.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+import { api } from '../api';
+
+type MeResponse = { user: { userId: string; roles: string[]; ownerProjects?: string[] | string } };
+
+export const CurrentUser: React.FC = () => {
+  const [me, setMe] = useState<MeResponse['user'] | null>(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    api<MeResponse>('/me')
+      .then((res) => setMe(res.user))
+      .catch(() => setError('取得に失敗'));
+  }, []);
+
+  return (
+    <div className="card" style={{ marginBottom: 12 }}>
+      <div className="row" style={{ alignItems: 'center' }}>
+        <strong>現在のユーザー</strong>
+        {error && <span style={{ color: '#dc2626', marginLeft: 8 }}>{error}</span>}
+      </div>
+      {me ? (
+        <div style={{ fontSize: 14 }}>
+          <div>ID: {me.userId}</div>
+          <div>Roles: {me.roles.join(', ')}</div>
+          <div>OwnerProjects: {Array.isArray(me.ownerProjects) ? me.ownerProjects.join(', ') : me.ownerProjects}</div>
+        </div>
+      ) : (
+        !error && <div style={{ fontSize: 14 }}>読み込み中...</div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/sections/Dashboard.tsx
+++ b/packages/frontend/src/sections/Dashboard.tsx
@@ -5,6 +5,7 @@ type Alert = { id: string; type: string; targetRef?: string; status: string; tri
 
 export const Dashboard: React.FC = () => {
   const [alerts, setAlerts] = useState<Alert[]>([]);
+  const [showAll, setShowAll] = useState(false);
 
   useEffect(() => {
     api<{ items: Alert[] }>('/alerts').then((data) => setAlerts(data.items)).catch(() => setAlerts([]));
@@ -13,9 +14,14 @@ export const Dashboard: React.FC = () => {
   return (
     <div>
       <h2>Dashboard</h2>
-      <p className="badge">Alerts (最新5件)</p>
+      <div className="row" style={{ alignItems: 'center' }}>
+        <p className="badge">Alerts {showAll ? '(全件)' : '(最新5件)'}</p>
+        <button className="button secondary" style={{ marginLeft: 'auto' }} onClick={() => setShowAll((v) => !v)}>
+          {showAll ? '最新のみ' : 'すべて表示'}
+        </button>
+      </div>
       <div className="list" style={{ display: 'grid', gap: 8 }}>
-        {alerts.slice(0, 5).map((a) => (
+        {(showAll ? alerts : alerts.slice(0, 5)).map((a) => (
           <div key={a.id} className="card" style={{ padding: 12 }}>
             <div className="row" style={{ justifyContent: 'space-between' }}>
               <div>


### PR DESCRIPTION
認証モック/アラート表示のTODOを一部対応しました。\n\n- /me の内容（userId/roles/ownerProjects）を表示するCurrentUserカードを追加\n- ダッシュボードのアラートを最新5件/全件で切り替えられるトグルを追加\n\nUIのみの変更で、API呼び出しは既存の /me /alerts を使用しています。