### PR TITLE
Refactor: reuse CSV utils

### DIFF
--- a/packages/backend/src/routes/reportSubscriptions.ts
+++ b/packages/backend/src/routes/reportSubscriptions.ts
@@ -19,6 +19,7 @@ import {
 } from '../services/pdf.js';
 import { sendEmail } from '../services/notifier.js';
 import { requireRole } from '../services/rbac.js';
+import { toCsv } from '../utils/csv.js';
 import { parseDateParam } from '../utils/date.js';
 import {
   reportSubscriptionPatchSchema,
@@ -248,23 +249,6 @@ function normalizeFormat(value: string | null): 'csv' | 'pdf' {
   if (!value) return 'csv';
   if (value === 'csv' || value === 'pdf') return value;
   throw new ReportParamError('INVALID_FORMAT', 'format must be csv or pdf');
-}
-
-function formatCsvValue(value: unknown) {
-  if (value == null) return '';
-  const text = String(value);
-  if (/[",\n\r]/.test(text)) {
-    return `"${text.replace(/"/g, '""')}"`;
-  }
-  return text;
-}
-
-function toCsv(headers: string[], rows: unknown[][]) {
-  const lines = [headers.map(formatCsvValue).join(',')];
-  for (const row of rows) {
-    lines.push(row.map(formatCsvValue).join(','));
-  }
-  return `${lines.join('\n')}\n`;
 }
 
 async function writeReportFile(filename: string, content: string) {

--- a/packages/backend/src/routes/reports.ts
+++ b/packages/backend/src/routes/reports.ts
@@ -11,6 +11,7 @@ import {
 import { generatePdf } from '../services/pdf.js';
 import { requireRole } from '../services/rbac.js';
 import { parseDateParam } from '../utils/date.js';
+import { sendCsv, toCsv } from '../utils/csv.js';
 
 function validateFormat(format: string | undefined, reply: any) {
   if (!format) return true;
@@ -21,30 +22,6 @@ function validateFormat(format: string | undefined, reply: any) {
     return false;
   }
   return true;
-}
-
-function formatCsvValue(value: unknown) {
-  if (value == null) return '';
-  const text = String(value);
-  if (/[",\n\r]/.test(text)) {
-    return `"${text.replace(/"/g, '""')}"`;
-  }
-  return text;
-}
-
-function toCsv(headers: string[], rows: unknown[][]) {
-  const lines = [headers.map(formatCsvValue).join(',')];
-  for (const row of rows) {
-    lines.push(row.map(formatCsvValue).join(','));
-  }
-  return `${lines.join('\n')}\n`;
-}
-
-function sendCsv(reply: any, filename: string, csv: string) {
-  return reply
-    .header('Content-Disposition', `attachment; filename="${filename}"`)
-    .type('text/csv; charset=utf-8')
-    .send(csv);
 }
 
 function buildTemplateId(reportName: string, layout?: string) {


### PR DESCRIPTION
## 概要
CSV生成処理を共通ユーティリティに寄せ、重複を削減しました。

## 対応内容
- reports/reportSubscriptions のCSV生成を utils/csv.ts に統合
- 既存のCSV出力互換性は維持

## 関連
- #345
