### PR TITLE
refactor(migration): extract csv/id helpers for PO import

### DIFF
--- a/packages/backend/src/migration/csv.ts
+++ b/packages/backend/src/migration/csv.ts
@@ -1,0 +1,63 @@
+export function parseCsvRaw(value: string): string[][] {
+  const rows: string[][] = [];
+  let currentRow: string[] = [];
+  let currentField = '';
+  let inQuotes = false;
+
+  const input = value.replace(/^\uFEFF/, '');
+  for (let idx = 0; idx < input.length; idx += 1) {
+    const ch = input[idx];
+    if (inQuotes) {
+      if (ch === '"') {
+        const next = input[idx + 1];
+        if (next === '"') {
+          currentField += '"';
+          idx += 1;
+          continue;
+        }
+        inQuotes = false;
+        continue;
+      }
+      currentField += ch;
+      continue;
+    }
+
+    if (ch === '"') {
+      inQuotes = true;
+      continue;
+    }
+    if (ch === ',') {
+      currentRow.push(currentField);
+      currentField = '';
+      continue;
+    }
+    if (ch === '\n' || ch === '\r') {
+      if (ch === '\r' && input[idx + 1] === '\n') idx += 1;
+      currentRow.push(currentField);
+      currentField = '';
+      const isEmptyRow = currentRow.every((cell) => !cell.trim());
+      if (!isEmptyRow) rows.push(currentRow);
+      currentRow = [];
+      continue;
+    }
+    currentField += ch;
+  }
+
+  currentRow.push(currentField);
+  if (!currentRow.every((cell) => !cell.trim())) rows.push(currentRow);
+  return rows;
+}
+
+export function normalizeCsvCell(value: string | undefined): string | null {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function parseCsvBoolean(value: string | null): boolean | undefined {
+  if (value == null) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'y'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'n'].includes(normalized)) return false;
+  return undefined;
+}

--- a/packages/backend/src/migration/legacyIds.ts
+++ b/packages/backend/src/migration/legacyIds.ts
@@ -1,0 +1,37 @@
+import crypto from 'node:crypto';
+
+export const PO_MIGRATION_NAMESPACE_UUID =
+  '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+
+function uuidToBytes(uuid: string): Buffer {
+  const hex = uuid.replace(/-/g, '');
+  if (!/^[0-9a-fA-F]{32}$/.test(hex)) {
+    throw new Error(`invalid uuid: ${uuid}`);
+  }
+  return Buffer.from(hex, 'hex');
+}
+
+function bytesToUuid(bytes: Buffer): string {
+  const hex = bytes.toString('hex');
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20),
+  ].join('-');
+}
+
+function uuidv5(name: string, namespaceUuid: string): string {
+  const namespace = uuidToBytes(namespaceUuid);
+  const input = Buffer.concat([namespace, Buffer.from(name, 'utf8')]);
+  const hash = crypto.createHash('sha1').update(input).digest();
+  const bytes = Buffer.from(hash.subarray(0, 16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  return bytesToUuid(bytes);
+}
+
+export function makePoMigrationId(kind: string, legacyId: string) {
+  return uuidv5(`erp4:po:${kind}:${legacyId}`, PO_MIGRATION_NAMESPACE_UUID);
+}

--- a/packages/backend/test/migrationCsv.test.js
+++ b/packages/backend/test/migrationCsv.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseCsvBoolean, parseCsvRaw } from '../dist/migration/csv.js';
+
+test('parseCsvRaw: basic csv', () => {
+  assert.deepEqual(parseCsvRaw('a,b\nc,d\n'), [
+    ['a', 'b'],
+    ['c', 'd'],
+  ]);
+});
+
+test('parseCsvRaw: quoted fields and escaped quotes', () => {
+  assert.deepEqual(parseCsvRaw('"a,1","b""2"\n"x","y"\n'), [
+    ['a,1', 'b"2'],
+    ['x', 'y'],
+  ]);
+});
+
+test('parseCsvRaw: supports CRLF and skips empty rows', () => {
+  assert.deepEqual(parseCsvRaw('a,b\r\n\r\nc,d\r\n'), [
+    ['a', 'b'],
+    ['c', 'd'],
+  ]);
+});
+
+test('parseCsvRaw: strips UTF-8 BOM', () => {
+  const bom = '\uFEFF';
+  assert.deepEqual(parseCsvRaw(`${bom}a,b\nc,d\n`), [
+    ['a', 'b'],
+    ['c', 'd'],
+  ]);
+});
+
+test('parseCsvBoolean: parses common values', () => {
+  assert.equal(parseCsvBoolean(null), undefined);
+  assert.equal(parseCsvBoolean(''), undefined);
+  assert.equal(parseCsvBoolean('1'), true);
+  assert.equal(parseCsvBoolean('true'), true);
+  assert.equal(parseCsvBoolean('yes'), true);
+  assert.equal(parseCsvBoolean('0'), false);
+  assert.equal(parseCsvBoolean('false'), false);
+  assert.equal(parseCsvBoolean('no'), false);
+  assert.equal(parseCsvBoolean('unknown'), undefined);
+});
+

--- a/packages/backend/test/migrationLegacyIds.test.js
+++ b/packages/backend/test/migrationLegacyIds.test.js
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { makePoMigrationId } from '../dist/migration/legacyIds.js';
+
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+test('makePoMigrationId: deterministic and valid uuid', () => {
+  const first = makePoMigrationId('customer', '123');
+  const second = makePoMigrationId('customer', '123');
+  assert.match(first, uuidPattern);
+  assert.equal(first, second);
+});
+
+test('makePoMigrationId: kind is part of the name', () => {
+  const a = makePoMigrationId('customer', '123');
+  const b = makePoMigrationId('vendor', '123');
+  assert.notEqual(a, b);
+});
+
+test('makePoMigrationId: legacyId affects output', () => {
+  const a = makePoMigrationId('customer', '123');
+  const b = makePoMigrationId('customer', '124');
+  assert.notEqual(a, b);
+});
+


### PR DESCRIPTION
Issue: #576

## 概要
POデータ移行スクリプト（`scripts/migrate-po.ts`）に内包されていた CSV パーサ/ID生成（UUIDv5）を、バックエンド側の再利用可能なモジュールへ抽出しました。

## 変更点
- `packages/backend/src/migration/csv.ts` を追加（`parseCsvRaw` / `normalizeCsvCell` / `parseCsvBoolean`）
- `packages/backend/src/migration/legacyIds.ts` を追加（`makePoMigrationId`、namespace 定数）
- `scripts/migrate-po.ts` から上記実装を削除し、dist 経由で import するように変更
- unit test 追加
  - `packages/backend/test/migrationCsv.test.js`
  - `packages/backend/test/migrationLegacyIds.test.js`

## 動作確認
- `make lint format-check typecheck test`
- `npx --prefix packages/backend ts-node --project packages/backend/tsconfig.json scripts/migrate-po.ts --help`

## 補足
- `scripts/migrate-po.ts` は既存と同様に `packages/backend/dist` を参照します（ts-node実行時の型は `@ts-expect-error` で抑止）。
