### PR TITLE
ops(dr): DR plan + restore verification

### DIFF
--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -2,6 +2,7 @@
 
 ## 入口
 詳細は `docs/requirements/backup-restore.md` を参照。
+DR計画（RTO/RPO/復元演習）は `docs/ops/dr-plan.md` を参照。
 
 ## PoC/検証（Podman DB）
 `scripts/podman-poc.sh` にバックアップ/リストア手順が実装済み。

--- a/docs/ops/dr-plan.md
+++ b/docs/ops/dr-plan.md
@@ -1,0 +1,66 @@
+# DR計画（RTO/RPO）と復元演習
+
+## 目的
+バックアップが存在しても「復元できる」保証が無いと運用上の価値が低い。
+本ドキュメントでは、暫定の RTO/RPO と、復元手順/演習を定義する。
+
+## 対象（復旧対象）
+### 最小（必須）
+- PostgreSQL（業務データ）
+
+### 追加（環境により）
+- 添付ファイル（チャット添付等）
+  - 現時点では、検証環境はローカル保存、将来は S3/Google Drive 等へ移行する可能性がある
+- 設定/シークレット
+  - `DATABASE_URL`、JWT/認証設定、Push通知鍵（VAPID）、メール設定、暗号鍵（GPG等）
+
+## RTO/RPO（暫定推奨値）
+最終値は業務要件（再入力コスト、法令/監査、月次締め等）に基づき確定する必要がある。
+ここでは、初期運用を前提に暫定値を置く。
+
+### 重要データ（例: 工数/経費/請求/承認）
+- RPO: **1時間**
+- RTO: **4時間**
+
+### 通常データ（例: ログ/一部の補助データ）
+- RPO: **24時間**
+- RTO: **24時間**
+
+## バックアップ方式（現状）
+### 検証環境（Podman）
+- `scripts/podman-poc.sh backup` / `restore` を使用する（`docs/ops/backup-restore.md`）
+
+### 本番相当（ホスト上のPostgreSQLを想定）
+- `scripts/backup-prod.sh` を使用する
+  - ローカル保存（`BACKUP_DIR`）
+  - 別ホスト退避（`REMOTE_HOST` 等）
+  - 暗号化（`GPG_RECIPIENT` 等）
+  - S3は未提供の前提でも運用可能（S3関連は後続）
+
+設定例は `docs/requirements/backup-restore.env.example` を参照。
+
+## 復元手順（最小）
+### 検証環境（Podman）
+1. バックアップ取得（source）
+2. 別コンテナへリストア（verify）
+3. 整合性チェック実行
+
+復元検証スクリプト:
+- `scripts/restore-verify.sh`
+
+### 本番相当（注意）
+本番DBへのリストアは破壊的操作になり得るため、原則として「専用の復旧環境」で実施する。
+本番環境への直接復元は、影響範囲・切り戻し・個人情報の扱いを含めて判断する。
+
+## 復元演習（定期）
+### 方針（暫定）
+- まずは **週1回**（検証環境）で実施し、所要時間/失敗要因を記録する
+- 本番相当は、実行環境が用意できた時点で定期化（nightly/weekly）
+
+### 記録（テンプレ）
+- `docs/test-results/dr-restore-template.md` をコピーし、`docs/test-results/YYYY-MM-DD-dr-restore.md` として保存する
+
+## 関連
+- バックアップ/リストア（Runbook）: `docs/ops/backup-restore.md`
+- 障害対応: `docs/ops/incident-response.md`
+

--- a/docs/ops/index.md
+++ b/docs/ops/index.md
@@ -10,6 +10,7 @@
 
 ### バックアップ/リストア
 - [backup-restore](backup-restore.md)
+  - DR計画（RTO/RPO/復元演習）: [dr-plan](dr-plan.md)
   - 詳細: [docs/requirements/backup-restore.md](../requirements/backup-restore.md)
 
 ### 移行（Project-Open → ERP4）

--- a/docs/ops/release-strategy.md
+++ b/docs/ops/release-strategy.md
@@ -64,7 +64,7 @@ git push origin vX.Y.Z
 - 原則: **DB を戻さずに前方互換（expand/contract）** を目指す
 - 破壊的変更やデータ補正を伴う場合は、バックアップからのリストアを含めて判断する
   - バックアップ/リストア: `docs/ops/backup-restore.md`
-  - DR計画（RTO/RPO）は後続（Issue #590）
+  - DR計画（RTO/RPO/復元演習）: `docs/ops/dr-plan.md`
 
 ## 関連
 - チェックリスト（短縮版）: `docs/ops/release-checklist.md`

--- a/docs/test-results/dr-restore-template.md
+++ b/docs/test-results/dr-restore-template.md
@@ -1,0 +1,39 @@
+# DR復元演習 結果テンプレート
+
+## 実施情報
+- 実施日: YYYY-MM-DD
+- 環境: PoC / 検証 / 本番相当
+- 実施者:
+- 対象: DB / 添付 / 設定（該当するもの）
+
+## RTO/RPO（当該演習の前提）
+- RPO:
+- RTO:
+
+## バックアップ
+- バックアップ取得方法: `scripts/podman-poc.sh backup` / `scripts/backup-prod.sh backup`
+- 退避先: ローカル / 別ホスト / （S3は後続）
+- 暗号化: あり / なし（方式）
+- バックアップファイル:
+  - DB:
+  - globals:
+  - assets（該当時）:
+
+## リストア
+- 手順/コマンド:
+- 実行ログ:
+  - ファイル: （例: `tmp/erp4-dr-verify-YYYYMMDD-HHMMSS.log`）
+- 所要時間:
+  - リストア開始〜完了:
+  - 整合性チェック完了:
+
+## 検証（チェック項目）
+- `scripts/podman-poc.sh check`:
+- 追加検証（任意）:
+
+## 結果
+- 成功/失敗:
+- 失敗時の原因:
+- 改善点（Issue化）:
+  - #
+

--- a/scripts/restore-verify.sh
+++ b/scripts/restore-verify.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+SOURCE_CONTAINER_NAME="${SOURCE_CONTAINER_NAME:-erp4-pg-poc}"
+SOURCE_HOST_PORT="${SOURCE_HOST_PORT:-55432}"
+
+VERIFY_CONTAINER_NAME="${VERIFY_CONTAINER_NAME:-erp4-pg-dr-verify}"
+VERIFY_HOST_PORT="${VERIFY_HOST_PORT:-55433}"
+
+BACKUP_DIR="${BACKUP_DIR:-$ROOT_DIR/tmp/erp4-backups}"
+BACKUP_PREFIX="${BACKUP_PREFIX:-erp4}"
+BACKUP_TIMESTAMP="${BACKUP_TIMESTAMP:-$(date +%Y%m%d-%H%M%S)}"
+
+KEEP_VERIFY_CONTAINER="${KEEP_VERIFY_CONTAINER:-0}"
+LOG_FILE="${LOG_FILE:-$ROOT_DIR/tmp/erp4-dr-verify-${BACKUP_TIMESTAMP}.log}"
+
+usage() {
+  cat <<USAGE
+Usage: $0
+
+This script performs a restore verification on Podman by:
+  1) creating a backup from SOURCE_CONTAINER_NAME
+  2) restoring into VERIFY_CONTAINER_NAME (separate container)
+  3) running integrity checks
+
+Optional env:
+  SOURCE_CONTAINER_NAME, SOURCE_HOST_PORT
+  VERIFY_CONTAINER_NAME, VERIFY_HOST_PORT
+  BACKUP_DIR, BACKUP_PREFIX, BACKUP_TIMESTAMP
+  LOG_FILE
+  KEEP_VERIFY_CONTAINER=1 (do not stop/remove verify container)
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+echo "[restore-verify] started: $(date -Is)"
+echo "[restore-verify] source container: ${SOURCE_CONTAINER_NAME} (port ${SOURCE_HOST_PORT})"
+echo "[restore-verify] verify container: ${VERIFY_CONTAINER_NAME} (port ${VERIFY_HOST_PORT})"
+echo "[restore-verify] backup dir: ${BACKUP_DIR}"
+echo "[restore-verify] backup prefix: ${BACKUP_PREFIX}"
+echo "[restore-verify] backup timestamp: ${BACKUP_TIMESTAMP}"
+echo "[restore-verify] log file: ${LOG_FILE}"
+
+START_EPOCH="$(date +%s)"
+
+backup_file="${BACKUP_DIR}/${BACKUP_PREFIX}-backup-${BACKUP_TIMESTAMP}.sql"
+globals_file="${BACKUP_DIR}/${BACKUP_PREFIX}-globals-${BACKUP_TIMESTAMP}.sql"
+
+echo "[1/4] create backup from source"
+CONTAINER_NAME="$SOURCE_CONTAINER_NAME" \
+  HOST_PORT="$SOURCE_HOST_PORT" \
+  BACKUP_DIR="$BACKUP_DIR" \
+  BACKUP_PREFIX="$BACKUP_PREFIX" \
+  BACKUP_TIMESTAMP="$BACKUP_TIMESTAMP" \
+  "$ROOT_DIR/scripts/podman-poc.sh" backup
+
+if [[ ! -s "$backup_file" ]]; then
+  echo "[restore-verify] backup file is missing or empty: $backup_file" >&2
+  exit 1
+fi
+if [[ ! -s "$globals_file" ]]; then
+  echo "[restore-verify] globals file is missing or empty: $globals_file" >&2
+  exit 1
+fi
+
+echo "[2/4] reset verify container"
+CONTAINER_NAME="$VERIFY_CONTAINER_NAME" \
+  HOST_PORT="$VERIFY_HOST_PORT" \
+  "$ROOT_DIR/scripts/podman-poc.sh" stop || true
+
+echo "[3/4] restore into verify container"
+CONTAINER_NAME="$VERIFY_CONTAINER_NAME" \
+  HOST_PORT="$VERIFY_HOST_PORT" \
+  BACKUP_FILE="$backup_file" \
+  BACKUP_GLOBALS_FILE="$globals_file" \
+  BACKUP_DIR="$BACKUP_DIR" \
+  BACKUP_PREFIX="$BACKUP_PREFIX" \
+  RESTORE_CONFIRM=1 \
+  RESTORE_CLEAN=1 \
+  "$ROOT_DIR/scripts/podman-poc.sh" restore
+
+echo "[4/4] run integrity checks"
+CONTAINER_NAME="$VERIFY_CONTAINER_NAME" \
+  HOST_PORT="$VERIFY_HOST_PORT" \
+  "$ROOT_DIR/scripts/podman-poc.sh" check
+
+END_EPOCH="$(date +%s)"
+DURATION="$((END_EPOCH - START_EPOCH))"
+echo "[restore-verify] success (duration: ${DURATION}s)"
+
+if [[ "$KEEP_VERIFY_CONTAINER" == "1" ]]; then
+  echo "[restore-verify] KEEP_VERIFY_CONTAINER=1; leaving verify container running"
+else
+  CONTAINER_NAME="$VERIFY_CONTAINER_NAME" \
+    HOST_PORT="$VERIFY_HOST_PORT" \
+    "$ROOT_DIR/scripts/podman-poc.sh" stop
+fi
+
+echo "[restore-verify] completed: $(date -Is)"
+


### PR DESCRIPTION
Issue #590 対応。

## 変更内容
- DR計画（RTO/RPO/復元対象/演習運用）を追加: `docs/ops/dr-plan.md`
- Podman向けの復元検証スクリプトを追加: `scripts/restore-verify.sh`
  - source DB からバックアップ取得 → 別コンテナへリストア → 整合性チェック
  - 実行ログを `tmp/` に保存
- 復元演習の結果記録テンプレを追加: `docs/test-results/dr-restore-template.md`
- `docs/ops/index.md` / `docs/ops/backup-restore.md` / `docs/ops/release-strategy.md` の導線を更新

## 補足
- 定期実行（weekly/nightly）は実行環境に依存するため、本PRは「手順の成立」と「記録テンプレ」を優先しています。
