### PR TITLE
P2-2b: タスク親変更は理由必須 + 監査ログ

### DIFF
--- a/packages/backend/src/routes/validators.ts
+++ b/packages/backend/src/routes/validators.ts
@@ -176,7 +176,12 @@ export const projectTaskSchema = {
 };
 
 export const projectTaskPatchSchema = {
-  body: Type.Partial(projectTaskSchema.body),
+  body: Type.Intersect([
+    Type.Partial(projectTaskSchema.body),
+    Type.Object({
+      reasonText: Type.Optional(Type.String({ minLength: 1 })),
+    }),
+  ]),
 };
 
 export const projectMilestoneSchema = {


### PR DESCRIPTION
## 概要
タスクの親子付け替え（`parentTaskId` の変更）について、仕様（`docs/requirements/project-task-milestone-flow.md`）に合わせて「理由必須 + 監査ログ」を追加します。
併せて、タスクの作成/更新を project スコープの user でも実行できるようにします（一覧は既に user で可能でした）。

## 変更内容
- Backend
  - `PATCH /projects/:projectId/tasks/:taskId` で `parentTaskId` が変更される場合は `reasonText` 必須（`INVALID_REASON`）
  - 親変更時に監査ログ `project_task_parent_updated` を記録
  - タスク `POST/PATCH` を `admin/mgmt/user` + project scope で許可（外部/無所属は 403）
- Frontend
  - タスク編集時、親タスク変更時のみ「変更理由」入力を必須化（未入力は保存不可）
  - `削除` ボタンは admin/mgmt のみに表示
- E2E
  - `backend-task-parent.spec.ts` を理由必須仕様に追従（missing reason も検証）

## 動作確認
- `npm --prefix packages/backend run format:check`
- `npm --prefix packages/backend run lint`
- `npm --prefix packages/frontend run format:check`
- `npm --prefix packages/frontend run lint`
- `E2E_CAPTURE=0 E2E_GREP="task parent can be updated" E2E_SKIP_PLAYWRIGHT_INSTALL=1 ./scripts/e2e-frontend.sh`
