### PR TITLE
feat: タスク期間（計画/実績）の入力/クリア対応

### DIFF
--- a/packages/backend/src/routes/validators.ts
+++ b/packages/backend/src/routes/validators.ts
@@ -174,10 +174,18 @@ export const projectTaskSchema = {
     parentTaskId: Type.Optional(Type.String()),
     assigneeId: Type.Optional(Type.String()),
     status: Type.Optional(Type.String()),
-    planStart: Type.Optional(Type.String({ format: 'date' })),
-    planEnd: Type.Optional(Type.String({ format: 'date' })),
-    actualStart: Type.Optional(Type.String({ format: 'date' })),
-    actualEnd: Type.Optional(Type.String({ format: 'date' })),
+    planStart: Type.Optional(
+      Type.Union([Type.String({ format: 'date' }), Type.Null()]),
+    ),
+    planEnd: Type.Optional(
+      Type.Union([Type.String({ format: 'date' }), Type.Null()]),
+    ),
+    actualStart: Type.Optional(
+      Type.Union([Type.String({ format: 'date' }), Type.Null()]),
+    ),
+    actualEnd: Type.Optional(
+      Type.Union([Type.String({ format: 'date' }), Type.Null()]),
+    ),
   }),
 };
 

--- a/packages/frontend/e2e/backend-task-period.spec.ts
+++ b/packages/frontend/e2e/backend-task-period.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test } from '@playwright/test';
+
+const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
+const authHeaders = {
+  'x-user-id': 'demo-user',
+  'x-roles': 'admin,mgmt',
+  'x-project-ids': '00000000-0000-0000-0000-000000000001',
+  'x-group-ids': 'mgmt,hr-group',
+};
+
+const demoProjectId = '00000000-0000-0000-0000-000000000001';
+
+const runId = () =>
+  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+
+async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
+  if (res.ok()) return;
+  const body = await res.text();
+  throw new Error(`[e2e] api failed: ${res.status()} ${body}`);
+}
+
+const toDateString = (value: any) => {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toISOString().slice(0, 10);
+};
+
+test('task plan/actual dates can be set, cleared, validated @extended', async ({
+  request,
+}) => {
+  const suffix = runId();
+
+  const createRes = await request.post(
+    `${apiBase}/projects/${encodeURIComponent(demoProjectId)}/tasks`,
+    {
+      data: { name: `E2E Task Period ${suffix}` },
+      headers: authHeaders,
+    },
+  );
+  await ensureOk(createRes);
+  const task = await createRes.json();
+
+  const setPlanRes = await request.patch(
+    `${apiBase}/projects/${encodeURIComponent(demoProjectId)}/tasks/${encodeURIComponent(task.id)}`,
+    {
+      data: { planStart: '2026-01-01', planEnd: '2026-01-10' },
+      headers: authHeaders,
+    },
+  );
+  await ensureOk(setPlanRes);
+  const planned = await setPlanRes.json();
+  expect(toDateString(planned.planStart)).toBe('2026-01-01');
+  expect(toDateString(planned.planEnd)).toBe('2026-01-10');
+
+  const clearEndRes = await request.patch(
+    `${apiBase}/projects/${encodeURIComponent(demoProjectId)}/tasks/${encodeURIComponent(task.id)}`,
+    {
+      data: { planEnd: null },
+      headers: authHeaders,
+    },
+  );
+  await ensureOk(clearEndRes);
+  const clearedEnd = await clearEndRes.json();
+  expect(clearedEnd.planEnd).toBeNull();
+
+  const invalidPlanRes = await request.patch(
+    `${apiBase}/projects/${encodeURIComponent(demoProjectId)}/tasks/${encodeURIComponent(task.id)}`,
+    {
+      data: { planStart: '2026-02-01', planEnd: '2026-01-01' },
+      headers: authHeaders,
+    },
+  );
+  expect(invalidPlanRes.ok()).toBeFalsy();
+  expect(invalidPlanRes.status()).toBe(400);
+
+  const setActualRes = await request.patch(
+    `${apiBase}/projects/${encodeURIComponent(demoProjectId)}/tasks/${encodeURIComponent(task.id)}`,
+    {
+      data: { actualStart: '2026-01-02', actualEnd: '2026-01-03' },
+      headers: authHeaders,
+    },
+  );
+  await ensureOk(setActualRes);
+  const actual = await setActualRes.json();
+  expect(toDateString(actual.actualStart)).toBe('2026-01-02');
+  expect(toDateString(actual.actualEnd)).toBe('2026-01-03');
+
+  const invalidActualRes = await request.patch(
+    `${apiBase}/projects/${encodeURIComponent(demoProjectId)}/tasks/${encodeURIComponent(task.id)}`,
+    {
+      data: { actualStart: '2026-01-05', actualEnd: '2026-01-04' },
+      headers: authHeaders,
+    },
+  );
+  expect(invalidActualRes.ok()).toBeFalsy();
+  expect(invalidActualRes.status()).toBe(400);
+});


### PR DESCRIPTION
概要
- タスクの planStart/planEnd/actualStart/actualEnd を UI から設定/更新/クリアできるようにしました。
- 期間の基本整合（開始<=終了）を backend でバリデーションします。

変更点
- backend: tasks create/patch で日付を `null` でクリア可能、開始<=終了の検証（plan/actual）を追加
- frontend: タスク画面に「計画開始/終了」「実績開始/終了」の入力欄と一覧表示を追加
- e2e: APIベースで「設定→クリア→逆転エラー」を追加（@extended）

関連
- Closes #519
- Related: #504 (P2-2)

テスト
- backend: `npm -C packages/backend run lint` / `format:check` / `build`
- frontend: `npm -C packages/frontend run lint` / `format:check` / `build`
