### PR TITLE
PoC seed に ApprovalRule を追加

### DIFF
--- a/scripts/seed-demo.sql
+++ b/scripts/seed-demo.sql
@@ -4,6 +4,12 @@ insert into "Project" (id, code, name, status, "createdAt", "updatedAt") values
   ('00000000-0000-0000-0000-000000000001','PRJ-DEMO-1','Demo Project 1','active', now(), now()),
   ('00000000-0000-0000-0000-000000000002','PRJ-DEMO-2','Demo Project 2','active', now(), now());
 
+insert into "ApprovalRule" (id, "flowType", conditions, steps, "createdAt", "updatedAt") values
+  ('50000000-0000-0000-0000-000000000001','estimate','{}','[]', now(), now()),
+  ('50000000-0000-0000-0000-000000000002','invoice','{}','[]', now(), now()),
+  ('50000000-0000-0000-0000-000000000003','expense','{}','[]', now(), now()),
+  ('50000000-0000-0000-0000-000000000004','time','{}','[]', now(), now());
+
 insert into "Estimate" (id, "projectId", version, "totalAmount", currency, status, "createdAt", "updatedAt")
 values ('10000000-0000-0000-0000-000000000001','00000000-0000-0000-0000-000000000001',1,120000,'JPY','approved', now(), now());
 


### PR DESCRIPTION
概要
- PoC の seed に ApprovalRule を追加し、見積/請求/経費/工数の submit が失敗しないようにする

確認
- scripts/podman-poc.sh reset
- /estimates/:id/submit が 500 にならず pending_qa になることを確認
