### PR TITLE
feat: email delivery job for chat mention notifications

### DIFF
--- a/docs/requirements/batch-jobs.md
+++ b/docs/requirements/batch-jobs.md
@@ -93,6 +93,17 @@ for setting in alert_settings where is_enabled:
 - 注意: report-subscriptions/run は都度 delivery を作るため、過剰実行に注意（重複配信防止は cron 設定で担保）。
 - 運用補助: `scripts/run-report-deliveries.sh`（DRY_RUN=1 で検証可能）
 
+## 通知（メール配信）ジョブ（MVP）
+- 対象: app_notifications / app_notification_deliveries。
+- `/jobs/notification-deliveries/run`: 未配信（pending/failed）の通知をメールで送る。
+  - 初期スコープ: `kind=chat_mention` のみ。
+  - 宛先: `userId` がメール形式ならそれを使う。そうでなければ `user_accounts.emails` の primary/先頭を使う。
+  - 既読の通知は `skipped (already_read)` として送信しない。
+  - 監査: 実行者/件数を audit_logs に記録。
+- リトライ: `status=failed` は `nextRetryAt` 以降に再送（指数バックオフ）。
+  - 設定: `NOTIFICATION_DELIVERY_RETRY_MAX`, `NOTIFICATION_DELIVERY_RETRY_BASE_MINUTES`, `NOTIFICATION_DELIVERY_RETRY_MAX_DELAY_MINUTES`
+  - 送信対象の遡及範囲: `NOTIFICATION_DELIVERY_LOOKBACK_DAYS`（既定 30日）
+
 ## 承認タイムアウト（将来）
 - 設定された承認期限を超過した approval_step を検出し、エスカレーション先へ通知。初期スコープでは未実装、後続で追加。
 

--- a/packages/backend/prisma/migrations/20260112100159_add_app_notification_deliveries/migration.sql
+++ b/packages/backend/prisma/migrations/20260112100159_add_app_notification_deliveries/migration.sql
@@ -1,0 +1,34 @@
+-- CreateTable
+CREATE TABLE "AppNotificationDelivery" (
+    "id" TEXT NOT NULL,
+    "notificationId" TEXT NOT NULL,
+    "channel" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "target" TEXT,
+    "payload" JSONB,
+    "providerMessageId" TEXT,
+    "error" TEXT,
+    "retryCount" INTEGER NOT NULL DEFAULT 0,
+    "nextRetryAt" TIMESTAMP(3),
+    "lastErrorAt" TIMESTAMP(3),
+    "sentAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdBy" TEXT,
+
+    CONSTRAINT "AppNotificationDelivery_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AppNotificationDelivery_status_nextRetryAt_idx" ON "AppNotificationDelivery"("status", "nextRetryAt");
+
+-- CreateIndex
+CREATE INDEX "AppNotificationDelivery_channel_sentAt_idx" ON "AppNotificationDelivery"("channel", "sentAt");
+
+-- CreateIndex
+CREATE INDEX "AppNotificationDelivery_notificationId_createdAt_idx" ON "AppNotificationDelivery"("notificationId", "createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AppNotificationDelivery_notificationId_channel_key" ON "AppNotificationDelivery"("notificationId", "channel");
+
+-- AddForeignKey
+ALTER TABLE "AppNotificationDelivery" ADD CONSTRAINT "AppNotificationDelivery_notificationId_fkey" FOREIGN KEY ("notificationId") REFERENCES "AppNotification"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -237,23 +237,47 @@ model ProjectTask {
 }
 
 model AppNotification {
-  id        String    @id @default(uuid())
-  userId    String
-  kind      String
-  project   Project?  @relation(fields: [projectId], references: [id], onDelete: SetNull)
-  projectId String?
-  messageId String?
-  payload   Json?
-  readAt    DateTime?
-  createdAt DateTime  @default(now())
-  createdBy String?
-  updatedAt DateTime  @updatedAt
-  updatedBy String?
+  id         String                    @id @default(uuid())
+  userId     String
+  kind       String
+  project    Project?                  @relation(fields: [projectId], references: [id], onDelete: SetNull)
+  projectId  String?
+  messageId  String?
+  payload    Json?
+  readAt     DateTime?
+  deliveries AppNotificationDelivery[]
+  createdAt  DateTime                  @default(now())
+  createdBy  String?
+  updatedAt  DateTime                  @updatedAt
+  updatedBy  String?
 
   @@index([userId, createdAt])
   @@index([userId, readAt, createdAt])
   @@index([projectId])
   @@index([kind, createdAt])
+}
+
+model AppNotificationDelivery {
+  id                String          @id @default(uuid())
+  notification      AppNotification @relation(fields: [notificationId], references: [id], onDelete: Cascade)
+  notificationId    String
+  channel           String
+  status            String
+  target            String?
+  payload           Json?
+  providerMessageId String?
+  error             String?
+  retryCount        Int             @default(0)
+  nextRetryAt       DateTime?
+  lastErrorAt       DateTime?
+  sentAt            DateTime?
+  createdAt         DateTime        @default(now())
+  createdBy         String?
+
+  @@unique([notificationId, channel])
+  @@index([status, nextRetryAt])
+  @@index([channel, sentAt])
+  @@index([notificationId, createdAt])
 }
 
 model ChatRoom {
@@ -434,13 +458,13 @@ model ChatBreakGlassAccessLog {
 }
 
 model ChatSetting {
-  id                           String   @id @default("default")
+  id                            String   @id @default("default")
   allowUserPrivateGroupCreation Boolean  @default(true)
   allowDmCreation               Boolean  @default(true)
-  createdAt                    DateTime @default(now())
-  createdBy                    String?
-  updatedAt                    DateTime @updatedAt
-  updatedBy                    String?
+  createdAt                     DateTime @default(now())
+  createdBy                     String?
+  updatedAt                     DateTime @updatedAt
+  updatedBy                     String?
 }
 
 model ProjectMilestone {

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -38,6 +38,7 @@ import { registerReportSubscriptionRoutes } from './reportSubscriptions.js';
 import { registerIntegrationRoutes } from './integrations.js';
 import { registerPeriodLockRoutes } from './periodLocks.js';
 import { registerNotificationRoutes } from './notifications.js';
+import { registerNotificationJobRoutes } from './notificationJobs.js';
 
 export async function registerRoutes(app: FastifyInstance) {
   await registerAuthRoutes(app);
@@ -51,6 +52,7 @@ export async function registerRoutes(app: FastifyInstance) {
   await registerScimRoutes(app);
   await registerPushRoutes(app);
   await registerNotificationRoutes(app);
+  await registerNotificationJobRoutes(app);
   await registerReportSubscriptionRoutes(app);
   await registerIntegrationRoutes(app);
   await registerPeriodLockRoutes(app);

--- a/packages/backend/src/routes/notificationJobs.ts
+++ b/packages/backend/src/routes/notificationJobs.ts
@@ -1,0 +1,39 @@
+import { FastifyInstance } from 'fastify';
+import type { Prisma } from '@prisma/client';
+import { requireRole } from '../services/rbac.js';
+import { auditContextFromRequest, logAudit } from '../services/audit.js';
+import { runNotificationEmailDeliveries } from '../services/notificationDeliveries.js';
+import { notificationDeliveryRunSchema } from './validators.js';
+
+export async function registerNotificationJobRoutes(app: FastifyInstance) {
+  app.post(
+    '/jobs/notification-deliveries/run',
+    {
+      preHandler: requireRole(['admin', 'mgmt']),
+      schema: notificationDeliveryRunSchema,
+    },
+    async (req) => {
+      const body = (req.body || {}) as { dryRun?: boolean; limit?: number };
+      const result = await runNotificationEmailDeliveries({
+        actorId: req.user?.userId,
+        dryRun: body.dryRun,
+        limit: body.limit,
+      });
+
+      await logAudit({
+        action: 'notification_deliveries_run',
+        targetTable: 'app_notification_deliveries',
+        metadata: {
+          channel: 'email',
+          dryRun: result.dryRun,
+          created: result.created,
+          processed: result.processed,
+          counts: result.counts,
+        } as Prisma.InputJsonValue,
+        ...auditContextFromRequest(req, { source: 'job' }),
+      });
+
+      return result;
+    },
+  );
+}

--- a/packages/backend/src/routes/validators.ts
+++ b/packages/backend/src/routes/validators.ts
@@ -705,6 +705,16 @@ export const reportSubscriptionRunSchema = {
   ),
 };
 
+export const notificationDeliveryRunSchema = {
+  body: Type.Object(
+    {
+      dryRun: Type.Optional(Type.Boolean()),
+      limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200 })),
+    },
+    { additionalProperties: false },
+  ),
+};
+
 export const pushSubscriptionSchema = {
   body: Type.Object(
     {

--- a/packages/backend/src/services/notificationDeliveries.ts
+++ b/packages/backend/src/services/notificationDeliveries.ts
@@ -1,0 +1,504 @@
+import type { Prisma } from '@prisma/client';
+import { prisma } from './db.js';
+import { sendEmail } from './notifier.js';
+
+const DEFAULT_DELIVERY_LIMIT = 50;
+const DEFAULT_LOOKBACK_DAYS = 30;
+const DEFAULT_RETRY_MAX = 3;
+const DEFAULT_RETRY_BASE_MINUTES = 10;
+const DEFAULT_RETRY_MAX_DELAY_MINUTES = 24 * 60;
+
+const NON_RETRYABLE_ERRORS = new Set([
+  'missing_email',
+  'invalid_recipient',
+  'smtp_config_missing',
+  'smtp_disabled',
+  'smtp_unavailable',
+]);
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function parseNonNegativeInt(value: string | undefined, fallback: number) {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  return Math.floor(parsed);
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number) {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.floor(parsed);
+}
+
+function resolveLookbackDays() {
+  return parsePositiveInt(
+    process.env.NOTIFICATION_DELIVERY_LOOKBACK_DAYS,
+    DEFAULT_LOOKBACK_DAYS,
+  );
+}
+
+function resolveRetryMax() {
+  return parseNonNegativeInt(
+    process.env.NOTIFICATION_DELIVERY_RETRY_MAX,
+    DEFAULT_RETRY_MAX,
+  );
+}
+
+function resolveRetryBaseMinutes() {
+  return parseNonNegativeInt(
+    process.env.NOTIFICATION_DELIVERY_RETRY_BASE_MINUTES,
+    DEFAULT_RETRY_BASE_MINUTES,
+  );
+}
+
+function resolveRetryMaxDelayMinutes() {
+  return parseNonNegativeInt(
+    process.env.NOTIFICATION_DELIVERY_RETRY_MAX_DELAY_MINUTES,
+    DEFAULT_RETRY_MAX_DELAY_MINUTES,
+  );
+}
+
+function computeNextRetryAt(now: Date, attempt: number, baseMinutes: number) {
+  if (attempt <= 0 || baseMinutes <= 0) return null;
+  const factor = Math.pow(2, attempt - 1);
+  const maxDelayMinutes = resolveRetryMaxDelayMinutes();
+  const cappedMinutes =
+    maxDelayMinutes > 0
+      ? Math.min(baseMinutes * factor, maxDelayMinutes)
+      : baseMinutes * factor;
+  return new Date(now.getTime() + cappedMinutes * 60 * 1000);
+}
+
+function isRetryableError(error?: string | null) {
+  if (!error) return true;
+  return !NON_RETRYABLE_ERRORS.has(error);
+}
+
+function normalizeString(value: unknown) {
+  if (typeof value !== 'string') return '';
+  return value.trim();
+}
+
+function normalizeEmailList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const items = value
+    .map((item) => {
+      if (typeof item === 'string') return item.trim();
+      if (!item || typeof item !== 'object') return '';
+      const raw = (item as { value?: unknown }).value;
+      return typeof raw === 'string' ? raw.trim() : '';
+    })
+    .filter(Boolean);
+  return Array.from(new Set(items));
+}
+
+function pickPrimaryEmail(value: unknown) {
+  if (!Array.isArray(value)) return null;
+  const primary = value.find((item) => {
+    if (!item || typeof item !== 'object') return false;
+    return Boolean((item as { primary?: unknown }).primary);
+  });
+  if (primary && typeof primary === 'object') {
+    const email = normalizeString((primary as { value?: unknown }).value);
+    if (email) return email;
+  }
+  const candidates = normalizeEmailList(value);
+  return candidates.length ? candidates[0] : null;
+}
+
+async function resolveDeliveryEmailTarget(userId: string) {
+  const trimmed = userId.trim();
+  if (!trimmed) return null;
+  if (emailRegex.test(trimmed)) return trimmed;
+  const account = await prisma.userAccount.findUnique({
+    where: { userName: trimmed },
+    select: { emails: true },
+  });
+  const email = pickPrimaryEmail(account?.emails);
+  if (email && emailRegex.test(email)) return email;
+  return null;
+}
+
+function buildChatMentionEmailSubject(meta: {
+  projectCode?: string | null;
+  projectName?: string | null;
+}) {
+  const label = meta.projectCode || meta.projectName;
+  return label ? `ERP4: ${label} メンション` : 'ERP4: メンション';
+}
+
+function buildChatMentionEmailBody(notification: {
+  userId: string;
+  createdAt: Date;
+  project?: { code?: string | null; name?: string | null } | null;
+  messageId?: string | null;
+  payload?: Prisma.JsonValue | null;
+}) {
+  const projectLabel = notification.project
+    ? `${notification.project.code || '-'} / ${notification.project.name || '-'}`
+    : '-';
+  const payload = notification.payload as Record<string, unknown> | null;
+  const fromUserId = normalizeString(payload?.fromUserId);
+  const excerpt = normalizeString(payload?.excerpt);
+  return [
+    'chat mention notification',
+    `to: ${notification.userId}`,
+    `from: ${fromUserId || '-'}`,
+    `project: ${projectLabel}`,
+    `createdAt: ${notification.createdAt.toISOString()}`,
+    `messageId: ${notification.messageId || '-'}`,
+    excerpt ? `excerpt: ${excerpt}` : undefined,
+  ]
+    .filter((line) => typeof line === 'string' && line.trim() !== '')
+    .join('\n');
+}
+
+type DeliveryRunItem = {
+  id: string;
+  notificationId: string;
+  status: string;
+  target?: string | null;
+  error?: string | null;
+};
+
+export type NotificationDeliveryRunResult = {
+  ok: true;
+  dryRun: boolean;
+  created: number;
+  processed: number;
+  counts: Record<string, number>;
+  items: DeliveryRunItem[];
+};
+
+function incrementCount(counts: Record<string, number>, key: string) {
+  counts[key] = (counts[key] || 0) + 1;
+}
+
+function resolveDeliveryLimit(limit: number | undefined) {
+  if (typeof limit !== 'number' || !Number.isFinite(limit) || limit <= 0) {
+    return DEFAULT_DELIVERY_LIMIT;
+  }
+  return Math.min(Math.floor(limit), 200);
+}
+
+export async function runNotificationEmailDeliveries(options: {
+  actorId?: string;
+  dryRun?: boolean;
+  limit?: number;
+}): Promise<NotificationDeliveryRunResult> {
+  const actorId = options.actorId;
+  const dryRun = Boolean(options.dryRun);
+  const limit = resolveDeliveryLimit(options.limit);
+  const counts: Record<string, number> = {};
+
+  const now = new Date();
+  const lookbackDays = resolveLookbackDays();
+  const lookbackFrom = new Date(
+    now.getTime() - lookbackDays * 24 * 60 * 60 * 1000,
+  );
+
+  const candidates = await prisma.appNotification.findMany({
+    where: {
+      kind: 'chat_mention',
+      readAt: null,
+      createdAt: { gte: lookbackFrom },
+    },
+    orderBy: { createdAt: 'asc' },
+    take: 200,
+    select: {
+      id: true,
+      deliveries: {
+        where: { channel: 'email' },
+        select: { id: true },
+      },
+    },
+  });
+
+  const missingDeliveries = candidates.filter(
+    (item) => item.deliveries.length === 0,
+  );
+
+  let created = 0;
+  if (!dryRun && missingDeliveries.length > 0) {
+    const result = await prisma.appNotificationDelivery.createMany({
+      data: missingDeliveries.map((item) => ({
+        notificationId: item.id,
+        channel: 'email',
+        status: 'pending',
+        createdBy: actorId,
+      })),
+      skipDuplicates: true,
+    });
+    created = result.count;
+  }
+  counts.candidate_notifications = candidates.length;
+
+  const retryMax = resolveRetryMax();
+  const dueDeliveries = await prisma.appNotificationDelivery.findMany({
+    where: {
+      channel: 'email',
+      OR: [
+        { status: 'pending' },
+        {
+          status: 'failed',
+          retryCount: { lt: retryMax },
+          OR: [{ nextRetryAt: null }, { nextRetryAt: { lte: now } }],
+        },
+      ],
+    },
+    orderBy: [{ nextRetryAt: 'asc' }, { createdAt: 'asc' }],
+    take: limit,
+    include: {
+      notification: {
+        include: {
+          project: { select: { code: true, name: true } },
+        },
+      },
+    },
+  });
+
+  if (dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      created: 0,
+      processed: dueDeliveries.length,
+      counts: {
+        ...counts,
+        due_deliveries: dueDeliveries.length,
+        missing_deliveries: missingDeliveries.length,
+      },
+      items: dueDeliveries.map((item) => ({
+        id: item.id,
+        notificationId: item.notificationId,
+        status: 'dry_run',
+        target: item.target,
+        error: item.error,
+      })),
+    };
+  }
+
+  const items: DeliveryRunItem[] = [];
+  for (const delivery of dueDeliveries) {
+    const claimed = await prisma.appNotificationDelivery.updateMany({
+      where: {
+        id: delivery.id,
+        channel: 'email',
+        OR: [
+          { status: 'pending' },
+          {
+            status: 'failed',
+            retryCount: { lt: retryMax },
+            OR: [{ nextRetryAt: null }, { nextRetryAt: { lte: now } }],
+          },
+        ],
+      },
+      data: { status: 'sending', nextRetryAt: null },
+    });
+    if (claimed.count === 0) {
+      items.push({
+        id: delivery.id,
+        notificationId: delivery.notificationId,
+        status: 'skipped',
+        error: 'already_claimed',
+      });
+      incrementCount(counts, 'skipped');
+      continue;
+    }
+
+    const sentAt = new Date();
+    const notification = delivery.notification;
+    if (notification.readAt) {
+      await prisma.appNotificationDelivery.update({
+        where: { id: delivery.id },
+        data: {
+          status: 'skipped',
+          error: 'already_read',
+          sentAt,
+        },
+      });
+      items.push({
+        id: delivery.id,
+        notificationId: delivery.notificationId,
+        status: 'skipped',
+        error: 'already_read',
+      });
+      incrementCount(counts, 'skipped');
+      continue;
+    }
+
+    const emailTarget = await resolveDeliveryEmailTarget(notification.userId);
+    if (!emailTarget) {
+      await prisma.appNotificationDelivery.update({
+        where: { id: delivery.id },
+        data: {
+          status: 'skipped',
+          error: 'missing_email',
+          target: notification.userId,
+          sentAt,
+        },
+      });
+      items.push({
+        id: delivery.id,
+        notificationId: delivery.notificationId,
+        status: 'skipped',
+        target: notification.userId,
+        error: 'missing_email',
+      });
+      incrementCount(counts, 'skipped');
+      continue;
+    }
+
+    let subject = `ERP4: ${notification.kind}`;
+    let body = `${notification.kind}`;
+    if (notification.kind === 'chat_mention') {
+      subject = buildChatMentionEmailSubject({
+        projectCode: notification.project?.code,
+        projectName: notification.project?.name,
+      });
+      body = buildChatMentionEmailBody(notification);
+    }
+
+    try {
+      const emailResult = await sendEmail([emailTarget], subject, body, {
+        metadata: {
+          notificationId: notification.id,
+          deliveryId: delivery.id,
+          kind: notification.kind,
+        },
+      });
+      const error = emailResult.error ?? null;
+      const retryBase = resolveRetryBaseMinutes();
+
+      if (delivery.status === 'failed') {
+        const nextRetryCount = delivery.retryCount + 1;
+        const retryable =
+          emailResult.status === 'failed' &&
+          isRetryableError(error) &&
+          retryBase > 0 &&
+          nextRetryCount < retryMax;
+        const nextRetryAt = retryable
+          ? computeNextRetryAt(sentAt, nextRetryCount + 1, retryBase)
+          : null;
+        const status =
+          emailResult.status === 'failed' && !retryable
+            ? 'failed_permanent'
+            : emailResult.status;
+        await prisma.appNotificationDelivery.update({
+          where: { id: delivery.id },
+          data: {
+            status,
+            error: error ?? undefined,
+            target: emailResult.target || emailTarget,
+            providerMessageId: emailResult.messageId,
+            retryCount: nextRetryCount,
+            nextRetryAt,
+            lastErrorAt:
+              status === 'failed' || status === 'failed_permanent'
+                ? sentAt
+                : null,
+            sentAt,
+          },
+        });
+        items.push({
+          id: delivery.id,
+          notificationId: delivery.notificationId,
+          status,
+          target: emailResult.target || emailTarget,
+          error,
+        });
+        incrementCount(counts, status);
+        continue;
+      }
+
+      const retryable =
+        emailResult.status === 'failed' &&
+        isRetryableError(error) &&
+        retryMax > 0 &&
+        retryBase > 0;
+      const nextRetryAt = retryable
+        ? computeNextRetryAt(sentAt, delivery.retryCount + 1, retryBase)
+        : null;
+      const status =
+        emailResult.status === 'failed' && !retryable
+          ? 'failed_permanent'
+          : emailResult.status;
+      await prisma.appNotificationDelivery.update({
+        where: { id: delivery.id },
+        data: {
+          status,
+          error: error ?? undefined,
+          target: emailResult.target || emailTarget,
+          providerMessageId: emailResult.messageId,
+          nextRetryAt,
+          lastErrorAt:
+            status === 'failed' || status === 'failed_permanent'
+              ? sentAt
+              : null,
+          sentAt,
+        },
+      });
+      items.push({
+        id: delivery.id,
+        notificationId: delivery.notificationId,
+        status,
+        target: emailResult.target || emailTarget,
+        error,
+      });
+      incrementCount(counts, status);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : 'send_failed';
+      const retryBase = resolveRetryBaseMinutes();
+      const isRetry = delivery.status === 'failed';
+      const nextRetryCount = isRetry
+        ? delivery.retryCount + 1
+        : delivery.retryCount;
+      const retryable = isRetry
+        ? isRetryableError(error) &&
+          retryMax > 0 &&
+          retryBase > 0 &&
+          nextRetryCount < retryMax
+        : isRetryableError(error) && retryMax > 0 && retryBase > 0;
+      const attempt = isRetry ? nextRetryCount + 1 : delivery.retryCount + 1;
+      const nextRetryAt = retryable
+        ? computeNextRetryAt(sentAt, attempt, retryBase)
+        : null;
+      const status = retryable ? 'failed' : 'failed_permanent';
+      await prisma.appNotificationDelivery.update({
+        where: { id: delivery.id },
+        data: {
+          status,
+          error,
+          target: emailTarget,
+          retryCount: isRetry ? nextRetryCount : undefined,
+          nextRetryAt,
+          lastErrorAt: sentAt,
+          sentAt,
+        },
+      });
+      items.push({
+        id: delivery.id,
+        notificationId: delivery.notificationId,
+        status,
+        target: emailTarget,
+        error,
+      });
+      incrementCount(counts, status);
+    }
+  }
+
+  return {
+    ok: true,
+    dryRun: false,
+    created,
+    processed: items.length,
+    counts: {
+      ...counts,
+      due_deliveries: dueDeliveries.length,
+      missing_deliveries: missingDeliveries.length,
+    },
+    items,
+  };
+}


### PR DESCRIPTION
目的
- チャットのメンション通知（AppNotification: chat_mention）をメールでも配信できるようにする（MVP）

変更点
- DB: app_notification_deliveries（AppNotificationDelivery）を追加（channel/email, status, retry 等）
- Backend: `/jobs/notification-deliveries/run` を追加（admin/mgmt）
- 宛先解決: userId がメール形式ならそれを使用。そうでなければ `user_accounts.emails` の primary/先頭を使用
- 既読通知は送信せず `skipped (already_read)` として記録
- 監査: jobs 実行を audit_logs に記録（action: notification_deliveries_run）
- E2E: チャット投稿→メンション作成→配信ジョブ実行の確認を追加
- docs: `docs/requirements/batch-jobs.md` に通知配信ジョブを追記

運用/設定
- `NOTIFICATION_DELIVERY_LOOKBACK_DAYS`（既定 30）
- `NOTIFICATION_DELIVERY_RETRY_MAX`（既定 3）
- `NOTIFICATION_DELIVERY_RETRY_BASE_MINUTES`（既定 10）
- `NOTIFICATION_DELIVERY_RETRY_MAX_DELAY_MINUTES`（既定 1440）

Closes #495
