### PR TITLE
バリデーションエラー統一と監査ログ方針の明文化

### DIFF
--- a/docs/plan/todo.md
+++ b/docs/plan/todo.md
@@ -53,11 +53,11 @@
   - [x] mapping_users, mapping_projects, mapping_vendors のDDLと例データ
   - [x] 移行後に参照切れを検出するクエリテンプレート
 - [ ] 監査ログ設計: 主要操作（承認/発番/ウェルビーイング閲覧）のログ項目サマリ
-  - [ ] audit_logテーブル案（who/when/action/target/from/to/meta）
-  - [ ] 発番・承認・閲覧(Wellbeing)で記録する項目を列挙
+  - [x] audit_logテーブル案（who/when/action/target/from/to/meta）
+  - [x] 発番・承認・閲覧(Wellbeing)で記録する項目を列挙
 - [ ] バックエンド: シンプルなバリデーション (zod / fastify schema) を主要エンドポイントに付与
   - [x] time/expense/estimate/invoice/PO/leave の schema で必須/型/最小値を整理
-  - [ ] バリデーション失敗時のエラーレスポンスを揃える
+  - [x] バリデーション失敗時のエラーレスポンスを揃える
 - [ ] バックエンド: `/me` にロール/グループ等のモックデータを返す
   - [ ] roleに応じたownerOrgId/projectsフィルタのモックを追加
 - [ ] バックエンド: タイムシート修正時の承認ルール適用（変更時のみ approval 起動）

--- a/docs/requirements/approval-log.md
+++ b/docs/requirements/approval-log.md
@@ -1,5 +1,10 @@
 # 承認ステップ監査ログ（ドラフト）
 
+## audit_log テーブル案（共通）
+- id, action, user_id, target_table, target_id, metadata, created_at
+- metadata に from_status / to_status / reason / step_order / actor_group などを格納
+- 参照用途: 監査・履歴確認。UI での表示は後続スコープ
+
 ## ログ項目
 - instance_id, step_id, from_state, to_state
 - acted_by, acted_at
@@ -9,6 +14,11 @@
 ## 実装方針
 - approvalStep 更新時に logs テーブルへINSERT（または approval_steps に JSON logs フィールドを持つ）
 - PoCでは change_log テーブルを作成するか、approval_steps に acted_by/acted_at/from/to/reason を保持
+
+## 記録対象（MVP）
+- 発番: action=number_sequence_allocated, metadata={kind, year, month, serial}
+- 承認: action=approval_created/approval_approved/approval_rejected, metadata={from_status,to_status,step_order}
+- Wellbeing閲覧: action=wellbeing_viewed, metadata={target_user_id, entry_date, viewer_role}
 
 ## 利用
 - 申請の履歴表示（いつ誰が承認/却下したか）

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -12,6 +12,25 @@ async function main() {
   server.get('/health', async () => ({ ok: true }));
   await registerRoutes(server);
 
+  server.setErrorHandler((err: any, _req, reply) => {
+    const status = err.statusCode || 500;
+    if (err.validation) {
+      return reply.status(status).send({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          details: err.validation,
+        },
+      });
+    }
+    return reply.status(status).send({
+      error: {
+        code: 'INTERNAL_ERROR',
+        message: status >= 500 ? 'Internal server error' : err.message,
+      },
+    });
+  });
+
   const port = Number(process.env.PORT || 3001);
   server.listen({ port, host: '0.0.0.0' }).catch((err) => {
     server.log.error(err);


### PR DESCRIPTION
## 変更内容
- Fastifyのエラーハンドラでバリデーションエラーのレスポンス形式を統一
- audit_log テーブル案と記録対象を docs/requirements/approval-log.md に追記
- TODO の該当項目を完了に更新

## 背景
- エラーレスポンス統一と監査ログ設計のドキュメント化を進めるため

## 確認ポイント
- 返却フォーマット（error.code/message/details）の粒度が適切か