### PR TITLE
docs: reflect #560 progress in TODO

### DIFF
--- a/docs/plan/todo.md
+++ b/docs/plan/todo.md
@@ -27,8 +27,11 @@
   - [x] #559 BE: Slack/Webhook通知の実装（notifier の stub 解消、優先度低）
   - [ ] #560 BE: 添付AVスキャンの実運用（要否判断/方式決定）
     - [x] ClamAV/clamd オプション（`CHAT_ATTACHMENT_AV_PROVIDER=clamav`）の実装（PR #565）
+    - [x] 運用設計（叩き台）を docs に追加（PR #566）
+    - [x] Podman で clamd を起動/停止/疎通できる補助スクリプトを追加（PR #567）
+    - [x] readiness 改善（PING/PONG）+ 統合スモーク + テスト結果記録（PR #568）
     - [ ] 本番での有効化方針（`disabled` 継続 or `clamav`）の決定
-    - [ ] 定義更新/監視/障害時の運用方針の決定（`docs/requirements/chat-attachments-antivirus.md`）
+    - [ ] 定義更新/監視/障害時の運用方針の最終決定（`docs/requirements/chat-attachments-antivirus.md`）
   - [x] FE: SCIM 設定/状態のUI（/scim/status）
 
 ## 次アクション（プロジェクト運用/レポート）

--- a/scripts/smoke-chat-attachments-av.sh
+++ b/scripts/smoke-chat-attachments-av.sh
@@ -223,7 +223,7 @@ if [[ "$code" != "422" ]]; then
   cat "$body_file" >&2 || true
   exit 1
 fi
-err_code=$(cat "$body_file" | python -c 'import json,sys; print(json.load(sys.stdin).get("error", {}).get("code",""))' || true)
+err_code=$(cat "$body_file" | json_get "error.code" || true)
 echo "error_code=$err_code"
 
 echo "stop clamd and expect 503"


### PR DESCRIPTION
Refs #560

## 変更内容
- `docs/plan/todo.md` の #560 を現状（PR #565-#568）に合わせて詳細化
- `scripts/smoke-chat-attachments-av.sh` の JSON 解析を `json_get` に統一
