### PR TITLE
Expand approval rules schema and add instances list

### DIFF
--- a/packages/backend/src/services/approval.ts
+++ b/packages/backend/src/services/approval.ts
@@ -10,6 +10,10 @@ export type ApprovalCondition = {
   execThreshold?: number;
   skipSmallUnder?: number;
   isRecurring?: boolean;
+  projectType?: string;
+  customerId?: string;
+  orgUnitId?: string;
+  appliesTo?: string[]; // flowType フラグ
 };
 
 export function matchApprovalSteps(flowType: string, payload: Record<string, unknown>, conditions?: ApprovalCondition): Step[] {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -420,13 +420,14 @@ model LeaveRequest {
 model ApprovalRule {
   id         String             @id @default(uuid())
   flowType   FlowType
-  conditions Json
-  steps      Json
+  conditions Json   // amountMin/amountMax/isRecurring/skipUnder/projectType/customerId/orgUnitId/flowFlags
+  steps      Json   // [{stepOrder, approverGroupId?, approverUserId?, parallelKey?}]
   instances  ApprovalInstance[]
   createdAt  DateTime           @default(now())
   createdBy  String?
   updatedAt  DateTime           @updatedAt
   updatedBy  String?
+  @@index([flowType])
 }
 
 model ApprovalInstance {


### PR DESCRIPTION
承認仕様（Issue #51）に沿ってスキーマ/ルートを拡張しました。\n\n- Prisma: ApprovalRule に flowType index と conditions/steps のコメントを追加（amountMin/skipUnder/isRecurring/projectType等を想定）\n- approval matcher: conditions に project/customer/orgUnit/appliesTo を許容\n- API: /approval-instances 一覧を追加（flowType/status/approverGroupId/projectId/approverUserId/requesterId でフィルタ）\n\n既存エンドポイント互換のまま、承認ルール活用とインスタンス一覧を可能にする変更です。