### PR TITLE
スキーマ: 論理削除理由と請求リンク方針の明文化

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -145,6 +145,8 @@ model Project {
   createdBy         String?
   updatedAt         DateTime                  @updatedAt
   updatedBy         String?
+  deletedAt         DateTime?
+  deletedReason     String?
 }
 
 model ProjectTask {
@@ -168,6 +170,8 @@ model ProjectTask {
   createdBy    String?
   updatedAt    DateTime      @updatedAt
   updatedBy    String?
+  deletedAt    DateTime?
+  deletedReason String?
 }
 
 model ProjectMilestone {
@@ -185,6 +189,8 @@ model ProjectMilestone {
   createdBy         String?
   updatedAt         DateTime  @updatedAt
   updatedBy         String?
+  deletedAt         DateTime?
+  deletedReason     String?
 }
 
 model RecurringProjectTemplate {
@@ -220,6 +226,8 @@ model Estimate {
   createdBy       String?
   updatedAt       DateTime       @updatedAt
   updatedBy       String?
+  deletedAt       DateTime?
+  deletedReason   String?
 }
 
 model EstimateLine {
@@ -238,9 +246,9 @@ model Invoice {
   project         Project           @relation(fields: [projectId], references: [id])
   projectId       String
   estimate        Estimate?         @relation(fields: [estimateId], references: [id])
-  estimateId      String?
+  estimateId      String?           // 見積なし請求を許容
   milestone       ProjectMilestone? @relation(fields: [milestoneId], references: [id])
-  milestoneId     String?
+  milestoneId     String?           // 任意。未紐付けは納品請求漏れチェック対象
   invoiceNo       String            @unique
   issueDate       DateTime?
   dueDate         DateTime?
@@ -255,6 +263,8 @@ model Invoice {
   createdBy       String?
   updatedAt       DateTime          @updatedAt
   updatedBy       String?
+  deletedAt       DateTime?
+  deletedReason   String?
 }
 
 model BillingLine {
@@ -288,6 +298,8 @@ model PurchaseOrder {
   createdBy       String?
   updatedAt       DateTime            @updatedAt
   updatedBy       String?
+  deletedAt       DateTime?
+  deletedReason   String?
 }
 
 model PurchaseOrderLine {
@@ -318,6 +330,8 @@ model VendorQuote {
   createdBy   String?
   updatedAt   DateTime  @updatedAt
   updatedBy   String?
+  deletedAt   DateTime?
+  deletedReason String?
 }
 
 model VendorInvoice {
@@ -338,6 +352,8 @@ model VendorInvoice {
   createdBy       String?
   updatedAt       DateTime  @updatedAt
   updatedBy       String?
+  deletedAt       DateTime?
+  deletedReason   String?
 }
 
 model TimeEntry {
@@ -359,6 +375,8 @@ model TimeEntry {
   createdBy  String?
   updatedAt  DateTime     @updatedAt
   updatedBy  String?
+  deletedAt  DateTime?
+  deletedReason String?
 
   @@index([projectId, workDate])
   @@index([userId, workDate])
@@ -393,6 +411,8 @@ model Expense {
   createdBy  String?
   updatedAt  DateTime  @updatedAt
   updatedBy  String?
+  deletedAt  DateTime?
+  deletedReason String?
 
   @@index([projectId])
   @@index([userId, incurredOn])


### PR DESCRIPTION
## 変更内容
- 主要モデルに deletedAt/deletedReason を追加
- Invoice の estimateId/milestoneId を任意と明記（見積なし請求/マイルストーン任意）
- スキーマ叩き台に FK/削除ポリシーと経費プロジェクト必須の方針を反映

## 背景
- FK/削除ポリシー整理の決定事項を反映（#5）

## 確認ポイント
- 論理削除の理由コード方針（deletedReason）
- マイルストーン未請求検知の実装場所（アラート/レポート）