### PR TITLE
Generate report payloads for subscriptions

### DIFF
--- a/packages/backend/src/routes/reportSubscriptions.ts
+++ b/packages/backend/src/routes/reportSubscriptions.ts
@@ -112,7 +112,8 @@ function parseOffset(raw: string | undefined) {
 }
 
 function normalizeFormat(value: string | null): 'csv' | 'pdf' {
-  if (!value || value === 'csv' || value === 'pdf') return value ?? 'csv';
+  if (!value) return 'csv';
+  if (value === 'csv' || value === 'pdf') return value;
   throw new ReportParamError('INVALID_FORMAT', 'format must be csv or pdf');
 }
 


### PR DESCRIPTION
## 変更内容
- report_subscriptions 実行時に reportKey から実データを生成
- CSV/PDF 生成を行い、ReportDelivery に payload を保存
- 失敗時は lastRunStatus を failed に更新

## テスト
- npm run lint --prefix packages/backend
- npm run format:check --prefix packages/backend
