### PR TITLE
Fastify v4 と @fastify/helmet の互換性修正

### DIFF
--- a/packages/backend/package-lock.json
+++ b/packages/backend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fastify/cors": "^9.0.0",
-        "@fastify/helmet": "^13.0.2",
+        "@fastify/helmet": "^11.1.1",
         "@prisma/client": "^5.9.0",
         "@sinclair/typebox": "^0.32.30",
         "fastify": "^4.26.2",
@@ -948,40 +948,14 @@
       }
     },
     "node_modules/@fastify/helmet": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-13.0.2.tgz",
-      "integrity": "sha512-tO1QMkOfNeCt9l4sG/FiWErH4QMm+RjHzbMTrgew1DYOQ2vb/6M1G2iNABBrD7Xq6dUk+HLzWW8u+rmmhQHifA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-11.1.1.tgz",
+      "integrity": "sha512-pjJxjk6SLEimITWadtYIXt6wBMfFC1I6OQyH/jYVCqSAn36sgAIFjeNiibHtifjCd+e25442pObis3Rjtame6A==",
       "license": "MIT",
       "dependencies": {
-        "fastify-plugin": "^5.0.0",
-        "helmet": "^8.0.0"
+        "fastify-plugin": "^4.2.1",
+        "helmet": "^7.0.0"
       }
-    },
-    "node_modules/@fastify/helmet/node_modules/fastify-plugin": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
-      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/@fastify/merge-json-schemas": {
       "version": "0.1.1",
@@ -3217,12 +3191,12 @@
       }
     },
     "node_modules/helmet": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
-      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.2.0.tgz",
+      "integrity": "sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/ignore": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^9.0.0",
-    "@fastify/helmet": "^13.0.2",
+    "@fastify/helmet": "^11.1.1",
     "@prisma/client": "^5.9.0",
     "@sinclair/typebox": "^0.32.30",
     "fastify": "^4.26.2",


### PR DESCRIPTION
概要
- Fastify v4 と互換のある @fastify/helmet v11 に固定
- ローカル/PoC で backend を起動できるようにする

テスト
- npm --prefix packages/backend run build
- node packages/backend/dist/index.js
