### PR TITLE
休暇申請のバリデーション追加

### DIFF
--- a/docs/plan/todo.md
+++ b/docs/plan/todo.md
@@ -56,7 +56,7 @@
   - [ ] audit_logテーブル案（who/when/action/target/from/to/meta）
   - [ ] 発番・承認・閲覧(Wellbeing)で記録する項目を列挙
 - [ ] バックエンド: シンプルなバリデーション (zod / fastify schema) を主要エンドポイントに付与
-  - [ ] time/expense/estimate/invoice/PO/leave の schema で必須/型/最小値を整理
+  - [x] time/expense/estimate/invoice/PO/leave の schema で必須/型/最小値を整理
   - [ ] バリデーション失敗時のエラーレスポンスを揃える
 - [ ] バックエンド: `/me` にロール/グループ等のモックデータを返す
   - [ ] roleに応じたownerOrgId/projectsフィルタのモックを追加

--- a/packages/backend/src/routes/leave.ts
+++ b/packages/backend/src/routes/leave.ts
@@ -3,13 +3,18 @@ import { prisma } from '../services/db.js';
 import { createApprovalFor } from '../services/approval.js';
 import { FlowTypeValue } from '../types.js';
 import { requireRole, requireRoleOrSelf } from '../services/rbac.js';
+import { leaveRequestSchema } from './validators.js';
 
 export async function registerLeaveRoutes(app: FastifyInstance) {
-  app.post('/leave-requests', { preHandler: requireRoleOrSelf(['admin', 'mgmt'], (req) => (req.body as any)?.userId) }, async (req) => {
-    const body = req.body as any;
-    const leave = await prisma.leaveRequest.create({ data: body });
-    return leave;
-  });
+  app.post(
+    '/leave-requests',
+    { preHandler: requireRoleOrSelf(['admin', 'mgmt'], (req) => (req.body as any)?.userId), schema: leaveRequestSchema },
+    async (req) => {
+      const body = req.body as any;
+      const leave = await prisma.leaveRequest.create({ data: body });
+      return leave;
+    },
+  );
 
   app.post('/leave-requests/:id/submit', { preHandler: requireRole(['admin', 'mgmt', 'user']) }, async (req, reply) => {
     const { id } = req.params as { id: string };

--- a/packages/backend/src/routes/validators.ts
+++ b/packages/backend/src/routes/validators.ts
@@ -130,6 +130,17 @@ export const wellbeingSchema = {
   }),
 };
 
+export const leaveRequestSchema = {
+  body: Type.Object({
+    userId: Type.String(),
+    leaveType: Type.String(),
+    startDate: Type.String({ format: 'date' }),
+    endDate: Type.String({ format: 'date' }),
+    hours: Type.Optional(Type.Number({ minimum: 0 })),
+    notes: Type.Optional(Type.String()),
+  }),
+};
+
 export const approvalActionSchema = {
   body: Type.Object({
     action: Type.Union([Type.Literal('approve'), Type.Literal('reject')]),


### PR DESCRIPTION
## 変更内容
- leave_requests の TypeBox schema を追加
- POST /leave-requests に schema を適用
- TODO の該当項目を完了に更新

## 背景
- 主要エンドポイントのバリデーション整備の一環

## 確認ポイント
- 日付フォーマット（date）/hours の最小値が妥当か