### PR TITLE
Set pending status based on approval step group

### DIFF
--- a/packages/backend/src/services/approval.ts
+++ b/packages/backend/src/services/approval.ts
@@ -39,8 +39,7 @@ function resolvePendingStatus(
 ) {
   if (!stepOrder) return DocStatusValue.pending_qa;
   const isExec = steps.some(
-    (step) =>
-      step.stepOrder === stepOrder && step.approverGroupId === 'exec',
+    (step) => step.stepOrder === stepOrder && step.approverGroupId === 'exec',
   );
   return isExec ? DocStatusValue.pending_exec : DocStatusValue.pending_qa;
 }


### PR DESCRIPTION
- 承認インスタンスのpending状態をステップの承認グループに合わせて設定
- execステップ時は pending_exec を返すように調整
