### PR TITLE
feat: タスク進捗率(progressPercent)の追加

### DIFF
--- a/packages/backend/prisma/migrations/20260114145152_add_task_progress_percent/migration.sql
+++ b/packages/backend/prisma/migrations/20260114145152_add_task_progress_percent/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "ProjectTask" ADD COLUMN "progressPercent" INTEGER;
+

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -209,28 +209,29 @@ model ProjectMember {
 }
 
 model ProjectTask {
-  id            String        @id @default(uuid())
-  project       Project       @relation(fields: [projectId], references: [id], onDelete: Restrict)
-  projectId     String
-  parentTask    ProjectTask?  @relation("TaskToTask", fields: [parentTaskId], references: [id], onDelete: Restrict)
-  parentTaskId  String?
-  children      ProjectTask[] @relation("TaskToTask")
-  name          String
-  wbsCode       String?
-  assigneeId    String?
-  status        String?
-  planStart     DateTime?
-  planEnd       DateTime?
-  actualStart   DateTime?
-  actualEnd     DateTime?
-  baselineId    String?
-  timeEntries   TimeEntry[]
-  createdAt     DateTime      @default(now())
-  createdBy     String?
-  updatedAt     DateTime      @updatedAt
-  updatedBy     String?
-  deletedAt     DateTime?
-  deletedReason String?
+  id              String        @id @default(uuid())
+  project         Project       @relation(fields: [projectId], references: [id], onDelete: Restrict)
+  projectId       String
+  parentTask      ProjectTask?  @relation("TaskToTask", fields: [parentTaskId], references: [id], onDelete: Restrict)
+  parentTaskId    String?
+  children        ProjectTask[] @relation("TaskToTask")
+  name            String
+  wbsCode         String?
+  assigneeId      String?
+  status          String?
+  progressPercent Int?
+  planStart       DateTime?
+  planEnd         DateTime?
+  actualStart     DateTime?
+  actualEnd       DateTime?
+  baselineId      String?
+  timeEntries     TimeEntry[]
+  createdAt       DateTime      @default(now())
+  createdBy       String?
+  updatedAt       DateTime      @updatedAt
+  updatedBy       String?
+  deletedAt       DateTime?
+  deletedReason   String?
 
   @@index([projectId, deletedAt])
   @@index([parentTaskId, deletedAt])
@@ -572,30 +573,30 @@ model EstimateLine {
 }
 
 model Invoice {
-  id              String            @id @default(uuid())
-  project         Project           @relation(fields: [projectId], references: [id], onDelete: Restrict)
-  projectId       String
-  estimate        Estimate?         @relation(fields: [estimateId], references: [id], onDelete: SetNull)
-  estimateId      String? // 見積なし請求を許容
-  milestone       ProjectMilestone? @relation(fields: [milestoneId], references: [id], onDelete: SetNull)
-  milestoneId     String? // 任意。未紐付けは納品請求漏れチェック対象
-  invoiceNo       String            @unique
-  issueDate       DateTime?
-  dueDate         DateTime?
-  currency        String
-  totalAmount     Decimal
-  status          DocStatus         @default(draft)
-  pdfUrl          String?
-  emailMessageId  String?
-  numberingSerial Int?
-  lines           BillingLine[]
-  billedTimeEntries TimeEntry[]     @relation("InvoiceToTimeEntries")
-  createdAt       DateTime          @default(now())
-  createdBy       String?
-  updatedAt       DateTime          @updatedAt
-  updatedBy       String?
-  deletedAt       DateTime?
-  deletedReason   String?
+  id                String            @id @default(uuid())
+  project           Project           @relation(fields: [projectId], references: [id], onDelete: Restrict)
+  projectId         String
+  estimate          Estimate?         @relation(fields: [estimateId], references: [id], onDelete: SetNull)
+  estimateId        String? // 見積なし請求を許容
+  milestone         ProjectMilestone? @relation(fields: [milestoneId], references: [id], onDelete: SetNull)
+  milestoneId       String? // 任意。未紐付けは納品請求漏れチェック対象
+  invoiceNo         String            @unique
+  issueDate         DateTime?
+  dueDate           DateTime?
+  currency          String
+  totalAmount       Decimal
+  status            DocStatus         @default(draft)
+  pdfUrl            String?
+  emailMessageId    String?
+  numberingSerial   Int?
+  lines             BillingLine[]
+  billedTimeEntries TimeEntry[]       @relation("InvoiceToTimeEntries")
+  createdAt         DateTime          @default(now())
+  createdBy         String?
+  updatedAt         DateTime          @updatedAt
+  updatedBy         String?
+  deletedAt         DateTime?
+  deletedReason     String?
 
   @@index([projectId, status, deletedAt])
   @@index([issueDate])
@@ -706,29 +707,29 @@ model VendorInvoice {
 }
 
 model TimeEntry {
-  id            String       @id @default(uuid())
-  project       Project      @relation(fields: [projectId], references: [id], onDelete: Restrict)
-  projectId     String
-  task          ProjectTask? @relation(fields: [taskId], references: [id], onDelete: SetNull)
-  taskId        String?
-  billedInvoice Invoice?     @relation("InvoiceToTimeEntries", fields: [billedInvoiceId], references: [id], onDelete: SetNull)
+  id              String       @id @default(uuid())
+  project         Project      @relation(fields: [projectId], references: [id], onDelete: Restrict)
+  projectId       String
+  task            ProjectTask? @relation(fields: [taskId], references: [id], onDelete: SetNull)
+  taskId          String?
+  billedInvoice   Invoice?     @relation("InvoiceToTimeEntries", fields: [billedInvoiceId], references: [id], onDelete: SetNull)
   billedInvoiceId String?
-  billedAt      DateTime?
-  userId        String
-  workDate      DateTime
-  minutes       Int
-  workType      String?
-  location      String?
-  notes         String?
-  status        TimeStatus   @default(submitted)
-  approvedBy    String?
-  approvedAt    DateTime?
-  createdAt     DateTime     @default(now())
-  createdBy     String?
-  updatedAt     DateTime     @updatedAt
-  updatedBy     String?
-  deletedAt     DateTime?
-  deletedReason String?
+  billedAt        DateTime?
+  userId          String
+  workDate        DateTime
+  minutes         Int
+  workType        String?
+  location        String?
+  notes           String?
+  status          TimeStatus   @default(submitted)
+  approvedBy      String?
+  approvedAt      DateTime?
+  createdAt       DateTime     @default(now())
+  createdBy       String?
+  updatedAt       DateTime     @updatedAt
+  updatedBy       String?
+  deletedAt       DateTime?
+  deletedReason   String?
 
   @@index([projectId, workDate, deletedAt])
   @@index([userId, workDate])

--- a/packages/backend/src/routes/projects.ts
+++ b/packages/backend/src/routes/projects.ts
@@ -786,6 +786,13 @@ export async function registerProjectRoutes(app: FastifyInstance) {
       const { projectId } = req.params as { projectId: string };
       const body = req.body as any;
       const parentTaskId = normalizeParentId(body.parentTaskId);
+      const hasProgressPercentProp = Object.prototype.hasOwnProperty.call(
+        body,
+        'progressPercent',
+      );
+      const progressPercent = hasProgressPercentProp
+        ? body.progressPercent
+        : undefined;
       const { value: planStart } = parseNullableDateField(body, 'planStart');
       const { value: planEnd } = parseNullableDateField(body, 'planEnd');
       const { value: actualStart } = parseNullableDateField(
@@ -825,6 +832,7 @@ export async function registerProjectRoutes(app: FastifyInstance) {
           parentTaskId,
           assigneeId: body.assigneeId,
           status: body.status,
+          progressPercent: progressPercent ?? null,
           planStart: planStart ?? null,
           planEnd: planEnd ?? null,
           actualStart: actualStart ?? null,
@@ -864,6 +872,13 @@ export async function registerProjectRoutes(app: FastifyInstance) {
           error: { code: 'ALREADY_DELETED', message: 'Task already deleted' },
         });
       }
+      const hasProgressPercentProp = Object.prototype.hasOwnProperty.call(
+        body,
+        'progressPercent',
+      );
+      const progressPercent = hasProgressPercentProp
+        ? body.progressPercent
+        : undefined;
       const { hasProp: hasPlanStartProp, value: planStart } =
         parseNullableDateField(body, 'planStart');
       const { hasProp: hasPlanEndProp, value: planEnd } =
@@ -950,6 +965,7 @@ export async function registerProjectRoutes(app: FastifyInstance) {
           parentTaskId: hasParentTaskIdProp ? nextParentTaskId : undefined,
           assigneeId: body.assigneeId,
           status: body.status,
+          progressPercent: hasProgressPercentProp ? progressPercent : undefined,
           planStart: hasPlanStartProp ? planStart : undefined,
           planEnd: hasPlanEndProp ? planEnd : undefined,
           actualStart: hasActualStartProp ? actualStart : undefined,

--- a/packages/backend/src/routes/validators.ts
+++ b/packages/backend/src/routes/validators.ts
@@ -174,6 +174,9 @@ export const projectTaskSchema = {
     parentTaskId: Type.Optional(Type.String()),
     assigneeId: Type.Optional(Type.String()),
     status: Type.Optional(Type.String()),
+    progressPercent: Type.Optional(
+      Type.Union([Type.Integer({ minimum: 0, maximum: 100 }), Type.Null()]),
+    ),
     planStart: Type.Optional(
       Type.Union([Type.String({ format: 'date' }), Type.Null()]),
     ),

--- a/packages/frontend/e2e/backend-task-progress.spec.ts
+++ b/packages/frontend/e2e/backend-task-progress.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/test';
+
+const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
+const authHeaders = {
+  'x-user-id': 'demo-user',
+  'x-roles': 'admin,mgmt',
+  'x-project-ids': '00000000-0000-0000-0000-000000000001',
+  'x-group-ids': 'mgmt,hr-group',
+};
+
+const demoProjectId = '00000000-0000-0000-0000-000000000001';
+
+const runId = () =>
+  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+
+async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
+  if (res.ok()) return;
+  const body = await res.text();
+  throw new Error(`[e2e] api failed: ${res.status()} ${body}`);
+}
+
+test('task progress percent can be set, cleared, validated @extended', async ({
+  request,
+}) => {
+  const suffix = runId();
+
+  const createRes = await request.post(
+    `${apiBase}/projects/${encodeURIComponent(demoProjectId)}/tasks`,
+    {
+      data: { name: `E2E Task Progress ${suffix}`, progressPercent: 10 },
+      headers: authHeaders,
+    },
+  );
+  await ensureOk(createRes);
+  const task = await createRes.json();
+  expect(task.progressPercent).toBe(10);
+
+  const setRes = await request.patch(
+    `${apiBase}/projects/${encodeURIComponent(demoProjectId)}/tasks/${encodeURIComponent(task.id)}`,
+    {
+      data: { progressPercent: 55 },
+      headers: authHeaders,
+    },
+  );
+  await ensureOk(setRes);
+  const updated = await setRes.json();
+  expect(updated.progressPercent).toBe(55);
+
+  const clearRes = await request.patch(
+    `${apiBase}/projects/${encodeURIComponent(demoProjectId)}/tasks/${encodeURIComponent(task.id)}`,
+    {
+      data: { progressPercent: null },
+      headers: authHeaders,
+    },
+  );
+  await ensureOk(clearRes);
+  const cleared = await clearRes.json();
+  expect(cleared.progressPercent).toBeNull();
+
+  const tooHighRes = await request.patch(
+    `${apiBase}/projects/${encodeURIComponent(demoProjectId)}/tasks/${encodeURIComponent(task.id)}`,
+    {
+      data: { progressPercent: 101 },
+      headers: authHeaders,
+    },
+  );
+  expect(tooHighRes.ok()).toBeFalsy();
+  expect(tooHighRes.status()).toBe(400);
+
+  const negativeRes = await request.patch(
+    `${apiBase}/projects/${encodeURIComponent(demoProjectId)}/tasks/${encodeURIComponent(task.id)}`,
+    {
+      data: { progressPercent: -1 },
+      headers: authHeaders,
+    },
+  );
+  expect(negativeRes.ok()).toBeFalsy();
+  expect(negativeRes.status()).toBe(400);
+});

--- a/packages/frontend/src/sections/ProjectTasks.tsx
+++ b/packages/frontend/src/sections/ProjectTasks.tsx
@@ -13,6 +13,7 @@ type ProjectTask = {
   planEnd?: string | null;
   actualStart?: string | null;
   actualEnd?: string | null;
+  progressPercent?: number | null;
 };
 
 const buildInitialForm = (projectId?: string) => ({
@@ -20,6 +21,7 @@ const buildInitialForm = (projectId?: string) => ({
   name: '',
   status: '',
   parentTaskId: '',
+  progressPercent: '',
   planStart: '',
   planEnd: '',
   actualStart: '',
@@ -134,6 +136,7 @@ export const ProjectTasks: React.FC = () => {
       name: '',
       status: '',
       parentTaskId: '',
+      progressPercent: '',
       planStart: '',
       planEnd: '',
       actualStart: '',
@@ -158,6 +161,21 @@ export const ProjectTasks: React.FC = () => {
       setMessage('親タスクを変更する場合は理由を入力してください');
       return;
     }
+    const trimmedProgress = form.progressPercent.trim();
+    let progressPercent: number | null = null;
+    if (trimmedProgress.length > 0) {
+      const parsed = Number(trimmedProgress);
+      if (
+        !Number.isFinite(parsed) ||
+        !Number.isInteger(parsed) ||
+        parsed < 0 ||
+        parsed > 100
+      ) {
+        setMessage('進捗率は0〜100の整数で入力してください');
+        return;
+      }
+      progressPercent = parsed;
+    }
     const planStart = form.planStart.trim();
     const planEnd = form.planEnd.trim();
     const actualStart = form.actualStart.trim();
@@ -172,6 +190,7 @@ export const ProjectTasks: React.FC = () => {
               name,
               status: status || undefined,
               parentTaskId,
+              progressPercent,
               planStart: planStart || null,
               planEnd: planEnd || null,
               actualStart: actualStart || null,
@@ -196,6 +215,7 @@ export const ProjectTasks: React.FC = () => {
             name,
             status: status || undefined,
             ...(parentTaskId ? { parentTaskId } : {}),
+            ...(progressPercent != null ? { progressPercent } : {}),
             ...(planStart ? { planStart } : {}),
             ...(planEnd ? { planEnd } : {}),
             ...(actualStart ? { actualStart } : {}),
@@ -221,6 +241,8 @@ export const ProjectTasks: React.FC = () => {
       name: item.name,
       status: item.status || '',
       parentTaskId: item.parentTaskId || '',
+      progressPercent:
+        item.progressPercent != null ? String(item.progressPercent) : '',
       planStart: toDateInput(item.planStart),
       planEnd: toDateInput(item.planEnd),
       actualStart: toDateInput(item.actualStart),
@@ -292,6 +314,19 @@ export const ProjectTasks: React.FC = () => {
             value={form.status}
             onChange={(e) => setForm({ ...form, status: e.target.value })}
             placeholder="ステータス（任意）"
+          />
+          <input
+            aria-label="進捗率"
+            type="number"
+            inputMode="numeric"
+            min={0}
+            max={100}
+            step={1}
+            value={form.progressPercent}
+            onChange={(e) =>
+              setForm({ ...form, progressPercent: e.target.value })
+            }
+            placeholder="進捗(%)"
           />
           <select
             aria-label="親タスク選択"
@@ -385,6 +420,8 @@ export const ProjectTasks: React.FC = () => {
             <li key={item.id}>
               <span className="badge">{item.status || 'open'}</span> {item.name}{' '}
               / {renderProject(item.projectId)}
+              {item.progressPercent != null &&
+                ` / 進捗: ${item.progressPercent}%`}
               {parentLabel && ` / 親: ${parentLabel}`}
               {(planLabel || actualLabel) && (
                 <div style={{ marginTop: 4, fontSize: 12 }}>


### PR DESCRIPTION
概要
- タスクに進捗率（`progressPercent` 0〜100）を追加し、UIから設定/更新/クリアできるようにしました。

変更点
- DB/Prisma: `ProjectTask.progressPercent` を追加（migration含む）
- backend: タスク作成/更新で `progressPercent` を受け取り、`null` でクリア可能
- frontend: タスク画面に「進捗(%)」入力欄と一覧表示を追加
- e2e: APIベースで「設定→クリア→範囲外エラー」テストを追加（@extended）

関連
- Closes #523
- Related: #521

テスト
- backend: `npm -C packages/backend run lint` / `format:check` / `prisma:generate` / `build`
- frontend: `npm -C packages/frontend run lint` / `format:check` / `build`
