### PR TITLE
Restrict project list by user access

### DIFF
--- a/packages/backend/src/routes/projects.ts
+++ b/packages/backend/src/routes/projects.ts
@@ -68,6 +68,13 @@ export async function registerProjectRoutes(app: FastifyInstance) {
     async (req) => {
       const roles = req.user?.roles || [];
       const projectIds = req.user?.projectIds || [];
+      if (
+        !roles.includes('admin') &&
+        !roles.includes('mgmt') &&
+        projectIds.length === 0
+      ) {
+        return { items: [] };
+      }
       const where =
         roles.includes('admin') || roles.includes('mgmt')
           ? { deletedAt: null }


### PR DESCRIPTION
## 概要
- /projects を requireRole で保護
- admin/mgmt 以外は projectIds に限定して一覧を返す
- deletedAt=null のみ取得

Refs #276