### PR TITLE
chat: /chat-rooms 一覧APIを追加 (#465)

### DIFF
--- a/packages/backend/src/routes/chatRooms.ts
+++ b/packages/backend/src/routes/chatRooms.ts
@@ -1,0 +1,143 @@
+import { FastifyInstance } from 'fastify';
+import { prisma } from '../services/db.js';
+import { requireRole } from '../services/rbac.js';
+
+export async function registerChatRoomRoutes(app: FastifyInstance) {
+  const chatRoles = ['admin', 'mgmt', 'user', 'hr', 'exec', 'external_chat'];
+
+  app.get(
+    '/chat-rooms',
+    { preHandler: requireRole(chatRoles) },
+    async (req) => {
+      const roles = req.user?.roles || [];
+      const userId = req.user?.userId;
+      const projectIds = req.user?.projectIds || [];
+      const canSeeAllProjects =
+        roles.includes('admin') || roles.includes('mgmt');
+
+      if (!canSeeAllProjects && projectIds.length === 0) {
+        return { items: [] };
+      }
+
+      const projects = await prisma.project.findMany({
+        where: canSeeAllProjects
+          ? { deletedAt: null }
+          : { id: { in: projectIds }, deletedAt: null },
+        orderBy: { createdAt: 'desc' },
+        take: 200,
+        select: {
+          id: true,
+          code: true,
+          name: true,
+          createdAt: true,
+        },
+      });
+
+      const targetProjectIds = projects.map((project) => project.id);
+      if (targetProjectIds.length === 0) {
+        return { items: [] };
+      }
+
+      const existing = await prisma.chatRoom.findMany({
+        where: {
+          type: 'project',
+          projectId: { in: targetProjectIds },
+          deletedAt: null,
+        },
+        select: {
+          id: true,
+          type: true,
+          name: true,
+          isOfficial: true,
+          projectId: true,
+          groupId: true,
+          allowExternalUsers: true,
+          allowExternalIntegrations: true,
+          createdAt: true,
+          createdBy: true,
+          updatedAt: true,
+          updatedBy: true,
+        },
+      });
+
+      const existingByProject = new Map(
+        existing
+          .filter(
+            (room) => typeof room.projectId === 'string' && room.projectId,
+          )
+          .map((room) => [room.projectId as string, room]),
+      );
+      const missingProjects = projects.filter(
+        (project) => !existingByProject.has(project.id),
+      );
+
+      if (missingProjects.length > 0) {
+        await prisma.chatRoom.createMany({
+          data: missingProjects.map((project) => ({
+            type: 'project',
+            name: project.code,
+            isOfficial: true,
+            projectId: project.id,
+            createdBy: userId || null,
+          })),
+          skipDuplicates: true,
+        });
+      }
+
+      const rooms = await prisma.chatRoom.findMany({
+        where: {
+          type: 'project',
+          projectId: { in: targetProjectIds },
+          deletedAt: null,
+        },
+        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true,
+          type: true,
+          name: true,
+          isOfficial: true,
+          projectId: true,
+          groupId: true,
+          allowExternalUsers: true,
+          allowExternalIntegrations: true,
+          createdAt: true,
+          createdBy: true,
+          updatedAt: true,
+          updatedBy: true,
+        },
+      });
+
+      const projectMap = new Map(
+        projects.map((project) => [
+          project.id,
+          { code: project.code, name: project.name },
+        ]),
+      );
+
+      const items = rooms
+        .map((room) => {
+          const projectId = room.projectId || null;
+          const project = projectId ? projectMap.get(projectId) : undefined;
+          return {
+            id: room.id,
+            type: room.type,
+            name: room.name,
+            isOfficial: room.isOfficial,
+            projectId,
+            projectCode: project?.code || null,
+            projectName: project?.name || null,
+            groupId: room.groupId || null,
+            allowExternalUsers: room.allowExternalUsers,
+            allowExternalIntegrations: room.allowExternalIntegrations,
+            createdAt: room.createdAt,
+            createdBy: room.createdBy || null,
+            updatedAt: room.updatedAt,
+            updatedBy: room.updatedBy || null,
+          };
+        })
+        .filter((item) => item.projectId);
+
+      return { items };
+    },
+  );
+}

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -28,6 +28,7 @@ import { registerPdfTemplateRoutes } from './pdfTemplates.js';
 import { registerTemplateSettingRoutes } from './templateSettings.js';
 import { registerChatRoutes } from './chat.js';
 import { registerChatBreakGlassRoutes } from './chatBreakGlass.js';
+import { registerChatRoomRoutes } from './chatRooms.js';
 import { registerPdfFileRoutes } from './pdfFiles.js';
 import { registerSendEventRoutes } from './sendEvents.js';
 import { registerScimRoutes } from './scim.js';
@@ -60,6 +61,7 @@ export async function registerRoutes(app: FastifyInstance) {
   await registerWellbeingRoutes(app);
   await registerChatRoutes(app);
   await registerChatBreakGlassRoutes(app);
+  await registerChatRoomRoutes(app);
   await registerProjectRoutes(app);
   await registerCustomerRoutes(app);
   await registerVendorRoutes(app);


### PR DESCRIPTION
目的
- room-based chat の最小APIとして、参加/参照可能なルーム一覧を取得できるようにする（projectルーム先行）。

変更内容
- backend: `GET /chat-rooms`
  - admin/mgmt: 全projectを対象に projectルームを返す
  - user/hr/exec: projectIds に含まれるprojectの projectルームを返す
  - 既存project向けに、roomが無い場合は on-demand で作成（type=project）

Issue
- #465
