### PR TITLE
Add approval summary to dashboard

### DIFF
--- a/packages/frontend/src/sections/Dashboard.tsx
+++ b/packages/frontend/src/sections/Dashboard.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { api } from '../api';
+import React, { useEffect, useMemo, useState } from 'react';
+import { api, getAuthState } from '../api';
 
 type Alert = {
   id: string;
@@ -10,11 +10,49 @@ type Alert = {
   sentChannels?: string[];
 };
 
+type ApprovalStep = {
+  id: string;
+  stepOrder: number;
+  approverGroupId?: string | null;
+  approverUserId?: string | null;
+  status: string;
+};
+
+type ApprovalInstance = {
+  id: string;
+  status: string;
+  currentStep?: number | null;
+  steps: ApprovalStep[];
+};
+
 export const Dashboard: React.FC = () => {
+  const auth = getAuthState();
+  const userId = auth?.userId ?? '';
+  const userGroupIds = auth?.groupIds ?? [];
   const [alerts, setAlerts] = useState<Alert[]>([]);
+  const [approvals, setApprovals] = useState<ApprovalInstance[]>([]);
+  const [approvalMessage, setApprovalMessage] = useState('');
   const [showAll, setShowAll] = useState(false);
   const hasMore = alerts.length > 5;
   const visibleAlerts = showAll ? alerts : alerts.slice(0, 5);
+  const myPendingApprovals = useMemo(() => {
+    if (!approvals.length) return 0;
+    return approvals.filter((item) => {
+      if (!item.currentStep) return false;
+      const currentSteps = item.steps.filter(
+        (step) =>
+          step.stepOrder === item.currentStep && step.status === 'pending_qa',
+      );
+      if (!currentSteps.length) return false;
+      return currentSteps.some((step) => {
+        if (step.approverUserId) return step.approverUserId === userId;
+        if (step.approverGroupId) {
+          return userGroupIds.includes(step.approverGroupId);
+        }
+        return true;
+      });
+    }).length;
+  }, [approvals, userGroupIds, userId]);
 
   useEffect(() => {
     api<{ items: Alert[] }>('/alerts')
@@ -22,9 +60,50 @@ export const Dashboard: React.FC = () => {
       .catch(() => setAlerts([]));
   }, []);
 
+  useEffect(() => {
+    const loadApprovals = async () => {
+      try {
+        const [pendingQa, pendingExec] = await Promise.all([
+          api<{ items: ApprovalInstance[] }>(
+            '/approval-instances?status=pending_qa',
+          ),
+          api<{ items: ApprovalInstance[] }>(
+            '/approval-instances?status=pending_exec',
+          ),
+        ]);
+        const all = [...(pendingQa.items || []), ...(pendingExec.items || [])];
+        const unique = Array.from(
+          new Map(all.map((item) => [item.id, item])).values(),
+        );
+        setApprovals(unique);
+        setApprovalMessage('');
+      } catch (err) {
+        console.error('Failed to load approvals.', err);
+        setApprovals([]);
+        setApprovalMessage('承認状況の取得に失敗しました');
+      }
+    };
+    loadApprovals();
+  }, []);
+
   return (
     <div>
       <h2>Dashboard</h2>
+      <div className="card" style={{ marginBottom: 12, padding: 12 }}>
+        <div className="row" style={{ justifyContent: 'space-between' }}>
+          <strong>承認状況</strong>
+          <span className="badge">Pending</span>
+        </div>
+        <div style={{ marginTop: 8 }}>
+          承認待ち: {approvals.length}件 / 自分の承認待ち: {myPendingApprovals}
+          件
+        </div>
+        {approvalMessage && (
+          <div style={{ color: '#dc2626', marginTop: 6 }}>
+            {approvalMessage}
+          </div>
+        )}
+      </div>
       <div className="row" style={{ alignItems: 'center' }}>
         <p className="badge">
           Alerts{' '}


### PR DESCRIPTION
- ダッシュボードに承認待ち件数/自分の承認待ち件数を表示
- pending_qa/pending_exec をまとめて集計
