### PR TITLE
refactor(projects): extract task dependency graph helpers

### DIFF
--- a/packages/backend/src/routes/projects.ts
+++ b/packages/backend/src/routes/projects.ts
@@ -22,6 +22,13 @@ import { logReassignment } from '../services/reassignmentLog.js';
 import { parseDueDateRule } from '../services/dueDateRule.js';
 import { toNumber } from '../services/utils.js';
 import { findPeriodLock, toPeriodKey } from '../services/periodLock.js';
+import {
+  addTaskDependency,
+  buildTaskDependencyGraph,
+  hasTaskDependencyPath,
+  normalizeParentId,
+  removeTaskDependency,
+} from '../services/taskDependencyGraph.js';
 import { DocStatusValue, TimeStatusValue } from '../types.js';
 
 type RecurringFrequency = 'monthly' | 'quarterly' | 'semiannual' | 'annual';
@@ -123,72 +130,6 @@ async function hasCircularParent(taskId: string, parentTaskId: string) {
     currentId = current.parentTaskId;
   }
   return false;
-}
-
-type TaskDependencyEdge = { fromTaskId: string; toTaskId: string };
-
-function buildTaskDependencyGraph(edges: TaskDependencyEdge[]) {
-  const graph = new Map<string, Set<string>>();
-  for (const edge of edges) {
-    const next = graph.get(edge.fromTaskId) ?? new Set<string>();
-    next.add(edge.toTaskId);
-    graph.set(edge.fromTaskId, next);
-  }
-  return graph;
-}
-
-function removeTaskDependency(
-  graph: Map<string, Set<string>>,
-  fromTaskId: string,
-  toTaskId: string,
-) {
-  const next = graph.get(fromTaskId);
-  if (!next) return;
-  next.delete(toTaskId);
-  if (next.size === 0) {
-    graph.delete(fromTaskId);
-  }
-}
-
-function addTaskDependency(
-  graph: Map<string, Set<string>>,
-  fromTaskId: string,
-  toTaskId: string,
-) {
-  const next = graph.get(fromTaskId) ?? new Set<string>();
-  next.add(toTaskId);
-  graph.set(fromTaskId, next);
-}
-
-function hasTaskDependencyPath(
-  graph: Map<string, Set<string>>,
-  startId: string,
-  targetId: string,
-) {
-  if (startId === targetId) return true;
-  const visited = new Set<string>();
-  const stack = [startId];
-  while (stack.length) {
-    const current = stack.pop();
-    if (!current) continue;
-    if (current === targetId) return true;
-    if (visited.has(current)) continue;
-    visited.add(current);
-    const next = graph.get(current);
-    if (!next) continue;
-    for (const neighbor of next) {
-      if (!visited.has(neighbor)) {
-        stack.push(neighbor);
-      }
-    }
-  }
-  return false;
-}
-
-function normalizeParentId(value: unknown): string | null {
-  if (value === null || value === undefined) return null;
-  const trimmed = String(value).trim();
-  return trimmed.length > 0 ? trimmed : null;
 }
 
 async function hasCircularProjectParent(projectId: string, parentId: string) {

--- a/packages/backend/src/services/taskDependencyGraph.ts
+++ b/packages/backend/src/services/taskDependencyGraph.ts
@@ -1,0 +1,65 @@
+export type TaskDependencyEdge = { fromTaskId: string; toTaskId: string };
+
+export function buildTaskDependencyGraph(edges: TaskDependencyEdge[]) {
+  const graph = new Map<string, Set<string>>();
+  for (const edge of edges) {
+    const next = graph.get(edge.fromTaskId) ?? new Set<string>();
+    next.add(edge.toTaskId);
+    graph.set(edge.fromTaskId, next);
+  }
+  return graph;
+}
+
+export function removeTaskDependency(
+  graph: Map<string, Set<string>>,
+  fromTaskId: string,
+  toTaskId: string,
+) {
+  const next = graph.get(fromTaskId);
+  if (!next) return;
+  next.delete(toTaskId);
+  if (next.size === 0) {
+    graph.delete(fromTaskId);
+  }
+}
+
+export function addTaskDependency(
+  graph: Map<string, Set<string>>,
+  fromTaskId: string,
+  toTaskId: string,
+) {
+  const next = graph.get(fromTaskId) ?? new Set<string>();
+  next.add(toTaskId);
+  graph.set(fromTaskId, next);
+}
+
+export function hasTaskDependencyPath(
+  graph: Map<string, Set<string>>,
+  startId: string,
+  targetId: string,
+) {
+  if (startId === targetId) return true;
+  const visited = new Set<string>();
+  const stack = [startId];
+  while (stack.length) {
+    const current = stack.pop();
+    if (!current) continue;
+    if (current === targetId) return true;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    const next = graph.get(current);
+    if (!next) continue;
+    for (const neighbor of next) {
+      if (!visited.has(neighbor)) {
+        stack.push(neighbor);
+      }
+    }
+  }
+  return false;
+}
+
+export function normalizeParentId(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  const trimmed = String(value).trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/packages/backend/test/taskDependencyGraph.test.js
+++ b/packages/backend/test/taskDependencyGraph.test.js
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  addTaskDependency,
+  buildTaskDependencyGraph,
+  hasTaskDependencyPath,
+  normalizeParentId,
+  removeTaskDependency,
+} from '../dist/services/taskDependencyGraph.js';
+
+test('task dependency graph: reachability', () => {
+  const graph = buildTaskDependencyGraph([
+    { fromTaskId: 'a', toTaskId: 'b' },
+    { fromTaskId: 'b', toTaskId: 'c' },
+  ]);
+  assert.equal(hasTaskDependencyPath(graph, 'a', 'c'), true);
+  assert.equal(hasTaskDependencyPath(graph, 'c', 'a'), false);
+});
+
+test('task dependency graph: add/remove edges', () => {
+  const graph = buildTaskDependencyGraph([]);
+  assert.equal(hasTaskDependencyPath(graph, 'a', 'b'), false);
+
+  addTaskDependency(graph, 'a', 'b');
+  assert.equal(hasTaskDependencyPath(graph, 'a', 'b'), true);
+  assert.equal(hasTaskDependencyPath(graph, 'b', 'a'), false);
+
+  removeTaskDependency(graph, 'a', 'b');
+  assert.equal(hasTaskDependencyPath(graph, 'a', 'b'), false);
+});
+
+test('normalizeParentId: trims and converts to null', () => {
+  assert.equal(normalizeParentId(undefined), null);
+  assert.equal(normalizeParentId(null), null);
+  assert.equal(normalizeParentId(''), null);
+  assert.equal(normalizeParentId('   '), null);
+  assert.equal(normalizeParentId(' x '), 'x');
+});
+


### PR DESCRIPTION
## 対応Issue
- #576

## 変更概要
- `packages/backend/src/routes/projects.ts` からタスク依存グラフ関連の純粋関数を抽出
  - 新規: `packages/backend/src/services/taskDependencyGraph.ts`
  - ルートは I/O と DTO に寄せ、ロジックは services に集約
- 既存挙動の固定（characterization）として unit test を追加
  - `packages/backend/test/taskDependencyGraph.test.js`

## 互換性/影響
- エンドポイント/レスポンス形式の変更なし（関数の移動のみ）

## テスト
- `make lint format-check typecheck test`
