### PR TITLE
chore(chat): 旧ProjectChat*テーブル廃止 (Step 5)

### DIFF
--- a/docs/plan/todo.md
+++ b/docs/plan/todo.md
@@ -12,10 +12,10 @@
   - [x] #469 ProjectChat の案件選択を /chat-rooms へ切替（projectルーム先行）
   - [x] #471 projectルームIDをprojectIdに固定（roomId=projectId）
 - [x] #472 room-based messageテーブル導入とproject chat API移行（Step 3）
-  - [ ] #475 旧ProjectChat*テーブルの凍結/廃止（Step 5）
+  - [x] #475 旧ProjectChat*テーブルの凍結/廃止（Step 5）
   - [x] 互換維持の移行ステップ（Step 1〜5）の確定
 - [ ] #434 ガバナンス（公式/私的/DM）と監査break-glassの設計を確定
-  - [ ] #477 break-glass を room target に対応
+  - [x] #477 break-glass を room target に対応
 - [x] #454 break-glass（申請/二重承認/閲覧許可/監査ログ）を実装
 - [x] #455 break-glass UI（申請/承認/履歴）+ システムメッセージ
 - [ ] #445 AI支援（要約/アクション抽出/FAQ/検索支援）のMVP方針決定

--- a/docs/requirements/chat-rooms.md
+++ b/docs/requirements/chat-rooms.md
@@ -85,7 +85,7 @@ DB上は `type` として表現し、ポリシー（公式/私的、外部連携
 2) **Step 2: room API を追加（既存project chatは維持）【部分完了】**
    - `GET /chat-rooms`（一覧）（#465）
    - ProjectChat の案件選択を room一覧に切替（#469）
-   - ルーム作成/招待/DM は #434 の設計確定後に実装
+   - private_group/DM の作成/招待/room chat API（#479）
 
 3) **Step 3: project chat API を room に寄せる（互換を維持）【完了】**
    - 既存の `/projects/:projectId/chat-*` は `Chat*`（room-based）参照へ移行（#472）
@@ -95,15 +95,15 @@ DB上は `type` として表現し、ポリシー（公式/私的、外部連携
    - migration `20260112003555_add_chat_room_messages` で `ProjectChat*` → `Chat*` をコピー
    - `prisma migrate deploy` を使う環境で適用される（`prisma db push` はデータ移行を含まない）
 
-5) **Step 5: 旧ProjectChat* テーブルを凍結 → 廃止【残】**
-   - #475 で扱う（件数一致チェック、削除タイミング、最終削除のmigration）
+5) **Step 5: 旧ProjectChat* テーブルを凍結 → 廃止【完了】**
+   - 移行検証SQL: `scripts/checks/chat-migration-step5.sql`
+   - 削除migration: `20260112030000_drop_legacy_project_chat`（不整合がある場合は失敗する）
 
 ## 既存仕様との整合
 - メンション/未読/確認メッセージ/添付/通知/AI要約は「Room単位」で提供する想定です。
 - 既存の ProjectChat UI は「projectルームのフロント」として継続し、room UI（一覧/作成）は別画面として追加します。
 
 ## 未決定（後続で確定）
-- DMを許可するか（許可する場合も私的ルームとして同一ポリシー）
 - 公式ルームの作成/管理権限（project leader の範囲）
 - projectルームのメンバー同期（ProjectMemberの自動同期 vs room member の別管理）
 - break-glass の cooldown（MVPは0想定）

--- a/docs/requirements/project-chat.md
+++ b/docs/requirements/project-chat.md
@@ -7,6 +7,7 @@
 
 ## 現状（実装済み）
 - プロジェクト単位の簡易グループチャット（room-based: `ChatRoom(type=project)` + `ChatMessage`）
+- private_group/DM（room-based: `ChatRoom(type=private_group/dm)` + `ChatMessage`）
 - 投稿/閲覧/タグ/リアクション/ページング
 - メンション（ユーザ/グループ/@all）+ @all の投稿制限
 - 未読/既読（自分のみ）
@@ -16,8 +17,7 @@
 - 手動要約スタブ（UI）
 
 ## 未実装（後続）
-- ルーム種別拡張（project以外: 部門/全社/私的/DM）とガバナンス実装（#434）
-- 旧ProjectChat*テーブルの凍結/廃止（Step 5、#475）
+- ルーム種別拡張（部門/全社）とガバナンス実装（#434）
 - ガバナンス（公式/私的）と break-glass（#434/#454/#455）
 - 検索（チャットのみ/ERP横断）とインデックス
 - 通知チャネルの拡張（メール/Push/外部連携）
@@ -176,55 +176,7 @@
 - 主テーブル: `ChatRoom` / `ChatMessage` / `ChatAttachment` / `ChatReadState` / `ChatAckRequest` / `ChatAck`
 - break-glass: `ChatBreakGlassRequest` / `ChatBreakGlassAccessLog`
 - projectルームは `roomId = projectId`（`ChatRoom.id = Project.id`）
-
-以下の ProjectChat* は **legacy** です（Step 5で凍結/廃止、#475）。
-
-### ProjectChatMessage（legacy）
-- `id`: UUID
-- `projectId`: 参照先 `Project`
-- `userId`: 投稿者のID
-- `body`: メッセージ本文
-- `tags`: JSON配列（文字列のタグ一覧）
-- `reactions`: JSONマップ（emoji -> { count, userIds[] }）
-- `ackRequest`: 確認依頼（任意、特別メッセージ）
-- `createdAt/createdBy`, `updatedAt/updatedBy`
-- `deletedAt/deletedReason`（論理削除用、API未実装）
-
-### ProjectChatAckRequest（legacy: 確認依頼）
-- `id`: UUID
-- `messageId`: 参照先 `ProjectChatMessage`（1:1）
-- `projectId`: 参照先 `Project`（検索/一覧用途）
-- `requiredUserIds`: JSON配列（確認対象ユーザID、重複なしを想定）
-- `dueAt`: 任意（期限）
-- `createdAt/createdBy`
-
-### ProjectChatAck（legacy: 確認）
-- `id`: UUID
-- `requestId`: 参照先 `ProjectChatAckRequest`
-- `userId`: 確認したユーザID
-- `ackedAt`
-
-### ProjectChatAttachment（legacy: 添付）
-- `id`: UUID
-- `messageId`: 参照先 `ProjectChatMessage`
-- `provider`: `local` / `gdrive`
-- `providerKey`: 保存先側のキー（ローカルキー/Drive fileId 等）
-- `sha256`: 任意
-- `sizeBytes`: 任意
-- `mimeType`: 任意
-- `originalName`: 元のファイル名
-- `createdAt/createdBy`
-- `deletedAt/deletedReason`（論理削除用、API未実装）
-
-### ProjectChatReadState（legacy: 未読/既読：自分のみ）
-- `id`: UUID
-- `projectId`: 参照先 `Project`
-- `userId`: ユーザID
-- `lastReadAt`: 最終既読時刻（この時刻より新しい投稿を未読として数える）
-- `createdAt/updatedAt`
-
-### インデックス
-- `projectId, createdAt`
+- `ProjectChat*`（legacy）は Step 5 で削除済み（migration: `20260112030000_drop_legacy_project_chat`）
 
 ## データモデル（後続案）
 - ChatMention（メンションの正規化: `messageId`, `targetType`, `targetId`）

--- a/packages/backend/prisma/migrations/20260112030000_drop_legacy_project_chat/migration.sql
+++ b/packages/backend/prisma/migrations/20260112030000_drop_legacy_project_chat/migration.sql
@@ -1,0 +1,81 @@
+-- Drop legacy ProjectChat* tables after verifying data exists in Chat* tables.
+--
+-- This migration is intended as "Step 5" of chat room migration (see docs/requirements/chat-rooms.md).
+-- It is safe to run even if ProjectChat* tables do not exist (fresh installs).
+
+DO $$
+DECLARE
+  missing_messages bigint;
+  mismatched_room_ids bigint;
+  missing_ack_requests bigint;
+  missing_acks bigint;
+  missing_attachments bigint;
+  missing_read_states bigint;
+  mismatched_read_state_room_ids bigint;
+BEGIN
+  IF to_regclass('"ProjectChatMessage"') IS NOT NULL THEN
+    SELECT count(*) INTO missing_messages
+    FROM "ProjectChatMessage" legacy
+    LEFT JOIN "ChatMessage" chat ON chat.id = legacy.id
+    WHERE chat.id IS NULL;
+
+    SELECT count(*) INTO mismatched_room_ids
+    FROM "ProjectChatMessage" legacy
+    JOIN "ChatMessage" chat ON chat.id = legacy.id
+    WHERE chat."roomId" <> legacy."projectId";
+
+    SELECT count(*) INTO missing_ack_requests
+    FROM "ProjectChatAckRequest" legacy
+    LEFT JOIN "ChatAckRequest" chat ON chat.id = legacy.id
+    WHERE chat.id IS NULL;
+
+    SELECT count(*) INTO missing_acks
+    FROM "ProjectChatAck" legacy
+    LEFT JOIN "ChatAck" chat ON chat.id = legacy.id
+    WHERE chat.id IS NULL;
+
+    SELECT count(*) INTO missing_attachments
+    FROM "ProjectChatAttachment" legacy
+    LEFT JOIN "ChatAttachment" chat ON chat.id = legacy.id
+    WHERE chat.id IS NULL;
+
+    SELECT count(*) INTO missing_read_states
+    FROM "ProjectChatReadState" legacy
+    LEFT JOIN "ChatReadState" chat ON chat.id = legacy.id
+    WHERE chat.id IS NULL;
+
+    SELECT count(*) INTO mismatched_read_state_room_ids
+    FROM "ProjectChatReadState" legacy
+    JOIN "ChatReadState" chat ON chat.id = legacy.id
+    WHERE chat."roomId" <> legacy."projectId";
+
+    IF missing_messages > 0
+      OR mismatched_room_ids > 0
+      OR missing_ack_requests > 0
+      OR missing_acks > 0
+      OR missing_attachments > 0
+      OR missing_read_states > 0
+      OR mismatched_read_state_room_ids > 0
+    THEN
+      RAISE EXCEPTION USING
+        MESSAGE = format(
+          'Legacy chat data verification failed: missing_messages=%s mismatched_room_ids=%s missing_ack_requests=%s missing_acks=%s missing_attachments=%s missing_read_states=%s mismatched_read_state_room_ids=%s',
+          missing_messages,
+          mismatched_room_ids,
+          missing_ack_requests,
+          missing_acks,
+          missing_attachments,
+          missing_read_states,
+          mismatched_read_state_room_ids
+        ),
+        HINT = 'Run scripts/checks/chat-migration-step5.sql and confirm Step 4 migration (20260112003555_add_chat_room_messages) was applied before dropping legacy tables.';
+    END IF;
+  END IF;
+END $$;
+
+DROP TABLE IF EXISTS "ProjectChatAck";
+DROP TABLE IF EXISTS "ProjectChatAckRequest";
+DROP TABLE IF EXISTS "ProjectChatAttachment";
+DROP TABLE IF EXISTS "ProjectChatReadState";
+DROP TABLE IF EXISTS "ProjectChatMessage";
+

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -167,9 +167,6 @@ model Project {
   members                 ProjectMember[]
   tasks                   ProjectTask[]
   milestones              ProjectMilestone[]
-  chatMessages            ProjectChatMessage[]
-  chatAckRequests         ProjectChatAckRequest[]
-  chatReadStates          ProjectChatReadState[]
   notifications           AppNotification[]
   chatRooms               ChatRoom[]
   estimates               Estimate[]
@@ -237,89 +234,6 @@ model ProjectTask {
 
   @@index([projectId, deletedAt])
   @@index([parentTaskId, deletedAt])
-}
-
-model ProjectChatMessage {
-  id            String                  @id @default(uuid())
-  project       Project                 @relation(fields: [projectId], references: [id], onDelete: Restrict)
-  projectId     String
-  userId        String
-  body          String
-  tags          Json?
-  reactions     Json?
-  mentions      Json?
-  mentionsAll   Boolean                 @default(false)
-  ackRequest    ProjectChatAckRequest?
-  attachments   ProjectChatAttachment[]
-  createdAt     DateTime                @default(now())
-  createdBy     String?
-  updatedAt     DateTime                @updatedAt
-  updatedBy     String?
-  deletedAt     DateTime?
-  deletedReason String?
-
-  @@index([projectId, createdAt])
-  @@index([projectId, userId, mentionsAll, createdAt])
-}
-
-model ProjectChatAckRequest {
-  id              String             @id @default(uuid())
-  message         ProjectChatMessage @relation(fields: [messageId], references: [id], onDelete: Cascade)
-  messageId       String             @unique
-  project         Project            @relation(fields: [projectId], references: [id], onDelete: Restrict)
-  projectId       String
-  requiredUserIds Json
-  dueAt           DateTime?
-  createdAt       DateTime           @default(now())
-  createdBy       String?
-  acks            ProjectChatAck[]
-
-  @@index([projectId, createdAt])
-}
-
-model ProjectChatAck {
-  id        String                @id @default(uuid())
-  request   ProjectChatAckRequest @relation(fields: [requestId], references: [id], onDelete: Cascade)
-  requestId String
-  userId    String
-  ackedAt   DateTime              @default(now())
-
-  @@unique([requestId, userId])
-  @@index([userId])
-}
-
-model ProjectChatAttachment {
-  id            String             @id @default(uuid())
-  message       ProjectChatMessage @relation(fields: [messageId], references: [id], onDelete: Cascade)
-  messageId     String
-  provider      String
-  providerKey   String
-  sha256        String?
-  sizeBytes     Int?
-  mimeType      String?
-  originalName  String
-  createdAt     DateTime           @default(now())
-  createdBy     String?
-  deletedAt     DateTime?
-  deletedReason String?
-
-  @@unique([provider, providerKey])
-  @@index([messageId])
-  @@index([createdAt])
-}
-
-model ProjectChatReadState {
-  id         String   @id @default(uuid())
-  project    Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  projectId  String
-  userId     String
-  lastReadAt DateTime
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
-
-  @@unique([projectId, userId])
-  @@index([userId])
-  @@index([projectId])
 }
 
 model AppNotification {

--- a/scripts/checks/chat-migration-step5.sql
+++ b/scripts/checks/chat-migration-step5.sql
@@ -1,0 +1,74 @@
+-- Chat migration (Step 5) verification checks
+-- Purpose: Verify old ProjectChat* rows are present in Chat* tables before dropping legacy tables.
+--
+-- Usage:
+--   psql "$DATABASE_URL_PSQL" -v ON_ERROR_STOP=1 -f scripts/checks/chat-migration-step5.sql
+--
+-- Notes:
+-- - This script expects legacy tables (ProjectChat*) to still exist.
+-- - If you already applied the drop migration, this script will fail (tables not found).
+
+-- 1) Row counts (legacy vs new)
+select count(*) as legacy_project_chat_message_count from "ProjectChatMessage";
+select count(*) as legacy_project_chat_ack_request_count from "ProjectChatAckRequest";
+select count(*) as legacy_project_chat_ack_count from "ProjectChatAck";
+select count(*) as legacy_project_chat_attachment_count from "ProjectChatAttachment";
+select count(*) as legacy_project_chat_read_state_count from "ProjectChatReadState";
+
+select count(*) as chat_message_total_count from "ChatMessage";
+select count(*) as chat_ack_request_total_count from "ChatAckRequest";
+select count(*) as chat_ack_total_count from "ChatAck";
+select count(*) as chat_attachment_total_count from "ChatAttachment";
+select count(*) as chat_read_state_total_count from "ChatReadState";
+
+-- 2) Inclusion checks (legacy IDs must exist in new tables)
+select count(*) as missing_chat_messages
+from "ProjectChatMessage" legacy
+left join "ChatMessage" chat on chat.id = legacy.id
+where chat.id is null;
+
+select count(*) as mismatched_room_ids
+from "ProjectChatMessage" legacy
+join "ChatMessage" chat on chat.id = legacy.id
+where chat."roomId" <> legacy."projectId";
+
+select legacy."projectId", count(*) as missing_count
+from "ProjectChatMessage" legacy
+left join "ChatMessage" chat on chat.id = legacy.id
+where chat.id is null
+group by legacy."projectId"
+order by missing_count desc, legacy."projectId"
+limit 20;
+
+select count(*) as missing_chat_ack_requests
+from "ProjectChatAckRequest" legacy
+left join "ChatAckRequest" chat on chat.id = legacy.id
+where chat.id is null;
+
+select count(*) as missing_chat_acks
+from "ProjectChatAck" legacy
+left join "ChatAck" chat on chat.id = legacy.id
+where chat.id is null;
+
+select count(*) as missing_chat_attachments
+from "ProjectChatAttachment" legacy
+left join "ChatAttachment" chat on chat.id = legacy.id
+where chat.id is null;
+
+select count(*) as missing_chat_read_states
+from "ProjectChatReadState" legacy
+left join "ChatReadState" chat on chat.id = legacy.id
+where chat.id is null;
+
+select count(*) as mismatched_read_state_room_ids
+from "ProjectChatReadState" legacy
+join "ChatReadState" chat on chat.id = legacy.id
+where chat."roomId" <> legacy."projectId";
+
+-- 3) Freshness checks (legacy should not receive new writes after migration)
+select max("createdAt") as legacy_project_chat_message_max_created_at from "ProjectChatMessage";
+select max("createdAt") as chat_message_max_created_at from "ChatMessage";
+
+select max("updatedAt") as legacy_project_chat_read_state_max_updated_at from "ProjectChatReadState";
+select max("updatedAt") as chat_read_state_max_updated_at from "ChatReadState";
+


### PR DESCRIPTION
目的
- room-based chat への移行完了後に残っていた旧 ProjectChat* テーブルを「凍結→廃止（Step 5）」する
- 破壊的変更になるため、削除前に検証できるチェックと、移行不整合がある場合に失敗するガードを用意する

主な変更
- 検証SQLを追加
  - `scripts/checks/chat-migration-step5.sql`
  - 旧 ProjectChat* の各IDが Chat* 側に存在すること（欠落=0）を確認
- 旧テーブル削除migrationを追加
  - `packages/backend/prisma/migrations/20260112030000_drop_legacy_project_chat/migration.sql`
  - 旧テーブルが存在する場合のみ、欠落/不整合があると migration を失敗させる（誤削除防止）
  - その後 `ProjectChat*` を DROP
- Prismaスキーマから legacy モデルを除去
  - `ProjectChatMessage/Attachment/ReadState/Ack*` を削除
  - `Project` の legacy relation も削除
- ドキュメント更新
  - `docs/requirements/chat-rooms.md` / `docs/requirements/project-chat.md` / `docs/plan/todo.md`

テスト
- `packages/backend`: `npm run prisma:generate && npm run build && npm run lint && npm run format:check`
- `packages/frontend`: `npm run lint && npm run format:check`
- E2E（Podman）: `E2E_CAPTURE=0 E2E_SCOPE=extended E2E_SKIP_PLAYWRIGHT_INSTALL=1 ./scripts/e2e-frontend.sh`

Closes #475
