### PR TITLE
日付入力のパースを明示化

### DIFF
--- a/packages/backend/src/routes/wellbeing.ts
+++ b/packages/backend/src/routes/wellbeing.ts
@@ -18,9 +18,17 @@ export async function registerWellbeingRoutes(app: FastifyInstance) {
       schema: wellbeingSchema,
       preHandler: requireRole(['admin', 'mgmt', 'user']),
     },
-    async (req) => {
+    async (req, reply) => {
       const body = req.body as any;
-      const entry = await prisma.wellbeingEntry.create({ data: body });
+      const entryDate = parseDateParam(body.entryDate);
+      if (!entryDate) {
+        return reply.status(400).send({
+          error: { code: 'INVALID_DATE', message: 'Invalid entryDate' },
+        });
+      }
+      const entry = await prisma.wellbeingEntry.create({
+        data: { ...body, entryDate },
+      });
       return entry;
     },
   );


### PR DESCRIPTION
概要
- TimeEntry/Expense/DailyReport/Wellbeing の日付文字列を Date に変換して保存
- 400 エラーで invalid date を返すように統一

確認
- PoC 手動確認で time/expense/daily/wellbeing の POST が成功することを確認
