### PR TITLE
フロント入力を認証ユーザーに紐付け

### DIFF
--- a/packages/frontend/src/sections/DailyReport.tsx
+++ b/packages/frontend/src/sections/DailyReport.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { api } from '../api';
+import { api, getAuthState } from '../api';
 import { HelpModal } from './HelpModal';
 
 const tags = ['仕事量が多い', '役割/進め方', '人間関係', '体調', '私生活', '特になし'];
@@ -12,6 +12,7 @@ export const DailyReport: React.FC = () => {
   const [message, setMessage] = useState('');
   const [showHelp, setShowHelp] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const userId = getAuthState()?.userId || 'demo-user';
 
   const toggleTag = (tag: string) => {
     setSelectedTags((prev) => (prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]));
@@ -22,11 +23,18 @@ export const DailyReport: React.FC = () => {
       setIsSubmitting(true);
       await api('/daily-reports', {
         method: 'POST',
-        body: JSON.stringify({ content: '日報本文', reportDate: new Date().toISOString(), linkedProjectIds: [], status: 'submitted' }),
+        body: JSON.stringify({
+          userId,
+          content: '日報本文',
+          reportDate: new Date().toISOString(),
+          linkedProjectIds: [],
+          status: 'submitted',
+        }),
       });
       await api('/wellbeing-entries', {
         method: 'POST',
         body: JSON.stringify({
+          userId,
           entryDate: new Date().toISOString(),
           status,
           notes: selectedTags.length ? `${notes}\nTags:${selectedTags.join(',')}` : notes,

--- a/packages/frontend/src/sections/Invoices.tsx
+++ b/packages/frontend/src/sections/Invoices.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { api } from '../api';
+import { api, getAuthState } from '../api';
 import { InvoiceDetail } from './InvoiceDetail';
 
 interface Invoice {
@@ -11,11 +11,12 @@ interface Invoice {
   lines?: { description: string; quantity: number; unitPrice: number }[];
 }
 
-const initialForm = { projectId: 'demo-project', totalAmount: 100000 };
+const buildInitialForm = (projectId?: string) => ({ projectId: projectId || 'demo-project', totalAmount: 100000 });
 
 export const Invoices: React.FC = () => {
   const [items, setItems] = useState<Invoice[]>([]);
-  const [form, setForm] = useState(initialForm);
+  const auth = getAuthState();
+  const [form, setForm] = useState(() => buildInitialForm(auth?.projectIds?.[0]));
   const [selected, setSelected] = useState<Invoice | null>(null);
   const [message, setMessage] = useState('');
 

--- a/packages/frontend/src/sections/Reports.tsx
+++ b/packages/frontend/src/sections/Reports.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { api } from '../api';
+import { api, getAuthState } from '../api';
 
 type ProjectEffort = { projectId: string; totalMinutes: number; totalExpenses: number };
 type GroupEffort = { userId: string; totalMinutes: number };
@@ -14,9 +14,12 @@ function buildQuery(from?: string, to?: string) {
 }
 
 export const Reports: React.FC = () => {
-  const [projectId, setProjectId] = useState('demo-project');
-  const [groupUserIds, setGroupUserIds] = useState('demo-user');
-  const [overtimeUserId, setOvertimeUserId] = useState('demo-user');
+  const auth = getAuthState();
+  const defaultProjectId = auth?.projectIds?.[0] || 'demo-project';
+  const defaultUserId = auth?.userId || 'demo-user';
+  const [projectId, setProjectId] = useState(defaultProjectId);
+  const [groupUserIds, setGroupUserIds] = useState(defaultUserId);
+  const [overtimeUserId, setOvertimeUserId] = useState(defaultUserId);
   const [from, setFrom] = useState('');
   const [to, setTo] = useState('');
   const [projectReport, setProjectReport] = useState<ProjectEffort | null>(null);


### PR DESCRIPTION
## 概要
- 日報/ウェルビーイング/工数/請求/レポートの入力を認証ユーザーに紐付け
- projectId/userIdの初期値を認証情報から補完

## 動作確認
- 未実施
