### PR TITLE
Enforce self userId for user submissions

### DIFF
--- a/packages/backend/src/routes/dailyReports.ts
+++ b/packages/backend/src/routes/dailyReports.ts
@@ -13,6 +13,15 @@ export async function registerDailyReportRoutes(app: FastifyInstance) {
     },
     async (req, reply) => {
       const body = req.body as any;
+      const roles = req.user?.roles || [];
+      const isPrivileged = roles.includes('admin') || roles.includes('mgmt');
+      const currentUserId = req.user?.userId;
+      if (!isPrivileged) {
+        if (!currentUserId) {
+          return reply.code(403).send({ error: 'forbidden' });
+        }
+        body.userId = currentUserId;
+      }
       const reportDate = parseDateParam(body.reportDate);
       if (!reportDate) {
         return reply.status(400).send({
@@ -29,8 +38,22 @@ export async function registerDailyReportRoutes(app: FastifyInstance) {
   app.get(
     '/daily-reports',
     { preHandler: requireRole(['admin', 'mgmt', 'user']) },
-    async () => {
+    async (req, reply) => {
+      const { userId } = req.query as { userId?: string };
+      const roles = req.user?.roles || [];
+      const isPrivileged = roles.includes('admin') || roles.includes('mgmt');
+      const currentUserId = req.user?.userId;
+      const where: { userId?: string } = {};
+      if (!isPrivileged) {
+        if (!currentUserId) {
+          return reply.code(403).send({ error: 'forbidden' });
+        }
+        where.userId = currentUserId;
+      } else if (userId) {
+        where.userId = userId;
+      }
       const reports = await prisma.dailyReport.findMany({
+        where,
         orderBy: { reportDate: 'desc' },
         take: 50,
       });

--- a/packages/backend/src/routes/expenses.ts
+++ b/packages/backend/src/routes/expenses.ts
@@ -21,6 +21,15 @@ export async function registerExpenseRoutes(app: FastifyInstance) {
     },
     async (req, reply) => {
       const body = req.body as any;
+      const roles = req.user?.roles || [];
+      const isPrivileged = roles.includes('admin') || roles.includes('mgmt');
+      const currentUserId = req.user?.userId;
+      if (!isPrivileged) {
+        if (!currentUserId) {
+          return reply.code(403).send({ error: 'forbidden' });
+        }
+        body.userId = currentUserId;
+      }
       const incurredOn = parseDateParam(body.incurredOn);
       if (!incurredOn) {
         return reply.status(400).send({

--- a/packages/backend/src/routes/timeEntries.ts
+++ b/packages/backend/src/routes/timeEntries.ts
@@ -95,6 +95,15 @@ export async function registerTimeEntryRoutes(app: FastifyInstance) {
     },
     async (req, reply) => {
       const body = req.body as any;
+      const roles = req.user?.roles || [];
+      const isPrivileged = roles.includes('admin') || roles.includes('mgmt');
+      const currentUserId = req.user?.userId;
+      if (!isPrivileged) {
+        if (!currentUserId) {
+          return reply.code(403).send({ error: 'forbidden' });
+        }
+        body.userId = currentUserId;
+      }
       const workDate = parseDateParam(body.workDate);
       if (!workDate) {
         return reply.status(400).send({

--- a/packages/backend/src/routes/wellbeing.ts
+++ b/packages/backend/src/routes/wellbeing.ts
@@ -20,6 +20,15 @@ export async function registerWellbeingRoutes(app: FastifyInstance) {
     },
     async (req, reply) => {
       const body = req.body as any;
+      const roles = req.user?.roles || [];
+      const isPrivileged = roles.includes('admin') || roles.includes('mgmt');
+      const currentUserId = req.user?.userId;
+      if (!isPrivileged) {
+        if (!currentUserId) {
+          return reply.code(403).send({ error: 'forbidden' });
+        }
+        body.userId = currentUserId;
+      }
       const entryDate = parseDateParam(body.entryDate);
       if (!entryDate) {
         return reply.status(400).send({


### PR DESCRIPTION
## 概要
- userロールのPOSTで userId を自己に固定し、なりすましを防止
- 日報の一覧は user ロールの場合に自分のみ取得

## 変更点
- time_entries / expenses / daily_reports / wellbeing_entries / leave_requests のPOSTで、admin/mgmt以外は `req.user.userId` を強制
- daily_reports のGETに userId フィルタを追加（admin/mgmt は任意指定可、user は自分のみ）

## 補足
- JWT利用時でも userId は `req.user.userId` に統一されます。
