### PR TITLE
chat: ChatRoom/ChatRoomMember を追加 (#464)

### DIFF
--- a/packages/backend/prisma/migrations/20260111110000_add_chat_rooms/migration.sql
+++ b/packages/backend/prisma/migrations/20260111110000_add_chat_rooms/migration.sql
@@ -1,0 +1,63 @@
+-- CreateTable
+CREATE TABLE "ChatRoom" (
+    "id" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "isOfficial" BOOLEAN NOT NULL DEFAULT true,
+    "projectId" TEXT,
+    "groupId" TEXT,
+    "allowExternalUsers" BOOLEAN NOT NULL DEFAULT false,
+    "allowExternalIntegrations" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdBy" TEXT,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "updatedBy" TEXT,
+    "deletedAt" TIMESTAMP(3),
+    "deletedReason" TEXT,
+
+    CONSTRAINT "ChatRoom_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ChatRoomMember" (
+    "id" TEXT NOT NULL,
+    "roomId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'member',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdBy" TEXT,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "updatedBy" TEXT,
+    "deletedAt" TIMESTAMP(3),
+    "deletedReason" TEXT,
+
+    CONSTRAINT "ChatRoomMember_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChatRoom_type_projectId_key" ON "ChatRoom"("type", "projectId");
+
+-- CreateIndex
+CREATE INDEX "ChatRoom_type_createdAt_idx" ON "ChatRoom"("type", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ChatRoom_projectId_createdAt_idx" ON "ChatRoom"("projectId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ChatRoom_deletedAt_idx" ON "ChatRoom"("deletedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChatRoomMember_roomId_userId_key" ON "ChatRoomMember"("roomId", "userId");
+
+-- CreateIndex
+CREATE INDEX "ChatRoomMember_userId_idx" ON "ChatRoomMember"("userId");
+
+-- CreateIndex
+CREATE INDEX "ChatRoomMember_roomId_idx" ON "ChatRoomMember"("roomId");
+
+-- AddForeignKey
+ALTER TABLE "ChatRoom" ADD CONSTRAINT "ChatRoom_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ChatRoomMember" ADD CONSTRAINT "ChatRoomMember_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "ChatRoom"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -171,6 +171,7 @@ model Project {
   chatAckRequests         ProjectChatAckRequest[]
   chatReadStates          ProjectChatReadState[]
   notifications           AppNotification[]
+  chatRooms               ChatRoom[]
   estimates               Estimate[]
   invoices                Invoice[]
   timeEntries             TimeEntry[]
@@ -339,6 +340,48 @@ model AppNotification {
   @@index([userId, readAt, createdAt])
   @@index([projectId])
   @@index([kind, createdAt])
+}
+
+model ChatRoom {
+  id                        String           @id @default(uuid())
+  type                      String // project/department/company/private_group/dm
+  name                      String
+  isOfficial                Boolean          @default(true)
+  project                   Project?         @relation(fields: [projectId], references: [id], onDelete: Restrict)
+  projectId                 String?
+  groupId                   String?
+  allowExternalUsers        Boolean          @default(false)
+  allowExternalIntegrations Boolean          @default(false)
+  createdAt                 DateTime         @default(now())
+  createdBy                 String?
+  updatedAt                 DateTime         @updatedAt
+  updatedBy                 String?
+  deletedAt                 DateTime?
+  deletedReason             String?
+  members                   ChatRoomMember[]
+
+  @@unique([type, projectId])
+  @@index([type, createdAt])
+  @@index([projectId, createdAt])
+  @@index([deletedAt])
+}
+
+model ChatRoomMember {
+  id            String    @id @default(uuid())
+  room          ChatRoom  @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  roomId        String
+  userId        String
+  role          String    @default("member")
+  createdAt     DateTime  @default(now())
+  createdBy     String?
+  updatedAt     DateTime  @updatedAt
+  updatedBy     String?
+  deletedAt     DateTime?
+  deletedReason String?
+
+  @@unique([roomId, userId])
+  @@index([userId])
+  @@index([roomId])
 }
 
 model ChatBreakGlassRequest {


### PR DESCRIPTION
目的
- room-based chat の土台として ChatRoom/ChatRoomMember をDBに追加し、projectルームを先行して生成できるようにする。

変更内容
- Prisma/DB: `ChatRoom` / `ChatRoomMember` を追加（migration含む）
- Project作成時に projectルームを自動作成（type=project, name=project.code）

注意
- 既存の project chat（ProjectChatMessage系）は変更なし
- 既存projectの backfill は #465（/chat-rooms実装側）で on-demand 生成予定

Issue
- #464
