### PR TITLE
Optimize member candidate search query

### DIFF
--- a/packages/backend/src/routes/projects.ts
+++ b/packages/backend/src/routes/projects.ts
@@ -245,11 +245,11 @@ export async function registerProjectRoutes(app: FastifyInstance) {
         FROM "UserAccount" AS ua
         WHERE ua."active" = true
           AND (
-            ua."userName" ILIKE ${likePattern}
-            OR ua."displayName" ILIKE ${likePattern}
-            OR ua."givenName" ILIKE ${likePattern}
-            OR ua."familyName" ILIKE ${likePattern}
-            OR ua."department" ILIKE ${likePattern}
+            ua."userName" ILIKE ${likePattern} ESCAPE '\\'
+            OR ua."displayName" ILIKE ${likePattern} ESCAPE '\\'
+            OR ua."givenName" ILIKE ${likePattern} ESCAPE '\\'
+            OR ua."familyName" ILIKE ${likePattern} ESCAPE '\\'
+            OR ua."department" ILIKE ${likePattern} ESCAPE '\\'
           )
           AND NOT EXISTS (
             SELECT 1


### PR DESCRIPTION
## 概要
- member-candidates の検索を NOT EXISTS の1クエリに置換
- 検索語の長さ上限（64）とワイルドカードのエスケープを追加

## 動作確認
- 未実施（必要なら実施します）