### PR TITLE
Restrict alerts and job endpoints

### DIFF
--- a/packages/backend/src/routes/alerts.ts
+++ b/packages/backend/src/routes/alerts.ts
@@ -1,20 +1,25 @@
 import { FastifyInstance } from 'fastify';
 import { prisma } from '../services/db.js';
+import { requireRole } from '../services/rbac.js';
 
 export async function registerAlertRoutes(app: FastifyInstance) {
-  app.get('/alerts', async (req) => {
-    const { projectId, status } = req.query as {
-      projectId?: string;
-      status?: string;
-    };
-    const alerts = await prisma.alert.findMany({
-      where: {
-        ...(projectId ? { targetRef: projectId } : {}),
-        ...(status ? { status } : {}),
-      } as any,
-      orderBy: { triggeredAt: 'desc' },
-      take: 50,
-    });
-    return { items: alerts };
-  });
+  app.get(
+    '/alerts',
+    { preHandler: requireRole(['admin', 'mgmt']) },
+    async (req) => {
+      const { projectId, status } = req.query as {
+        projectId?: string;
+        status?: string;
+      };
+      const alerts = await prisma.alert.findMany({
+        where: {
+          ...(projectId ? { targetRef: projectId } : {}),
+          ...(status ? { status } : {}),
+        } as any,
+        orderBy: { triggeredAt: 'desc' },
+        take: 50,
+      });
+      return { items: alerts };
+    },
+  );
 }

--- a/packages/backend/src/routes/metricsJobs.ts
+++ b/packages/backend/src/routes/metricsJobs.ts
@@ -8,22 +8,31 @@ import {
   computeOvertime,
 } from '../services/metrics.js';
 import { AlertTypeValue } from '../types.js';
+import { requireRole } from '../services/rbac.js';
 
 export async function registerMetricJobRoutes(app: FastifyInstance) {
-  app.post('/jobs/alerts/run', async () => {
-    await computeAndTrigger({
-      [AlertTypeValue.budget_overrun]: (setting) =>
-        computeBudgetOverrun(setting),
-      [AlertTypeValue.overtime]: (setting) => computeOvertime(setting),
-      [AlertTypeValue.approval_delay]: (setting) =>
-        computeApprovalDelay(setting),
-      [AlertTypeValue.delivery_due]: (setting) => computeDeliveryDue(setting),
-    });
-    return { ok: true };
-  });
+  app.post(
+    '/jobs/alerts/run',
+    { preHandler: requireRole(['admin', 'mgmt']) },
+    async () => {
+      await computeAndTrigger({
+        [AlertTypeValue.budget_overrun]: (setting) =>
+          computeBudgetOverrun(setting),
+        [AlertTypeValue.overtime]: (setting) => computeOvertime(setting),
+        [AlertTypeValue.approval_delay]: (setting) =>
+          computeApprovalDelay(setting),
+        [AlertTypeValue.delivery_due]: (setting) => computeDeliveryDue(setting),
+      });
+      return { ok: true };
+    },
+  );
 
-  app.post('/jobs/approval-escalations/run', async () => {
-    await runApprovalEscalations();
-    return { ok: true };
-  });
+  app.post(
+    '/jobs/approval-escalations/run',
+    { preHandler: requireRole(['admin', 'mgmt']) },
+    async () => {
+      await runApprovalEscalations();
+      return { ok: true };
+    },
+  );
 }


### PR DESCRIPTION
## 概要
- /alerts と /jobs/* をRBACで制限

## 変更点
- `/alerts` は admin/mgmt のみアクセス可能に変更
- `/jobs/alerts/run` と `/jobs/approval-escalations/run` も admin/mgmt に限定

## 補足
- 既存の data-quality job は従来通り admin/mgmt 制限済みです。
