### PR TITLE
feat: バーンダウン（残工数推移）をmainへ反映

### DIFF
--- a/packages/frontend/e2e/backend-project-burndown.spec.ts
+++ b/packages/frontend/e2e/backend-project-burndown.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from '@playwright/test';
+
+const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
+const authHeaders = {
+  'x-user-id': 'demo-user',
+  'x-roles': 'admin,mgmt',
+  'x-project-ids': '00000000-0000-0000-0000-000000000001',
+  'x-group-ids': 'mgmt,hr-group',
+};
+
+const demoProjectId = '00000000-0000-0000-0000-000000000001';
+
+const runId = () =>
+  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+
+async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
+  if (res.ok()) return;
+  const body = await res.text();
+  throw new Error(`[e2e] api failed: ${res.status()} ${body}`);
+}
+
+test('project burndown returns daily remaining minutes @extended', async ({
+  request,
+}) => {
+  const suffix = runId();
+
+  const patchProjectRes = await request.patch(
+    `${apiBase}/projects/${encodeURIComponent(demoProjectId)}`,
+    {
+      data: { planHours: 10 },
+      headers: authHeaders,
+    },
+  );
+  await ensureOk(patchProjectRes);
+
+  const baselineName = `E2E Burndown ${suffix}`;
+  const baselineRes = await request.post(
+    `${apiBase}/projects/${encodeURIComponent(demoProjectId)}/baselines`,
+    { data: { name: baselineName }, headers: authHeaders },
+  );
+  await ensureOk(baselineRes);
+  const baseline = await baselineRes.json();
+
+  const createTimeEntry = async (workDate: string, minutes: number) => {
+    const res = await request.post(`${apiBase}/time-entries`, {
+      data: {
+        projectId: demoProjectId,
+        userId: 'demo-user',
+        workDate,
+        minutes,
+      },
+      headers: authHeaders,
+    });
+    await ensureOk(res);
+    return res.json();
+  };
+
+  await createTimeEntry('2026-01-02', 60);
+  await createTimeEntry('2026-01-03', 120);
+
+  const reportRes = await request.get(
+    `${apiBase}/reports/burndown/${encodeURIComponent(demoProjectId)}?baselineId=${encodeURIComponent(baseline.id)}&from=2026-01-01&to=2026-01-03`,
+    { headers: authHeaders },
+  );
+  await ensureOk(reportRes);
+  const report = await reportRes.json();
+  expect(report.planMinutes).toBe(600);
+  expect(Array.isArray(report.items)).toBeTruthy();
+  expect(report.items.map((item: any) => item.date)).toEqual([
+    '2026-01-01',
+    '2026-01-02',
+    '2026-01-03',
+  ]);
+
+  const day1 = report.items[0];
+  expect(day1).toMatchObject({
+    date: '2026-01-01',
+    burnedMinutes: 0,
+    cumulativeBurnedMinutes: 0,
+    remainingMinutes: 600,
+  });
+  const day2 = report.items[1];
+  expect(day2).toMatchObject({
+    date: '2026-01-02',
+    burnedMinutes: 60,
+    cumulativeBurnedMinutes: 60,
+    remainingMinutes: 540,
+  });
+  const day3 = report.items[2];
+  expect(day3).toMatchObject({
+    date: '2026-01-03',
+    burnedMinutes: 120,
+    cumulativeBurnedMinutes: 180,
+    remainingMinutes: 420,
+  });
+});
+

--- a/packages/frontend/src/sections/Reports.tsx
+++ b/packages/frontend/src/sections/Reports.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { api, getAuthState } from '../api';
 import { useProjects } from '../hooks/useProjects';
 
@@ -12,6 +12,29 @@ type ProjectEffort = {
 };
 type GroupEffort = { userId: string; totalMinutes: number };
 type Overtime = { userId: string; totalMinutes: number; dailyHours: number };
+
+type ProjectBaseline = {
+  id: string;
+  name: string;
+  createdAt?: string | null;
+};
+
+type BurndownItem = {
+  date: string;
+  burnedMinutes: number;
+  cumulativeBurnedMinutes: number;
+  remainingMinutes: number;
+};
+
+type BurndownReport = {
+  projectId: string;
+  baselineId: string;
+  planMinutes: number;
+  from: string;
+  to: string;
+  items: BurndownItem[];
+};
+
 function buildQuery(from?: string, to?: string) {
   const params = new URLSearchParams();
   if (from) params.set('from', from);
@@ -25,6 +48,8 @@ export const Reports: React.FC = () => {
   const defaultProjectId = auth?.projectIds?.[0] || 'demo-project';
   const defaultUserId = auth?.userId || 'demo-user';
   const [projectId, setProjectId] = useState(defaultProjectId);
+  const [baselines, setBaselines] = useState<ProjectBaseline[]>([]);
+  const [baselineId, setBaselineId] = useState('');
   const [groupUserIds, setGroupUserIds] = useState(defaultUserId);
   const [overtimeUserId, setOvertimeUserId] = useState(defaultUserId);
   const [from, setFrom] = useState('');
@@ -34,6 +59,9 @@ export const Reports: React.FC = () => {
   );
   const [groupReport, setGroupReport] = useState<GroupEffort[]>([]);
   const [overtimeReport, setOvertimeReport] = useState<Overtime | null>(null);
+  const [burndownReport, setBurndownReport] = useState<BurndownReport | null>(
+    null,
+  );
   const [message, setMessage] = useState('');
 
   const { projects, projectMessage } = useProjects({
@@ -44,6 +72,60 @@ export const Reports: React.FC = () => {
     () => new Map(projects.map((project) => [project.id, project])),
     [projects],
   );
+
+  useEffect(() => {
+    if (!projectId) {
+      setBaselines([]);
+      setBaselineId('');
+      return;
+    }
+    const run = async () => {
+      try {
+        const res = await api<{ items: ProjectBaseline[] }>(
+          `/projects/${projectId}/baselines`,
+        );
+        const items = Array.isArray(res.items) ? res.items : [];
+        setBaselines(items);
+        setBaselineId((prev) => {
+          if (items.some((baseline) => baseline.id === prev)) return prev;
+          return items[0]?.id || '';
+        });
+      } catch (err) {
+        setBaselines([]);
+        setBaselineId('');
+      }
+    };
+    void run();
+  }, [projectId]);
+
+  const loadBurndown = async () => {
+    if (!projectId) {
+      setMessage('案件を選択してください');
+      return;
+    }
+    if (!baselineId) {
+      setMessage('ベースラインを選択してください');
+      return;
+    }
+    if (!from || !to) {
+      setMessage('from/to を入力してください');
+      return;
+    }
+    const params = new URLSearchParams();
+    params.set('baselineId', baselineId);
+    params.set('from', from);
+    params.set('to', to);
+    try {
+      const res = await api<BurndownReport>(
+        `/reports/burndown/${projectId}?${params.toString()}`,
+      );
+      setBurndownReport(res);
+      setMessage('バーンダウンを取得しました');
+    } catch (err) {
+      setBurndownReport(null);
+      setMessage('取得に失敗しました');
+    }
+  };
 
   const loadProject = async () => {
     try {
@@ -144,6 +226,23 @@ export const Reports: React.FC = () => {
           個人別残業
         </button>
       </div>
+      <div className="row" style={{ gap: 8, marginTop: 8, flexWrap: 'wrap' }}>
+        <select
+          aria-label="ベースライン選択"
+          value={baselineId}
+          onChange={(e) => setBaselineId(e.target.value)}
+        >
+          <option value="">ベースラインを選択</option>
+          {baselines.map((baseline) => (
+            <option key={baseline.id} value={baseline.id}>
+              {baseline.name}
+            </option>
+          ))}
+        </select>
+        <button className="button" onClick={loadBurndown}>
+          バーンダウン
+        </button>
+      </div>
       {projectMessage && <p style={{ color: '#dc2626' }}>{projectMessage}</p>}
       {message && <p>{message}</p>}
       <div className="list" style={{ display: 'grid', gap: 8 }}>
@@ -184,6 +283,24 @@ export const Reports: React.FC = () => {
             </div>
           </div>
         )}
+        {burndownReport && (
+          <div className="card" style={{ padding: 12 }}>
+            <strong>バーンダウン</strong>
+            <div>Project: {renderProject(burndownReport.projectId)}</div>
+            <div>Plan: {burndownReport.planMinutes} min</div>
+            <div>
+              Period: {burndownReport.from}〜{burndownReport.to}
+            </div>
+            <div style={{ marginTop: 8 }}>
+              {burndownReport.items.map((item) => (
+                <div key={item.date}>
+                  {item.date}: burned {item.burnedMinutes} / remaining{' '}
+                  {item.remainingMinutes}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
         {groupReport.length > 0 && (
           <div className="card" style={{ padding: 12 }}>
             <strong>グループ別工数</strong>
@@ -202,9 +319,10 @@ export const Reports: React.FC = () => {
             <div>Hours (avg/day): {overtimeReport.dailyHours.toFixed(2)}</div>
           </div>
         )}
-        {!projectReport && groupReport.length === 0 && !overtimeReport && (
-          <div className="card">レポート未取得</div>
-        )}
+        {!projectReport &&
+          groupReport.length === 0 &&
+          !overtimeReport &&
+          !burndownReport && <div className="card">レポート未取得</div>}
       </div>
     </div>
   );


### PR DESCRIPTION
PR #530（バーンダウン）のベースブランチが `feat/project-baselines` のため、現状 `main` にはバーンダウン実装が未反映でした。

このPRで `feat/project-baselines` → `main` を取り込み、`main` に以下を反映します。
- バーンダウンAPI/UI（残工数推移）
- 日付ループの明確化 + 期間上限（365日）
- 取得失敗時のstale表示防止

関連: #522（EVM）実装の前提として、`main` にも反映しておきます。
