### PR TITLE
損益・工数予実の算出ロジック整理

### DIFF
--- a/docs/requirements/profit-and-variance.md
+++ b/docs/requirements/profit-and-variance.md
@@ -6,6 +6,8 @@
 
 ## 前提
 - 間接費配賦は行わない（間接費は案件分割 or 共通案件で管理）。
+  - 「間接費」の例: 会社全体の一般管理費（バックオフィス人件費、採用費、役員報酬）、オフィス賃料・水道光熱費、共通SaaS利用料など、特定の案件に直接ひもづかないコスト。
+  - 「直接費」は特定の projectId / taskId にひもづく支出（外注費・仕入、案件別経費、time_entries に基づく労務コストなど）を指す。
 - 経費は必ず projectId を持つ。共通経費は専用Projectで処理する。
 
 ## データソース（MVP）
@@ -13,10 +15,12 @@
   - 集計対象: status in (approved, sent, paid)
   - 期間: issueDate ベース（支払ベースは後続）
 - 外注/仕入: vendor_invoices.totalAmount
-  - 集計対象: status in (received, approved)
+  - 集計対象: status in (received, approved, paid)
 - 直接経費: expenses.amount
   - 集計対象: status in (approved)
+  - 備考: 承認待ち（pending_qa/pending_exec）は最終承認前のため集計対象外
 - 労務コスト: time_entries.minutes * rate_cards.unitPrice
+  - 集計対象: status in (submitted, approved)
   - rate_cards は projectId 指定優先、無ければ汎用（role/workType）を参照
 
 ## 予算（Budget）/見込
@@ -38,10 +42,12 @@
 - 為替: MVP は同一通貨前提（多通貨対応は後続）
 
 ## アラート連携
-- 予算超過: 売上予算に対する実績比率で判定（初期 110%）
+- 予算超過（売上）: 売上予算に対する実績比率で判定（初期 110%）
+- 予算超過（コスト）: budgetCost 定義後に別途判定ロジックを追加する
 - 残業: time_entries から集計
 
 ## 未決定/確認事項
 - 工数予算の持ち方（project/milestone/task のどこに planHours を置くか）
 - 売上予算の基準（estimate vs milestone のどちらを主とするか）
 - 複数通貨/税抜税込の集計方針
+- コスト予算（budgetCost）に対する予算超過アラートの有無としきい値


### PR DESCRIPTION
## 概要\n- 売上/コスト/工数の算出ルールを整理\n- 予算/実績/差分の定義と未決定事項を明文化\n\n## 参照\n- docs/requirements/mvp-scope.md\n- docs/requirements/approval-alerts.md