### PR TITLE
P2-4: 移行後の整合性チェックSQLを追加

### DIFF
--- a/docs/requirements/migration-poc.md
+++ b/docs/requirements/migration-poc.md
@@ -8,7 +8,9 @@ This note describes a minimal PoC load using demo seed data and a basic integrit
    - `psql $DATABASE_URL -f scripts/seed-demo.sql`
 3. Run integrity checks:
    - `psql $DATABASE_URL -f scripts/checks/poc-integrity.sql`
-4. Compare results with the expected values in `scripts/checks/poc-integrity.sql`.
+4. (Optional) After running `scripts/migrate-po.ts --apply`, run PO migration checks:
+   - `psql $DATABASE_URL -f scripts/checks/migration-po-integrity.sql`
+5. Compare results with the expected values in `scripts/checks/poc-integrity.sql`.
 
 ## Podman で実行する場合（psql が無い環境向け）
 1. PostgreSQL コンテナを起動（workspace をマウント）:
@@ -19,7 +21,9 @@ This note describes a minimal PoC load using demo seed data and a basic integrit
    - `podman exec -e PGPASSWORD=postgres erp4-pg-poc psql -U postgres -d postgres -f /workspace/scripts/seed-demo.sql`
 4. integrity check を実行:
    - `podman exec -e PGPASSWORD=postgres erp4-pg-poc psql -U postgres -d postgres -f /workspace/scripts/checks/poc-integrity.sql`
-5. 後片付け:
+5. (任意) `scripts/migrate-po.ts --apply` 実行後、移行チェックを実行:
+   - `podman exec -e PGPASSWORD=postgres erp4-pg-poc psql -U postgres -d postgres -f /workspace/scripts/checks/migration-po-integrity.sql`
+6. 後片付け:
    - `podman stop erp4-pg-poc && podman rm erp4-pg-poc`
 
 ### まとめて実行する場合

--- a/scripts/checks/migration-po-integrity.sql
+++ b/scripts/checks/migration-po-integrity.sql
@@ -1,0 +1,121 @@
+-- PO migration integrity checks (generic)
+-- - Intended to be run after `scripts/migrate-po.ts --apply`
+-- - Expected: mismatch queries should return 0 rows
+
+-- 1) counts
+select count(*) as customer_count from "Customer";
+select count(*) as vendor_count from "Vendor";
+select count(*) as project_count from "Project";
+select count(*) as task_count from "ProjectTask";
+select count(*) as milestone_count from "ProjectMilestone";
+select count(*) as estimate_count from "Estimate";
+select count(*) as invoice_count from "Invoice";
+select count(*) as purchase_order_count from "PurchaseOrder";
+select count(*) as vendor_quote_count from "VendorQuote";
+select count(*) as vendor_invoice_count from "VendorInvoice";
+select count(*) as time_entry_count from "TimeEntry";
+select count(*) as expense_count from "Expense";
+
+-- 2) totals per project
+select "projectId", sum("totalAmount") as invoice_total
+from "Invoice"
+group by "projectId"
+order by "projectId";
+
+select "projectId", sum(amount) as expense_total
+from "Expense"
+group by "projectId"
+order by "projectId";
+
+select "projectId", sum(minutes) as time_minutes
+from "TimeEntry"
+group by "projectId"
+order by "projectId";
+
+select "projectId", sum("totalAmount") as purchase_order_total
+from "PurchaseOrder"
+group by "projectId"
+order by "projectId";
+
+select "projectId", sum("totalAmount") as vendor_quote_total
+from "VendorQuote"
+group by "projectId"
+order by "projectId";
+
+select "projectId", sum("totalAmount") as vendor_invoice_total
+from "VendorInvoice"
+group by "projectId"
+order by "projectId";
+
+-- 3) referential integrity (cross-project mismatches)
+-- Invoice.estimateId -> Estimate.projectId mismatch
+select i.id, i."invoiceNo", i."projectId" as invoice_project_id, e."projectId" as estimate_project_id
+from "Invoice" i
+join "Estimate" e on e.id = i."estimateId"
+where i."estimateId" is not null
+  and i."projectId" <> e."projectId";
+
+-- Invoice.milestoneId -> ProjectMilestone.projectId mismatch
+select i.id, i."invoiceNo", i."projectId" as invoice_project_id, m."projectId" as milestone_project_id
+from "Invoice" i
+join "ProjectMilestone" m on m.id = i."milestoneId"
+where i."milestoneId" is not null
+  and i."projectId" <> m."projectId";
+
+-- PurchaseOrderLine.expenseId -> Expense.projectId mismatch
+select pol.id, po."poNo", po."projectId" as po_project_id, e."projectId" as expense_project_id, pol."expenseId"
+from "PurchaseOrderLine" pol
+join "PurchaseOrder" po on po.id = pol."purchaseOrderId"
+join "Expense" e on e.id = pol."expenseId"
+where pol."expenseId" is not null
+  and po."projectId" <> e."projectId";
+
+-- TimeEntry.taskId -> ProjectTask.projectId mismatch
+select te.id, te."projectId" as time_project_id, t."projectId" as task_project_id, te."taskId"
+from "TimeEntry" te
+join "ProjectTask" t on t.id = te."taskId"
+where te."taskId" is not null
+  and te."projectId" <> t."projectId";
+
+-- BillingLine.taskId -> Invoice.projectId mismatch
+select bl.id, i."invoiceNo", i."projectId" as invoice_project_id, t."projectId" as task_project_id, bl."taskId"
+from "BillingLine" bl
+join "Invoice" i on i.id = bl."invoiceId"
+join "ProjectTask" t on t.id = bl."taskId"
+where bl."taskId" is not null
+  and i."projectId" <> t."projectId";
+
+-- EstimateLine.taskId -> Estimate.projectId mismatch
+select el.id, e."estimateNo", e."projectId" as estimate_project_id, t."projectId" as task_project_id, el."taskId"
+from "EstimateLine" el
+join "Estimate" e on e.id = el."estimateId"
+join "ProjectTask" t on t.id = el."taskId"
+where el."taskId" is not null
+  and e."projectId" <> t."projectId";
+
+-- PurchaseOrderLine.taskId -> PurchaseOrder.projectId mismatch
+select pol.id, po."poNo", po."projectId" as po_project_id, t."projectId" as task_project_id, pol."taskId"
+from "PurchaseOrderLine" pol
+join "PurchaseOrder" po on po.id = pol."purchaseOrderId"
+join "ProjectTask" t on t.id = pol."taskId"
+where pol."taskId" is not null
+  and po."projectId" <> t."projectId";
+
+-- 4) line totals vs header totals (abs(diff) > 0.01)
+select e."estimateNo", e."totalAmount" as header_total, coalesce(sum(el.quantity * el."unitPrice"), 0) as lines_total
+from "Estimate" e
+left join "EstimateLine" el on el."estimateId" = e.id
+group by e.id
+having abs(coalesce(sum(el.quantity * el."unitPrice"), 0) - e."totalAmount") > 0.01;
+
+select i."invoiceNo", i."totalAmount" as header_total, coalesce(sum(bl.quantity * bl."unitPrice"), 0) as lines_total
+from "Invoice" i
+left join "BillingLine" bl on bl."invoiceId" = i.id
+group by i.id
+having abs(coalesce(sum(bl.quantity * bl."unitPrice"), 0) - i."totalAmount") > 0.01;
+
+select po."poNo", po."totalAmount" as header_total, coalesce(sum(pol.quantity * pol."unitPrice"), 0) as lines_total
+from "PurchaseOrder" po
+left join "PurchaseOrderLine" pol on pol."purchaseOrderId" = po.id
+group by po.id
+having abs(coalesce(sum(pol.quantity * pol."unitPrice"), 0) - po."totalAmount") > 0.01;


### PR DESCRIPTION
#533（段階2: 検証・整合性）向けに、移行後にDB側で確認できるSQLチェックを追加しました。

- `scripts/checks/migration-po-integrity.sql`
  - cross-project 参照不整合（Invoice⇔Estimate/Milestone、PO Line⇔Expense、TimeEntry/Lines⇔Task）の検出
  - 見積/請求/発注の明細合計 vs header total の不一致検出
  - 主要テーブルの件数/プロジェクト別合計の出力
- docs 追記: `docs/requirements/migration-poc.md`

Refs #533
