### PR TITLE
フロント認証モックのログインUI追加

### DIFF
--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -1,8 +1,65 @@
-const defaultHeaders = {
-  'Content-Type': 'application/json',
-  'x-user-id': 'demo-user',
-  'x-roles': 'admin,mgmt',
+export type AuthState = {
+  userId: string;
+  roles: string[];
+  projectIds?: string[];
+  groupIds?: string[];
+  token?: string;
 };
+
+const AUTH_STORAGE_KEY = 'erp4_auth';
+
+export function getAuthState(): AuthState | null {
+  if (typeof window === 'undefined') return null;
+  const raw = window.localStorage.getItem(AUTH_STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as AuthState;
+  } catch (err) {
+    return null;
+  }
+}
+
+export function setAuthState(state: AuthState | null) {
+  if (typeof window === 'undefined') return;
+  if (!state) {
+    window.localStorage.removeItem(AUTH_STORAGE_KEY);
+    return;
+  }
+  window.localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(state));
+}
+
+function buildAuthHeaders(): Record<string, string> {
+  const auth = getAuthState();
+  if (!auth) return {};
+  const headers: Record<string, string> = {};
+  if (auth.userId) headers['x-user-id'] = auth.userId;
+  if (auth.roles?.length) headers['x-roles'] = auth.roles.join(',');
+  if (auth.projectIds?.length) headers['x-project-ids'] = auth.projectIds.join(',');
+  if (auth.groupIds?.length) headers['x-group-ids'] = auth.groupIds.join(',');
+  if (auth.token) headers.Authorization = `Bearer ${auth.token}`;
+  return headers;
+}
+
+function mergeHeaders(extra?: HeadersInit): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...buildAuthHeaders(),
+  };
+  if (!extra) return headers;
+  if (extra instanceof Headers) {
+    extra.forEach((value, key) => {
+      headers[key] = value;
+    });
+    return headers;
+  }
+  if (Array.isArray(extra)) {
+    extra.forEach(([key, value]) => {
+      headers[key] = value;
+    });
+    return headers;
+  }
+  return { ...headers, ...(extra as Record<string, string>) };
+}
 
 async function handleResponse<T>(res: Response, path: string): Promise<T> {
   if (res.ok) {
@@ -19,15 +76,12 @@ async function handleResponse<T>(res: Response, path: string): Promise<T> {
 export async function api<T>(path: string, options: RequestInit = {}): Promise<T> {
   const res = await fetch(path, {
     ...options,
-    headers: {
-      ...defaultHeaders,
-      ...(options.headers || {}),
-    },
+    headers: mergeHeaders(options.headers),
   });
   return handleResponse<T>(res, path);
 }
 
 export async function apiWithAuth<T>(path: string, token?: string, options: RequestInit = {}): Promise<T> {
   const headers = token ? { Authorization: `Bearer ${token}` } : {};
-  return api<T>(path, { ...options, headers: { ...headers, ...(options.headers || {}) } });
+  return api<T>(path, { ...options, headers: { ...(options.headers || {}), ...headers } });
 }

--- a/packages/frontend/src/sections/CurrentUser.tsx
+++ b/packages/frontend/src/sections/CurrentUser.tsx
@@ -1,17 +1,53 @@
-import React, { useEffect, useState } from 'react';
-import { api } from '../api';
+import React, { useEffect, useMemo, useState } from 'react';
+import { api, AuthState, getAuthState, setAuthState } from '../api';
 
 type MeResponse = { user: { userId: string; roles: string[]; ownerProjects?: string[] | string } };
 
 export const CurrentUser: React.FC = () => {
   const [me, setMe] = useState<MeResponse['user'] | null>(null);
   const [error, setError] = useState('');
+  const [auth, setAuth] = useState<AuthState | null>(() => getAuthState());
+  const [form, setForm] = useState(() => ({
+    userId: auth?.userId || 'demo-user',
+    roles: auth?.roles?.join(',') || 'admin,mgmt',
+    projectIds: auth?.projectIds?.join(',') || '',
+    groupIds: auth?.groupIds?.join(',') || '',
+  }));
+  const authKey = useMemo(() => JSON.stringify(auth), [auth]);
 
   useEffect(() => {
+    if (!auth) {
+      setMe(null);
+      return;
+    }
     api<MeResponse>('/me')
-      .then((res) => setMe(res.user))
+      .then((res) => {
+        setMe(res.user);
+        setError('');
+      })
       .catch(() => setError('取得に失敗'));
-  }, []);
+  }, [authKey]);
+
+  const login = () => {
+    const roles = form.roles.split(',').map((r) => r.trim()).filter(Boolean);
+    const projectIds = form.projectIds.split(',').map((p) => p.trim()).filter(Boolean);
+    const groupIds = form.groupIds.split(',').map((g) => g.trim()).filter(Boolean);
+    const next: AuthState = {
+      userId: form.userId.trim() || 'demo-user',
+      roles: roles.length ? roles : ['user'],
+      projectIds: projectIds.length ? projectIds : undefined,
+      groupIds: groupIds.length ? groupIds : undefined,
+    };
+    setAuthState(next);
+    setAuth(next);
+  };
+
+  const logout = () => {
+    setAuthState(null);
+    setAuth(null);
+    setMe(null);
+    setError('');
+  };
 
   return (
     <div className="card" style={{ marginBottom: 12 }}>
@@ -19,14 +55,54 @@ export const CurrentUser: React.FC = () => {
         <strong>現在のユーザー</strong>
         {error && <span style={{ color: '#dc2626', marginLeft: 8 }}>{error}</span>}
       </div>
-      {me ? (
-        <div style={{ fontSize: 14 }}>
-          <div>ID: {me.userId}</div>
-          <div>Roles: {me.roles.join(', ')}</div>
-          <div>OwnerProjects: {Array.isArray(me.ownerProjects) ? me.ownerProjects.join(', ') : me.ownerProjects}</div>
+      {!auth && (
+        <div style={{ fontSize: 14, marginTop: 8 }}>
+          <div>未ログイン</div>
+          <div className="row" style={{ gap: 8, marginTop: 8 }}>
+            <input
+              type="text"
+              value={form.userId}
+              onChange={(e) => setForm({ ...form, userId: e.target.value })}
+              placeholder="userId"
+            />
+            <input
+              type="text"
+              value={form.roles}
+              onChange={(e) => setForm({ ...form, roles: e.target.value })}
+              placeholder="roles (admin,mgmt)"
+            />
+            <button className="button" onClick={login}>簡易ログイン</button>
+          </div>
+          <div className="row" style={{ gap: 8, marginTop: 8 }}>
+            <input
+              type="text"
+              value={form.projectIds}
+              onChange={(e) => setForm({ ...form, projectIds: e.target.value })}
+              placeholder="projectIds (optional)"
+            />
+            <input
+              type="text"
+              value={form.groupIds}
+              onChange={(e) => setForm({ ...form, groupIds: e.target.value })}
+              placeholder="groupIds (optional)"
+            />
+          </div>
         </div>
-      ) : (
-        !error && <div style={{ fontSize: 14 }}>読み込み中...</div>
+      )}
+      {auth && (
+        <div style={{ fontSize: 14 }}>
+          {me ? (
+            <>
+              <div>ID: {me.userId}</div>
+              <div>Roles: {me.roles.join(', ')}</div>
+              <div>OwnerProjects: {Array.isArray(me.ownerProjects) ? me.ownerProjects.join(', ') : me.ownerProjects}</div>
+              <div>Groups: {(auth.groupIds || []).join(', ') || '-'}</div>
+            </>
+          ) : (
+            !error && <div>読み込み中...</div>
+          )}
+          <button className="button secondary" style={{ marginTop: 8 }} onClick={logout}>ログアウト</button>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## 概要
- フロントの認証モック状態をローカルストレージに保持
- `/me` 取得をログイン状態に紐付け、簡易ログイン/ログアウトを追加
- fetchラッパで Authorization を含むヘッダ付与を集約

## 動作確認
- 未実施
