### PR TITLE
Add reasonCode/reasonText to task reassignment

### DIFF
--- a/docs/plan/todo.md
+++ b/docs/plan/todo.md
@@ -15,12 +15,13 @@
   - [ ] 例外操作（付け替え/承認取消）は理由必須 + 監査ログ必須
   - [ ] ドキュメント更新（access-control/rbac-matrix）
 - [ ] #277 付け替え運用（締め期間/理由コード/承認取消）
-  - [ ] PeriodLock テーブル追加（period/scope/projectId/closedAt/closedBy/reason）
-  - [ ] 付け替え理由コードを定義（input_error など）+ reasonText 必須
+  - [x] PeriodLock テーブル追加（period/scope/projectId/closedAt/closedBy/reason）
+  - [x] 付け替え理由コードを定義（input_error など）+ reasonText 必須
+  - [x] Task 付け替えに reasonCode/reasonText を適用し監査ログを記録
   - [ ] 付け替えAPIの実装（TimeEntry/Expense/Task 等、締め期間/承認状態のチェック）
   - [ ] 承認取消フローの実装（status=cancelled、権限と理由の検証）
   - [ ] 監査ログ・付け替え履歴の記録
-  - [ ] 仕様ドキュメント更新（reassignment-policy）
+  - [x] 仕様ドキュメント更新（reassignment-policy）
 - [ ] #278 バックアップ/リストア運用の確定と実装準備
   - [ ] 保持期間/RPO/RTO の確定（デフォルト: 日次14日/週次8週/月次12か月）
   - [ ] 暗号化/保管先の運用手順を確定（SSE-KMS + 必要ならGPG二重化）

--- a/docs/requirements/reassignment-policy.md
+++ b/docs/requirements/reassignment-policy.md
@@ -43,6 +43,7 @@
 - APIは resource別に `POST /time-entries/:id/reassign` などを用意
 - サーバ側で状態/関連チェックを実施し、違反時は 400/403
 - 付け替え履歴テーブル（例: reassignment_log）を追加
+- reasonCode/reasonText を必須とし、監査ログに保存する
 
 ## 理由コード（案）
 | code | 説明 |

--- a/packages/backend/src/routes/validators.ts
+++ b/packages/backend/src/routes/validators.ts
@@ -163,10 +163,19 @@ export const deleteReasonSchema = {
   }),
 };
 
+const reassignReasonCodeSchema = Type.Union([
+  Type.Literal('input_error'),
+  Type.Literal('project_misassignment'),
+  Type.Literal('task_restructure'),
+  Type.Literal('contract_split_merge'),
+  Type.Literal('internal_transfer'),
+]);
+
 export const reassignSchema = {
   body: Type.Object({
     toProjectId: Type.String(),
-    reason: Type.String(),
+    reasonCode: reassignReasonCodeSchema,
+    reasonText: Type.String({ minLength: 1 }),
   }),
 };
 


### PR DESCRIPTION
## 概要
- Task 付け替えAPIで reasonCode/reasonText を必須化
- 付け替え時の監査ログを記録
- TODO(#277) と再付け替え方針ドキュメントを更新

## 影響範囲
- packages/backend/src/routes/validators.ts
- packages/backend/src/routes/projects.ts
- docs/requirements/reassignment-policy.md
- docs/plan/todo.md

## テスト
- npm run lint --prefix packages/backend
- npm run format:check --prefix packages/backend
