### PR TITLE
チャット: projectルームIDをprojectIdに固定

### DIFF
--- a/docs/plan/todo.md
+++ b/docs/plan/todo.md
@@ -10,6 +10,8 @@
   - [x] #464 ChatRoom/ChatRoomMember のDB追加（projectルーム先行）
   - [x] #465 ルーム一覧API（projectルーム先行）
   - [x] #469 ProjectChat の案件選択を /chat-rooms へ切替（projectルーム先行）
+  - [ ] #471 projectルームIDをprojectIdに固定（roomId=projectId）
+  - [ ] #472 room-based messageテーブル導入とproject chat API移行（Step 3）
   - [ ] 互換維持の移行ステップ（Step 1〜5）の確定
 - [ ] #434 ガバナンス（公式/私的/DM）と監査break-glassの設計を確定
 - [x] #454 break-glass（申請/二重承認/閲覧許可/監査ログ）を実装

--- a/docs/requirements/chat-rooms.md
+++ b/docs/requirements/chat-rooms.md
@@ -62,6 +62,7 @@ DB上は `type` として表現し、ポリシー（公式/私的、外部連携
   - 既存の「確認メッセージ」（OK追跡）と同等
 
 補足
+- projectルーム（`type=project`）は **`roomId = projectId`** として扱う（`ChatRoom.id = Project.id`）。
 - 監査/改ざん検知・論理削除方針は `docs/requirements/project-chat.md` の方針を踏襲します。
 - break-glass 用のテーブルは別（#454）で設計/実装しますが、参照先は `roomId` とします。
 
@@ -108,4 +109,3 @@ DB上は `type` として表現し、ポリシー（公式/私的、外部連携
 - 公式ルームの作成/管理権限（project leader の範囲）
 - projectルームのメンバー同期（ProjectMemberの自動同期 vs room member の別管理）
 - break-glass の cooldown（MVPは0想定）
-

--- a/packages/backend/prisma/migrations/20260112002000_fix_project_room_ids/migration.sql
+++ b/packages/backend/prisma/migrations/20260112002000_fix_project_room_ids/migration.sql
@@ -1,0 +1,9 @@
+-- Normalize project rooms to deterministic ids (roomId = projectId).
+-- This simplifies future migrations and keeps project chat APIs stable.
+
+UPDATE "ChatRoom"
+SET "id" = "projectId"
+WHERE "type" = 'project'
+  AND "projectId" IS NOT NULL
+  AND "id" <> "projectId";
+

--- a/packages/backend/src/routes/chatRooms.ts
+++ b/packages/backend/src/routes/chatRooms.ts
@@ -74,6 +74,7 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
       if (missingProjects.length > 0) {
         await prisma.chatRoom.createMany({
           data: missingProjects.map((project) => ({
+            id: project.id,
             type: 'project',
             name: project.code,
             isOfficial: true,

--- a/packages/backend/src/routes/projects.ts
+++ b/packages/backend/src/routes/projects.ts
@@ -176,6 +176,7 @@ export async function registerProjectRoutes(app: FastifyInstance) {
         });
         await tx.chatRoom.create({
           data: {
+            id: created.id,
             type: 'project',
             name: created.code,
             isOfficial: true,


### PR DESCRIPTION
projectルーム（ChatRoom.type=project）のIDを `projectId` に固定し、roomId=projectId を前提にできるようにします。

- 対応内容
  - `/projects` 作成時の projectルーム生成で `ChatRoom.id=projectId`
  - `/chat-rooms` のon-demand生成でも `ChatRoom.id=projectId`
  - 既存の projectルームを `id=projectId` に揃える migration を追加
  - docs更新（`docs/requirements/chat-rooms.md` / `docs/plan/todo.md`）

Closes #471
