### PR TITLE
Record backup/restore test results (2026-01-08)

### DIFF
--- a/docs/test-results/2026-01-08-backup-restore.md
+++ b/docs/test-results/2026-01-08-backup-restore.md
@@ -1,0 +1,27 @@
+# テスト結果 2026-01-08 バックアップ/リストア
+
+## 実行日時
+- 2026-01-08
+
+## 実行方法
+- 対象コンテナ: `erp4-pg-backup-20260108`（`HOST_PORT=55434`）
+- バックアップ先: `tmp/erp4-backups-20260108`
+- 実行コマンド:
+  - `CONTAINER_NAME=erp4-pg-backup-20260108 HOST_PORT=55434 scripts/podman-poc.sh db-push`
+  - `CONTAINER_NAME=erp4-pg-backup-20260108 HOST_PORT=55434 scripts/podman-poc.sh seed`
+  - `CONTAINER_NAME=erp4-pg-backup-20260108 HOST_PORT=55434 scripts/podman-poc.sh check`
+  - `CONTAINER_NAME=erp4-pg-backup-20260108 HOST_PORT=55434 BACKUP_DIR=tmp/erp4-backups-20260108 scripts/podman-poc.sh backup`
+  - `CONTAINER_NAME=erp4-pg-backup-20260108 HOST_PORT=55434 BACKUP_DIR=tmp/erp4-backups-20260108 BACKUP_GLOBALS_FILE=/dev/null RESTORE_CONFIRM=1 scripts/podman-poc.sh restore`
+  - `CONTAINER_NAME=erp4-pg-backup-20260108 HOST_PORT=55434 scripts/podman-poc.sh check`
+
+## 結果
+- バックアップ: 成功
+- リストア: 成功（fresh container + globalsスキップで実施）
+- 整合チェック: 成功
+
+## 補足
+- globals には `postgres` ロール作成が含まれるため、既存ロールがある環境では restore が失敗する。
+- 既存スキーマがある状態で restore すると型の重複で失敗するため、クリーンなDBで実施する。
+
+## ログ
+- `tmp/backup-restore-2026-01-08.txt`

--- a/docs/test-results/README.md
+++ b/docs/test-results/README.md
@@ -6,6 +6,7 @@
 
 ## 一覧
 ### 2026-01-08
+- バックアップ/リストア: docs/test-results/2026-01-08-backup-restore.md
 - バックエンドスモーク: docs/test-results/2026-01-08-backend-smoke.md
 - フロントE2E(フルスコープ): docs/test-results/2026-01-08-frontend-e2e.md
 - 証跡: docs/test-results/2026-01-08-frontend-e2e/


### PR DESCRIPTION
## Summary
- Add backup/restore test result for 2026-01-08
- Update test results index

## Testing
- CONTAINER_NAME=erp4-pg-backup-20260108 HOST_PORT=55434 scripts/podman-poc.sh db-push
- CONTAINER_NAME=erp4-pg-backup-20260108 HOST_PORT=55434 scripts/podman-poc.sh seed
- CONTAINER_NAME=erp4-pg-backup-20260108 HOST_PORT=55434 scripts/podman-poc.sh check
- CONTAINER_NAME=erp4-pg-backup-20260108 HOST_PORT=55434 BACKUP_DIR=tmp/erp4-backups-20260108 scripts/podman-poc.sh backup
- CONTAINER_NAME=erp4-pg-backup-20260108 HOST_PORT=55434 BACKUP_DIR=tmp/erp4-backups-20260108 BACKUP_GLOBALS_FILE=/dev/null RESTORE_CONFIRM=1 scripts/podman-poc.sh restore
- CONTAINER_NAME=erp4-pg-backup-20260108 HOST_PORT=55434 scripts/podman-poc.sh check
