### PR TITLE
レポートAPIの案内と簡易UI追加

### DIFF
--- a/docs/requirements/frontend-api-wire.md
+++ b/docs/requirements/frontend-api-wire.md
@@ -10,6 +10,9 @@
 
 ## reports
 - GET `/reports/delivery-due?from=YYYY-MM-DD&to=YYYY-MM-DD&projectId?`
+- GET `/reports/project-effort/:projectId?from=YYYY-MM-DD&to=YYYY-MM-DD`
+- GET `/reports/group-effort?userIds=a,b,c&from=YYYY-MM-DD&to=YYYY-MM-DD`
+- GET `/reports/overtime/:userId?from=YYYY-MM-DD&to=YYYY-MM-DD`
 
 ## daily report / wellbeing
 - POST `/daily-reports` { content, reportDate, linkedProjectIds?, status }

--- a/packages/frontend/src/pages/App.tsx
+++ b/packages/frontend/src/pages/App.tsx
@@ -5,6 +5,7 @@ import { TimeEntries } from '../sections/TimeEntries';
 import { Invoices } from '../sections/Invoices';
 import { HRAnalytics } from '../sections/HRAnalytics';
 import { CurrentUser } from '../sections/CurrentUser';
+import { Reports } from '../sections/Reports';
 
 export const App: React.FC = () => {
   return (
@@ -15,6 +16,7 @@ export const App: React.FC = () => {
       <div className="card"><DailyReport /></div>
       <div className="card"><TimeEntries /></div>
       <div className="card"><Invoices /></div>
+      <div className="card"><Reports /></div>
       <div className="card"><HRAnalytics /></div>
     </div>
   );

--- a/packages/frontend/src/sections/Reports.tsx
+++ b/packages/frontend/src/sections/Reports.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import { api } from '../api';
+
+type ProjectEffort = { projectId: string; totalMinutes: number; totalExpenses: number };
+type GroupEffort = { userId: string; totalMinutes: number };
+type Overtime = { userId: string; totalMinutes: number; dailyHours: number };
+
+function buildQuery(from?: string, to?: string) {
+  const params = new URLSearchParams();
+  if (from) params.set('from', from);
+  if (to) params.set('to', to);
+  const qs = params.toString();
+  return qs ? `?${qs}` : '';
+}
+
+export const Reports: React.FC = () => {
+  const [projectId, setProjectId] = useState('demo-project');
+  const [groupUserIds, setGroupUserIds] = useState('demo-user');
+  const [overtimeUserId, setOvertimeUserId] = useState('demo-user');
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+  const [projectReport, setProjectReport] = useState<ProjectEffort | null>(null);
+  const [groupReport, setGroupReport] = useState<GroupEffort[]>([]);
+  const [overtimeReport, setOvertimeReport] = useState<Overtime | null>(null);
+  const [message, setMessage] = useState('');
+
+  const loadProject = async () => {
+    try {
+      const res = await api<ProjectEffort>(`/reports/project-effort/${projectId}${buildQuery(from, to)}`);
+      setProjectReport(res);
+      setMessage('プロジェクト別工数を取得しました');
+    } catch (err) {
+      setMessage('取得に失敗しました');
+    }
+  };
+
+  const loadGroup = async () => {
+    try {
+      const qs = buildQuery(from, to);
+      const joined = groupUserIds.split(',').map((v) => v.trim()).filter(Boolean).join(',');
+      const res = await api<{ items: GroupEffort[] }>(`/reports/group-effort?userIds=${encodeURIComponent(joined)}${qs ? `&${qs.slice(1)}` : ''}`);
+      setGroupReport(res.items);
+      setMessage('グループ別工数を取得しました');
+    } catch (err) {
+      setMessage('取得に失敗しました');
+    }
+  };
+
+  const loadOvertime = async () => {
+    try {
+      const res = await api<Overtime>(`/reports/overtime/${overtimeUserId}${buildQuery(from, to)}`);
+      setOvertimeReport(res);
+      setMessage('個人別残業を取得しました');
+    } catch (err) {
+      setMessage('取得に失敗しました');
+    }
+  };
+
+  return (
+    <div>
+      <h2>Reports</h2>
+      <div className="row" style={{ gap: 8, flexWrap: 'wrap' }}>
+        <input type="text" value={from} onChange={(e) => setFrom(e.target.value)} placeholder="from (YYYY-MM-DD)" />
+        <input type="text" value={to} onChange={(e) => setTo(e.target.value)} placeholder="to (YYYY-MM-DD)" />
+      </div>
+      <div className="row" style={{ gap: 8, marginTop: 8, flexWrap: 'wrap' }}>
+        <input type="text" value={projectId} onChange={(e) => setProjectId(e.target.value)} placeholder="projectId" />
+        <button className="button" onClick={loadProject}>PJ別工数</button>
+        <input type="text" value={groupUserIds} onChange={(e) => setGroupUserIds(e.target.value)} placeholder="userIds (a,b,c)" />
+        <button className="button" onClick={loadGroup}>グループ別工数</button>
+        <input type="text" value={overtimeUserId} onChange={(e) => setOvertimeUserId(e.target.value)} placeholder="userId" />
+        <button className="button" onClick={loadOvertime}>個人別残業</button>
+      </div>
+      {message && <p>{message}</p>}
+      <div className="list" style={{ display: 'grid', gap: 8 }}>
+        {projectReport && (
+          <div className="card" style={{ padding: 12 }}>
+            <strong>プロジェクト別工数</strong>
+            <div>Project: {projectReport.projectId}</div>
+            <div>Minutes: {projectReport.totalMinutes}</div>
+            <div>Expenses: ¥{Number(projectReport.totalExpenses || 0).toLocaleString()}</div>
+          </div>
+        )}
+        {groupReport.length > 0 && (
+          <div className="card" style={{ padding: 12 }}>
+            <strong>グループ別工数</strong>
+            {groupReport.map((item) => (
+              <div key={item.userId}>{item.userId}: {item.totalMinutes} min</div>
+            ))}
+          </div>
+        )}
+        {overtimeReport && (
+          <div className="card" style={{ padding: 12 }}>
+            <strong>個人別残業</strong>
+            <div>User: {overtimeReport.userId}</div>
+            <div>Minutes: {overtimeReport.totalMinutes}</div>
+            <div>Hours (avg/day): {overtimeReport.dailyHours.toFixed(2)}</div>
+          </div>
+        )}
+        {!projectReport && groupReport.length === 0 && !overtimeReport && (
+          <div className="card">レポート未取得</div>
+        )}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## 概要
- レポートAPIの一覧をフロントAPIワイヤに追記
- レポート取得の簡易UIを追加（PJ別/グループ別/個人別残業）

## 動作確認
- 未実施
