### PR TITLE
Frontend: invoice detail lines & approval

### DIFF
--- a/packages/frontend/src/sections/InvoiceDetail.tsx
+++ b/packages/frontend/src/sections/InvoiceDetail.tsx
@@ -6,10 +6,12 @@ type InvoiceDetailProps = {
   projectId: string;
   status: string;
   totalAmount: number;
+  lines?: { description: string; quantity: number; unitPrice: number }[];
+  approval?: { step: number; total: number; status: string };
   onSend?: () => void;
 };
 
-export const InvoiceDetail: React.FC<InvoiceDetailProps> = ({ id, invoiceNo, projectId, status, totalAmount, onSend }) => {
+export const InvoiceDetail: React.FC<InvoiceDetailProps> = ({ id, invoiceNo, projectId, status, totalAmount, lines = [], approval, onSend }) => {
   return (
     <div>
       <h3>請求詳細</h3>
@@ -18,6 +20,33 @@ export const InvoiceDetail: React.FC<InvoiceDetailProps> = ({ id, invoiceNo, pro
       <div>Project: {projectId}</div>
       <div>Status: {status}</div>
       <div>Amount: ¥{totalAmount.toLocaleString()}</div>
+      {lines.length > 0 && (
+        <table className="table" style={{ width: '100%', marginTop: 8 }}>
+          <thead>
+            <tr>
+              <th>明細</th>
+              <th>数量</th>
+              <th>単価</th>
+              <th>小計</th>
+            </tr>
+          </thead>
+          <tbody>
+            {lines.map((l, idx) => (
+              <tr key={idx}>
+                <td>{l.description}</td>
+                <td>{l.quantity}</td>
+                <td>¥{l.unitPrice.toLocaleString()}</td>
+                <td>¥{(l.quantity * l.unitPrice).toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {approval && (
+        <div style={{ marginTop: 8, fontSize: 14 }}>
+          承認 {approval.step}/{approval.total} : {approval.status}
+        </div>
+      )}
       <button className="button" onClick={onSend}>送信 (Stub)</button>
     </div>
   );


### PR DESCRIPTION
請求ドラフト詳細モックを拡充しました。\n\n- 明細行（数量/単価/小計）を表示\n- 承認ステータス（step/total/status）の表示枠を追加\n- 送信ボタンは従来どおりStub\n\nUIのみの変更です。