### PR TITLE
docs(plan): #558/#559 の完了反映

### DIFF
--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -67,6 +67,6 @@ Phase 3 のPoC計画と最小実装を完了し、次はPoC評価と本実装計
 - [ ] S3/OSS 移行の時期を決定（`docs/requirements/backup-restore.md`）
 - [ ] PO→ERP4 実データ移行 リハーサル（1回目）（#543）
 - [ ] design-system 依存を `@itdojp/design-system@1.0.0` へ戻す（GitHub Packages 配布復旧後）（#547）
-- [ ] Push通知の実配信（WebPush）（#558）
-- [ ] Slack/Webhook 通知（stub解消、SSRF対策）（#559）
+- [x] Push通知の実配信（WebPush）（#558）
+- [x] Slack/Webhook 通知（stub解消、SSRF対策）（#559）
 - [ ] 添付AVスキャン（要否判断/方式決定）（#560）

--- a/docs/plan/todo.md
+++ b/docs/plan/todo.md
@@ -23,8 +23,8 @@
   - [x] FE: PDFファイル閲覧導線（/pdf-files/:filename）
   - [x] FE: Pushテスト送信UI（/push-notifications/test）
 - [ ] 未実装項目の解消（優先度D: 実配信/外部連携）
-  - [ ] #558 BE: Push通知の実配信（/push-notifications/test の stub 解消）
-  - [ ] #559 BE: Slack/Webhook通知の実装（notifier の stub 解消、優先度低）
+  - [x] #558 BE: Push通知の実配信（/push-notifications/test の stub 解消）
+  - [x] #559 BE: Slack/Webhook通知の実装（notifier の stub 解消、優先度低）
   - [ ] #560 BE: 添付AVスキャンの実運用（stub/eicar からの移行、要否判断）
   - [x] FE: SCIM 設定/状態のUI（/scim/status）
 


### PR DESCRIPTION
## 概要
PR#563/#562 マージ後の現状に合わせ、`docs/plan/todo.md` と `docs/plan/roadmap.md` のチェックボックスを消し込みます。

## 変更点
- `docs/plan/todo.md`: #558/#559 を完了（[x]）へ更新
- `docs/plan/roadmap.md`: #558/#559 を完了（[x]）へ更新
