### PR TITLE
Add project member E2E coverage

### DIFF
--- a/scripts/seed-demo.sql
+++ b/scripts/seed-demo.sql
@@ -13,6 +13,11 @@ insert into "Customer" (id, code, name, status, "createdAt", "updatedAt") values
   ('00000000-0000-0000-0000-000000000020','CUST-DEMO-1','Demo Customer 1','active', now(), now())
 on conflict do nothing;
 
+insert into "UserAccount" (id, "userName", "displayName", "givenName", "familyName", department, active, "createdAt", "updatedAt") values
+  ('90000000-0000-0000-0000-000000000001','e2e-member-1@example.com','E2E Member 1','E2E','Member 1','Engineering', true, now(), now()),
+  ('90000000-0000-0000-0000-000000000002','e2e-member-2@example.com','E2E Member 2','E2E','Member 2','Sales', true, now(), now())
+on conflict do nothing;
+
 insert into "ApprovalRule" (id, "flowType", conditions, steps, "createdAt", "updatedAt") values
   ('50000000-0000-0000-0000-000000000001','estimate','{}','[]', now(), now()),
   ('50000000-0000-0000-0000-000000000002','invoice','{}','[]', now(), now()),


### PR DESCRIPTION
## 概要
- E2Eで案件メンバー管理（候補検索/追加/CSVインポート/エクスポート）を検証
- seed に候補検索用の UserAccount を追加

## 動作確認
- 未実施（必要なら実施します）