### PR TITLE
Wire approval matcher into submits

### DIFF
--- a/packages/backend/src/routes/estimates.ts
+++ b/packages/backend/src/routes/estimates.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify';
 import { nextNumber } from '../services/numbering.js';
-import { createApproval } from '../services/approval.js';
+import { createApprovalFor } from '../services/approval.js';
 import { DocStatusValue, FlowTypeValue } from '../types.js';
 import { estimateSchema } from './validators.js';
 import { requireRole } from '../services/rbac.js';
@@ -32,7 +32,7 @@ export async function registerEstimateRoutes(app: FastifyInstance) {
   app.post('/estimates/:id/submit', { preHandler: requireRole(['admin', 'mgmt']) }, async (req) => {
     const { id } = req.params as { id: string };
     const estimate = await prisma.estimate.update({ where: { id }, data: { status: DocStatusValue.pending_qa } });
-    await createApproval(FlowTypeValue.estimate, 'estimates', id, [{ approverGroupId: 'mgmt' }, { approverGroupId: 'exec' }]);
+    await createApprovalFor(FlowTypeValue.estimate, 'estimates', id, { totalAmount: estimate.totalAmount });
     return estimate;
   });
 }

--- a/packages/backend/src/routes/expenses.ts
+++ b/packages/backend/src/routes/expenses.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance } from 'fastify';
-import { createApproval } from '../services/approval.js';
+import { createApproval, createApprovalFor } from '../services/approval.js';
 import { expenseSchema } from './validators.js';
 import { DocStatusValue, FlowTypeValue } from '../types.js';
 import { requireProjectAccess, requireRole, requireRoleOrSelf } from '../services/rbac.js';
@@ -54,7 +54,7 @@ export async function registerExpenseRoutes(app: FastifyInstance) {
   app.post('/expenses/:id/submit', { preHandler: requireRoleOrSelf(['admin', 'mgmt'], (req) => req.user?.userId) }, async (req) => {
     const { id } = req.params as { id: string };
     const exp = await prisma.expense.update({ where: { id }, data: { status: DocStatusValue.pending_qa } });
-    await createApproval(FlowTypeValue.expense, 'expenses', id, [{ approverGroupId: 'mgmt' }]);
+    await createApprovalFor(FlowTypeValue.expense, 'expenses', id, { amount: exp.amount });
     return exp;
   });
 }

--- a/packages/backend/src/routes/invoices.ts
+++ b/packages/backend/src/routes/invoices.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify';
 import { nextNumber } from '../services/numbering.js';
-import { createApproval } from '../services/approval.js';
+import { createApprovalFor } from '../services/approval.js';
 import { FlowTypeValue, DocStatusValue } from '../types.js';
 import { invoiceSchema } from './validators.js';
 import { requireRole } from '../services/rbac.js';
@@ -34,7 +34,7 @@ export async function registerInvoiceRoutes(app: FastifyInstance) {
   app.post('/invoices/:id/submit', { preHandler: requireRole(['admin', 'mgmt']) }, async (req) => {
     const { id } = req.params as { id: string };
     const invoice = await prisma.invoice.update({ where: { id }, data: { status: DocStatusValue.pending_qa } });
-    await createApproval(FlowTypeValue.invoice, 'invoices', id, [{ approverGroupId: 'mgmt' }, { approverGroupId: 'exec' }]);
+    await createApprovalFor(FlowTypeValue.invoice, 'invoices', id, { totalAmount: invoice.totalAmount });
     return invoice;
   });
 }


### PR DESCRIPTION
承認周りのTODOを進めました。\n\n- ApprovalCondition 型を追加し、matchApprovalSteps に条件を渡せるように拡張\n- resolveRule(flowType) で approval_rules の最新を取得し、createApprovalFor で steps を自動生成\n- 見積submit/請求submit/経費submit で createApprovalFor を呼び出し、金額ベースの承認ステップを自動生成（ルール未設定時は従来の簡易判定）\n- time/expense GET の日付フィルタ追加と併せて lint 済み\n\n既存API互換を維持しつつ、承認ルールを利用できる入口を用意しました。