### PR TITLE
Scope leave request list to current user

### DIFF
--- a/packages/backend/src/routes/leave.ts
+++ b/packages/backend/src/routes/leave.ts
@@ -75,6 +75,9 @@ export async function registerLeaveRoutes(app: FastifyInstance) {
       const where: { userId?: string } = {};
       if (!isPrivileged) {
         if (!currentUserId) {
+          return reply.code(401).send({ error: 'unauthorized' });
+        }
+        if (userId && userId !== currentUserId) {
           return reply.code(403).send({ error: 'forbidden' });
         }
         where.userId = currentUserId;


### PR DESCRIPTION
## 概要
- leave_requests の一覧取得を user ロールの場合は本人のみに制限

## 変更点
- `/leave-requests` を `requireRole(['admin','mgmt','user'])` に変更
- 非特権ユーザは `req.user.userId` を強制し、userId queryは無視
- admin/mgmt は任意 userId でフィルタ可能
