### PR TITLE
Restrict time entry patch to owner

### DIFF
--- a/packages/backend/src/routes/timeEntries.ts
+++ b/packages/backend/src/routes/timeEntries.ts
@@ -142,9 +142,7 @@ export async function registerTimeEntryRoutes(app: FastifyInstance) {
       const roles = req.user?.roles || [];
       const isPrivileged = roles.includes('admin') || roles.includes('mgmt');
       const userId = req.user?.userId;
-      const where = isPrivileged
-        ? { id }
-        : { id, userId: userId || 'unknown' };
+      const where = isPrivileged ? { id } : { id, userId: userId || 'unknown' };
       const before = await prisma.timeEntry.findFirst({ where });
       if (!before) {
         return reply.code(404).send({ error: 'not_found' });


### PR DESCRIPTION
## 概要
- time_entries のPATCHで、userは自分のエントリのみ更新可能にする

## 変更点
- 非特権ユーザの場合、`before.userId` と `req.user.userId` を照合
- 所属projectIds外のエントリ更新は拒否
- 非特権ユーザは `userId` の変更を無効化（強制的に自分に固定）
