### PR TITLE
認証モックの/\meに組織・プロジェクト範囲を追加

### DIFF
--- a/docs/plan/todo.md
+++ b/docs/plan/todo.md
@@ -58,8 +58,8 @@
 - [ ] バックエンド: シンプルなバリデーション (zod / fastify schema) を主要エンドポイントに付与
   - [x] time/expense/estimate/invoice/PO/leave の schema で必須/型/最小値を整理
   - [x] バリデーション失敗時のエラーレスポンスを揃える
-- [ ] バックエンド: `/me` にロール/グループ等のモックデータを返す
-  - [ ] roleに応じたownerOrgId/projectsフィルタのモックを追加
+- [x] バックエンド: `/me` にロール/グループ等のモックデータを返す
+  - [x] roleに応じたownerOrgId/projectsフィルタのモックを追加
 - [ ] バックエンド: タイムシート修正時の承認ルール適用（変更時のみ approval 起動）
   - [ ] PATCH /time-entries/:id 追加、変更点判定でApprovalInstance作成スタブ
 - [ ] バックエンド: 承認ステップの監査ログ（who/when/from/to/reason）保存

--- a/docs/requirements/frontend-api-wire.md
+++ b/docs/requirements/frontend-api-wire.md
@@ -2,8 +2,8 @@
 
 ## auth
 - GET `/me`
-  - headers: `x-user-id`, `x-roles`
-  - res: `{ user: { userId, roles } }`
+  - headers: `x-user-id`, `x-roles`, `x-org-id`, `x-project-ids`
+  - res: `{ user: { userId, roles, orgId, ownerOrgId, ownerProjects } }`
 
 ## dashboard
 - GET `/alerts` → ダッシュボード表示

--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -19,6 +19,7 @@ async function authMock(fastify: any) {
     const userId = (req.headers['x-user-id'] as string) || 'demo-user';
     const rolesHeader = (req.headers['x-roles'] as string) || 'user';
     const roles = rolesHeader.split(',').map((r: string) => r.trim()).filter(Boolean);
+    const orgId = (req.headers['x-org-id'] as string) || undefined;
     const projectIdsHeader = (req.headers['x-project-ids'] as string) || '';
     const projectIds = projectIdsHeader
       .split(',')
@@ -29,7 +30,7 @@ async function authMock(fastify: any) {
       .split(',')
       .map((g: string) => g.trim())
       .filter(Boolean);
-    req.user = { userId, roles, projectIds, groupIds };
+    req.user = { userId, roles, orgId, projectIds, groupIds };
   });
 }
 

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -10,7 +10,9 @@ const demoUser = {
 export async function registerAuthRoutes(app: FastifyInstance) {
   app.get('/me', async (req) => {
     const user = req.user || demoUser;
-    const ownerProjects = user.roles.includes('admin') || user.roles.includes('mgmt') ? 'all' : user.projectIds || demoUser.projectIds;
-    return { user: { ...user, ownerProjects } };
+    const isPrivileged = user.roles.includes('admin') || user.roles.includes('mgmt');
+    const ownerProjects = isPrivileged ? 'all' : user.projectIds || demoUser.projectIds;
+    const ownerOrgId = isPrivileged ? user.orgId || 'all' : user.orgId || demoUser.orgId;
+    return { user: { ...user, ownerOrgId, ownerProjects } };
   });
 }


### PR DESCRIPTION
## 変更内容
- auth mockで `x-org-id` を受け取り user.orgId に反映
- /me のレスポンスに ownerOrgId/ownerProjects を追加
- frontend-api-wire の /me 仕様を更新
- TODO の該当項目を完了に更新

## 背景
- 役割に応じたスコープ情報をフロントへ返すため

## 確認ポイント
- 管理ロールの ownerOrgId を 'all' にする扱いで問題ないか