### PR TITLE
アラート設定のバリデーションと通知解決

### DIFF
--- a/packages/backend/src/routes/alertSettings.ts
+++ b/packages/backend/src/routes/alertSettings.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { requireRole } from '../services/rbac.js';
 import { prisma } from '../services/db.js';
+import { alertSettingPatchSchema, alertSettingSchema } from './validators.js';
 
 export async function registerAlertSettingRoutes(app: FastifyInstance) {
   app.get('/alert-settings', { preHandler: requireRole(['admin', 'mgmt']) }, async () => {
@@ -8,13 +9,13 @@ export async function registerAlertSettingRoutes(app: FastifyInstance) {
     return { items };
   });
 
-  app.post('/alert-settings', { preHandler: requireRole(['admin', 'mgmt']) }, async (req) => {
+  app.post('/alert-settings', { preHandler: requireRole(['admin', 'mgmt']), schema: alertSettingSchema }, async (req) => {
     const body = req.body as any;
     const created = await prisma.alertSetting.create({ data: body });
     return created;
   });
 
-  app.patch('/alert-settings/:id', { preHandler: requireRole(['admin', 'mgmt']) }, async (req) => {
+  app.patch('/alert-settings/:id', { preHandler: requireRole(['admin', 'mgmt']), schema: alertSettingPatchSchema }, async (req) => {
     const { id } = req.params as { id: string };
     const body = req.body as any;
     const updated = await prisma.alertSetting.update({ where: { id }, data: body });

--- a/packages/backend/src/routes/alerts.ts
+++ b/packages/backend/src/routes/alerts.ts
@@ -1,30 +1,17 @@
 import { FastifyInstance } from 'fastify';
 import { prisma } from '../services/db.js';
-import { computeAndTrigger } from '../services/alert.js';
-import { computeApprovalDelay, computeBudgetOverrun, computeDeliveryDue, computeOvertime } from '../services/metrics.js';
-import { AlertTypeValue } from '../types.js';
 
 export async function registerAlertRoutes(app: FastifyInstance) {
   app.get('/alerts', async (req) => {
     const { projectId, status } = req.query as { projectId?: string; status?: string };
     const alerts = await prisma.alert.findMany({
       where: {
-        ...(projectId ? { scopeProjectId: projectId } : {}),
+        ...(projectId ? { targetRef: projectId } : {}),
         ...(status ? { status } : {}),
       } as any,
       orderBy: { triggeredAt: 'desc' },
       take: 50,
     });
     return { items: alerts };
-  });
-
-  app.post('/jobs/alerts/run', async () => {
-    await computeAndTrigger({
-      [AlertTypeValue.budget_overrun]: () => computeBudgetOverrun('demo-project'),
-      [AlertTypeValue.overtime]: () => computeOvertime('demo-user'),
-      [AlertTypeValue.approval_delay]: () => computeApprovalDelay('demo-instance'),
-      [AlertTypeValue.delivery_due]: () => computeDeliveryDue(),
-    });
-    return { ok: true };
   });
 }

--- a/packages/backend/src/routes/validators.ts
+++ b/packages/backend/src/routes/validators.ts
@@ -161,3 +161,45 @@ export const approvalRuleSchema = {
 export const approvalRulePatchSchema = {
   body: Type.Partial(approvalRuleSchema.body),
 };
+
+const alertTypeSchema = Type.Union([
+  Type.Literal('budget_overrun'),
+  Type.Literal('overtime'),
+  Type.Literal('approval_delay'),
+  Type.Literal('delivery_due'),
+]);
+
+const alertChannelSchema = Type.Union([
+  Type.Literal('email'),
+  Type.Literal('dashboard'),
+  Type.Literal('slack'),
+  Type.Literal('webhook'),
+]);
+
+const alertRecipientsSchema = Type.Object(
+  {
+    emails: Type.Optional(Type.Array(Type.String())),
+    roles: Type.Optional(Type.Array(Type.String())),
+    users: Type.Optional(Type.Array(Type.String())),
+  },
+  { additionalProperties: true },
+);
+
+export const alertSettingSchema = {
+  body: Type.Object(
+    {
+      type: alertTypeSchema,
+      threshold: Type.Number({ minimum: 0 }),
+      period: Type.String(),
+      scopeProjectId: Type.Optional(Type.String()),
+      recipients: alertRecipientsSchema,
+      channels: Type.Array(alertChannelSchema, { minItems: 1 }),
+      isEnabled: Type.Optional(Type.Boolean()),
+    },
+    { additionalProperties: false },
+  ),
+};
+
+export const alertSettingPatchSchema = {
+  body: Type.Partial(alertSettingSchema.body),
+};

--- a/packages/backend/src/services/alert.ts
+++ b/packages/backend/src/services/alert.ts
@@ -3,17 +3,40 @@ import { prisma } from './db.js';
 
 type MetricFetcher = (settingId: string) => Promise<number>;
 
-export async function triggerAlert(settingId: string, metric: number, threshold: number, targetRef: string) {
-  const emailResult = await sendEmailStub(['alert@example.com'], `Alert ${settingId}`, `metric ${metric} > ${threshold}`);
-  const otherChannels = ['dashboard'];
-  const sentResult = [emailResult, ...buildStubResults(otherChannels)];
-  const channels = sentResult.map((r) => r.channel);
+type AlertRecipients = {
+  emails?: string[];
+  roles?: string[];
+  users?: string[];
+};
+
+function normalizeChannels(raw: unknown): string[] {
+  if (Array.isArray(raw)) return raw.map((c) => String(c)).filter(Boolean);
+  if (raw && typeof raw === 'object') {
+    return Object.keys(raw).filter((key) => (raw as Record<string, boolean>)[key]);
+  }
+  return ['dashboard'];
+}
+
+function resolveEmails(recipients: AlertRecipients | null | undefined): string[] {
+  const emails = recipients?.emails?.filter(Boolean) || [];
+  return emails.length ? emails : ['alert@example.com'];
+}
+
+export async function triggerAlert(setting: { id: string; recipients: unknown; channels: unknown }, metric: number, threshold: number, targetRef: string) {
+  const channels = normalizeChannels(setting.channels);
+  const otherChannels = channels.filter((c) => c !== 'email');
+  const sentResult = [...buildStubResults(otherChannels)];
+  if (channels.includes('email')) {
+    const emailResult = await sendEmailStub(resolveEmails(setting.recipients as AlertRecipients), `Alert ${setting.id}`, `metric ${metric} > ${threshold}`);
+    sentResult.unshift(emailResult);
+  }
+  const sentChannels = sentResult.map((r) => r.channel);
   return prisma.alert.create({
     data: {
-      settingId,
+      settingId: setting.id,
       targetRef,
       status: 'open',
-      sentChannels: { set: channels },
+      sentChannels: { set: sentChannels },
       sentResult: { set: sentResult },
     },
   });
@@ -26,7 +49,12 @@ export async function computeAndTrigger(fetchers: Record<string, MetricFetcher>)
     if (!fetcher) continue;
     const metric = await fetcher(s.id);
     if (metric > Number(s.threshold)) {
-      await triggerAlert(s.id, metric, Number(s.threshold), s.scopeProjectId || 'global');
+      await triggerAlert(
+        { id: s.id, recipients: s.recipients, channels: s.channels },
+        metric,
+        Number(s.threshold),
+        s.scopeProjectId || 'global',
+      );
     }
   }
 }


### PR DESCRIPTION
## 概要
- alert_settings のPOST/PATCHにバリデーションを追加
- アラート通知先/チャネルを設定値から解決して送信
- /alerts のprojectIdフィルタを targetRef に合わせる
- /jobs/alerts/run の重複定義を整理

## 動作確認
- 未実施
