### PR TITLE
チャット: ProjectChatの案件選択を/chat-roomsへ切替（projectルーム先行）

### DIFF
--- a/docs/plan/todo.md
+++ b/docs/plan/todo.md
@@ -9,6 +9,7 @@
   - [x] 仕様/方針ドキュメント（案）の追加（`docs/requirements/chat-rooms.md`）
   - [x] #464 ChatRoom/ChatRoomMember のDB追加（projectルーム先行）
   - [x] #465 ルーム一覧API（projectルーム先行）
+  - [x] #469 ProjectChat の案件選択を /chat-rooms へ切替（projectルーム先行）
   - [ ] 互換維持の移行ステップ（Step 1〜5）の確定
 - [ ] #434 ガバナンス（公式/私的/DM）と監査break-glassの設計を確定
 - [x] #454 break-glass（申請/二重承認/閲覧許可/監査ログ）を実装

--- a/packages/frontend/src/hooks/useChatRooms.ts
+++ b/packages/frontend/src/hooks/useChatRooms.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useState } from 'react';
+import { api } from '../api';
+
+export type ChatRoomOption = {
+  id: string;
+  type: string;
+  name: string;
+  projectId?: string | null;
+  projectCode?: string | null;
+  projectName?: string | null;
+};
+
+type UseChatRoomsOptions = {
+  selectedProjectId: string;
+  onSelect: (projectId: string) => void;
+};
+
+export const useChatRooms = ({
+  selectedProjectId,
+  onSelect,
+}: UseChatRoomsOptions) => {
+  const [rooms, setRooms] = useState<ChatRoomOption[]>([]);
+  const [roomMessage, setRoomMessage] = useState('');
+
+  const loadRooms = useCallback(async () => {
+    try {
+      const res = await api<{ items: ChatRoomOption[] }>('/chat-rooms');
+      const items = Array.isArray(res.items) ? res.items : [];
+      const projectRooms = items.filter(
+        (room) =>
+          room.type === 'project' &&
+          typeof room.projectId === 'string' &&
+          room.projectId.trim() !== '',
+      );
+      setRooms(projectRooms);
+      setRoomMessage('');
+    } catch (err) {
+      console.error('Failed to load chat rooms.', err);
+      setRooms([]);
+      setRoomMessage('ルーム一覧の取得に失敗しました');
+    }
+  }, []);
+
+  useEffect(() => {
+    loadRooms().catch(() => undefined);
+  }, [loadRooms]);
+
+  useEffect(() => {
+    if (rooms.length === 0) return;
+    if (rooms.some((room) => room.projectId === selectedProjectId)) {
+      return;
+    }
+    const firstProjectId = rooms[0]?.projectId;
+    if (firstProjectId) {
+      onSelect(firstProjectId);
+    }
+  }, [rooms, selectedProjectId, onSelect]);
+
+  return { rooms, roomMessage, loadRooms };
+};

--- a/packages/frontend/src/sections/ProjectChat.tsx
+++ b/packages/frontend/src/sections/ProjectChat.tsx
@@ -3,7 +3,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import { api, apiResponse, getAuthState } from '../api';
-import { useProjects } from '../hooks/useProjects';
+import { useChatRooms } from '../hooks/useChatRooms';
 
 type ChatMessage = {
   id: string;
@@ -147,7 +147,7 @@ export const ProjectChat: React.FC = () => {
   const auth = getAuthState();
   const defaultProjectId = auth?.projectIds?.[0] || 'demo-project';
   const [projectId, setProjectId] = useState(defaultProjectId);
-  const { projects, projectMessage } = useProjects({
+  const { rooms, roomMessage } = useChatRooms({
     selectedProjectId: projectId,
     onSelect: setProjectId,
   });
@@ -595,9 +595,13 @@ export const ProjectChat: React.FC = () => {
           onChange={(e) => setProjectId(e.target.value)}
         >
           <option value="">案件を選択</option>
-          {projects.map((project) => (
-            <option key={project.id} value={project.id}>
-              {project.code} / {project.name}
+          {rooms.map((room) => (
+            <option key={room.id} value={room.projectId || ''}>
+              {(() => {
+                const code = (room.projectCode || room.name || '').trim();
+                const name = (room.projectName || '').trim();
+                return name ? `${code} / ${name}` : code;
+              })()}
             </option>
           ))}
         </select>
@@ -629,7 +633,7 @@ export const ProjectChat: React.FC = () => {
           タグを変更した後は「読み込み」ボタンを押して絞り込みを適用します。
         </small>
       </div>
-      {projectMessage && <p style={{ color: '#dc2626' }}>{projectMessage}</p>}
+      {roomMessage && <p style={{ color: '#dc2626' }}>{roomMessage}</p>}
       {breakGlassEvents.length > 0 && (
         <div
           style={{


### PR DESCRIPTION
ProjectChat の案件選択を `/chat-rooms` から取得する project ルーム（ChatRoom）ベースに切り替えました。

- 対応内容
  - `useChatRooms` を追加し、ProjectChat の案件セレクトを project ルーム一覧に変更（互換のため projectId は継続利用）
  - Podman E2E のDB状態が揺れないように、`scripts/e2e-frontend.sh` を「専用コンテナ/ポート + デフォルトでリセット」へ変更
  - `docs/plan/todo.md` に #469 完了を反映

- 動作確認
  - `E2E_CAPTURE=0 E2E_SCOPE=extended ./scripts/e2e-frontend.sh`
  - `npm run lint --prefix packages/frontend`

- 補足
  - Podman E2E はデフォルトで `erp4-pg-e2e` / `55433` を使用します（既存の `erp4-pg-poc` を壊さない想定）。

Closes #469
