### PR TITLE
承認アクションAPIの追加

### DIFF
--- a/docs/requirements/frontend-api-wire.md
+++ b/docs/requirements/frontend-api-wire.md
@@ -50,6 +50,7 @@
 ## settings (admin/mgmt)
 - GET/POST/PATCH `/alert-settings`, `/alert-settings/:id/enable|disable`
 - GET/POST/PATCH `/approval-rules`
+- POST `/approval-instances/:id/act` { action: approve|reject, reason? }
 - POST `/jobs/alerts/run` (手動トリガー)
 
 ## role/permission policy (PoC)

--- a/packages/backend/src/routes/validators.ts
+++ b/packages/backend/src/routes/validators.ts
@@ -118,3 +118,10 @@ export const wellbeingSchema = {
     visibilityGroupId: Type.String(),
   }),
 };
+
+export const approvalActionSchema = {
+  body: Type.Object({
+    action: Type.Union([Type.Literal('approve'), Type.Literal('reject')]),
+    reason: Type.Optional(Type.String()),
+  }),
+};


### PR DESCRIPTION
## 概要
- 承認アクション用エンドポイントを追加（approve/reject）
- APIワイヤに承認アクションの記載を追加

## 動作確認
- 未実施
