### PR TITLE
perf(ops): regression policy + CI bench

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,59 @@
+name: Performance
+
+on:
+  workflow_dispatch:
+    inputs:
+      runLabel:
+        description: "Label for this run (stored in artifacts)"
+        required: false
+        default: "manual"
+  schedule:
+    - cron: "0 19 * * 1"
+
+jobs:
+  api-bench:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y postgresql-client
+      - name: Run api bench
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres?schema=public
+          OUT_DIR: tmp/perf-ci
+          RUN_LABEL: ${{ inputs.runLabel || 'scheduled' }}
+        run: ./scripts/perf/run-api-bench-ci.sh
+      - name: Compare with baseline (non-blocking)
+        continue-on-error: true
+        run: |
+          if [[ -f docs/performance/perf-baseline.json ]]; then
+            node ./scripts/perf/compare-api-bench.mjs --base docs/performance/perf-baseline.json --next tmp/perf-ci/result.json
+          else
+            echo "baseline not found; skipping comparison"
+          fi
+      - name: Upload perf artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-api-bench-${{ github.run_id }}
+          path: tmp/perf-ci/*
+          if-no-files-found: error
+          retention-days: 90
+

--- a/docs/ops/index.md
+++ b/docs/ops/index.md
@@ -44,4 +44,5 @@
 
 ### 性能
 - ベースライン（再計測手順）: [docs/performance/performance-baseline.md](../performance/performance-baseline.md)
+- 退行検知ポリシー: [docs/performance/perf-regression-policy.md](../performance/perf-regression-policy.md)
 - 計測結果: [docs/test-results/README.md](../test-results/README.md)

--- a/docs/performance/perf-regression-policy.md
+++ b/docs/performance/perf-regression-policy.md
@@ -1,0 +1,48 @@
+# 性能退行検知（運用ポリシー）
+
+## 目的
+- 性能改善を一過性にせず、退行（遅くなる変更）を継続的に検知する
+- PoC導線の主要APIに対して、比較可能な結果を残す
+
+## 対象シナリオ（暫定: 3本）
+PoC導線の代表として、以下を固定します。
+
+- `GET /projects`
+- `GET /reports/project-profit/:projectId`
+- `GET /reports/project-profit/:projectId/by-user`
+
+前提となる `projectId` は `00000000-0000-0000-0000-000000000001`（seed）を使用します。
+
+## 実行環境
+### ローカル（ベースライン作成）
+- Podman + PostgreSQL 15（既存の `scripts/perf/run-api-bench.sh`）
+- 結果は `docs/test-results/` に md として保存（コミットして履歴を残す）
+
+### CI（継続運用）
+- GitHub Actions で schedule / workflow_dispatch を実行
+- DB は service container（PostgreSQL 15）
+- 結果は artifact として保存（長期保存が必要なら、定期的に `docs/test-results/` へ取り込む）
+- workflow: `.github/workflows/perf.yml`
+
+## 結果フォーマット
+- JSON（機械可読）: `tmp/perf-ci/result.json`
+- Markdown（人間可読）: `tmp/perf-ci/result.md`
+
+## 暫定閾値（段階導入）
+以下を「退行候補」として扱います（暫定）。
+
+- `requests.average` が **20% 以上低下**
+- `latency.p99` が **25% 以上悪化**
+- `non2xx > 0` または `errors > 0` または `timeouts > 0`
+
+初期は「警告（ログ/Issue）」として運用し、安定後に CI fail（ブロック）へ移行します。
+
+## 運用フロー
+1. CI（またはローカル）で計測を実行し、結果を保存
+2. 退行候補が出た場合は、ローカル（Podman）で再現確認する
+3. 再現した場合は Issue 化し、原因調査（SQL/インデックス/実装差分）→対策を実施する
+
+## スクリプト
+- ローカル（Podman）: `scripts/perf/run-api-bench.sh`
+- CI互換: `scripts/perf/run-api-bench-ci.sh`
+- 比較: `scripts/perf/compare-api-bench.mjs`

--- a/docs/performance/performance-baseline.md
+++ b/docs/performance/performance-baseline.md
@@ -63,3 +63,5 @@ CONTAINER_NAME=erp4-pg-perf HOST_PORT=55434 ./scripts/podman-poc.sh stats-reset
 
 ## 計測結果
 計測結果は `docs/test-results/perf-YYYY-MM-DD.md` に残す。
+
+退行検知の運用ポリシー: `docs/performance/perf-regression-policy.md`

--- a/docs/test-results/README.md
+++ b/docs/test-results/README.md
@@ -5,6 +5,12 @@
 - 画面キャプチャなどの証跡は `docs/test-results/YYYY-MM-DD-*/` に保存する。
 
 ## 一覧
+### Performance
+- 入口: docs/test-results/perf/README.md
+
+### 2026-01-17
+- 性能ベースライン: docs/test-results/perf-2026-01-17.md
+
 ### 2026-01-16
 - チャット添付AV（ClamAV/clamd）: docs/test-results/2026-01-16-chat-attachments-av.md
 

--- a/docs/test-results/perf/README.md
+++ b/docs/test-results/perf/README.md
@@ -1,0 +1,9 @@
+# 性能計測結果（Performance）
+
+## 方針
+- 手動/ローカル計測の結果は `docs/test-results/` に md として残す（レビュー可能にする）
+- CI計測の結果は GitHub Actions artifact として保存し、必要に応じて md/json を取り込む
+
+## 関連ドキュメント
+- ベースライン（再計測手順）: `docs/performance/performance-baseline.md`
+- 退行検知ポリシー: `docs/performance/perf-regression-policy.md`

--- a/scripts/perf/compare-api-bench.mjs
+++ b/scripts/perf/compare-api-bench.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import process from 'node:process';
+
+function parseArgs(argv) {
+  const args = {
+    base: '',
+    next: '',
+    thresholdReqDrop: 0.2,
+    thresholdLatencyIncrease: 0.25,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const value = argv[i];
+    if (value === '--base') {
+      args.base = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (value === '--next') {
+      args.next = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (value === '--threshold-req-drop') {
+      args.thresholdReqDrop = Number(argv[i + 1]);
+      i += 1;
+      continue;
+    }
+    if (value === '--threshold-latency-increase') {
+      args.thresholdLatencyIncrease = Number(argv[i + 1]);
+      i += 1;
+      continue;
+    }
+    if (value === '--help' || value === '-h') {
+      args.help = true;
+    }
+  }
+  return args;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function pickNumber(obj, pathParts) {
+  let current = obj;
+  for (const part of pathParts) {
+    if (!current || typeof current !== 'object') return null;
+    current = current[part];
+  }
+  if (typeof current === 'number' && Number.isFinite(current)) return current;
+  return null;
+}
+
+function resolveReqAvg(autocannon) {
+  return (
+    pickNumber(autocannon, ['requests', 'average']) ??
+    pickNumber(autocannon, ['requests', 'mean'])
+  );
+}
+
+function resolveLatencyP99(autocannon) {
+  return (
+    pickNumber(autocannon, ['latency', 'p99']) ??
+    pickNumber(autocannon, ['latency', 'average'])
+  );
+}
+
+function formatPercent(value) {
+  return `${Math.round(value * 1000) / 10}%`;
+}
+
+function compareScenario(options) {
+  const base = options.base.autocannon || {};
+  const next = options.next.autocannon || {};
+
+  const baseReq = resolveReqAvg(base);
+  const nextReq = resolveReqAvg(next);
+  const baseLat = resolveLatencyP99(base);
+  const nextLat = resolveLatencyP99(next);
+
+  const non2xx = pickNumber(next, ['non2xx']) ?? 0;
+  const errors = pickNumber(next, ['errors']) ?? 0;
+  const timeouts = pickNumber(next, ['timeouts']) ?? 0;
+
+  const findings = [];
+
+  if (typeof baseReq === 'number' && typeof nextReq === 'number' && baseReq > 0) {
+    const drop = (baseReq - nextReq) / baseReq;
+    if (drop >= options.thresholdReqDrop) {
+      findings.push(
+        `requests.average drop ${formatPercent(drop)} (base=${baseReq}, next=${nextReq})`,
+      );
+    }
+  }
+
+  if (typeof baseLat === 'number' && typeof nextLat === 'number' && baseLat > 0) {
+    const increase = (nextLat - baseLat) / baseLat;
+    if (increase >= options.thresholdLatencyIncrease) {
+      findings.push(
+        `latency.p99 increase ${formatPercent(increase)} (base=${baseLat}, next=${nextLat})`,
+      );
+    }
+  }
+
+  if (non2xx > 0 || errors > 0 || timeouts > 0) {
+    findings.push(`non2xx/errors/timeouts detected (non2xx=${non2xx}, errors=${errors}, timeouts=${timeouts})`);
+  }
+
+  return { findings, baseReq, nextReq, baseLat, nextLat };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(
+      'Usage: node scripts/perf/compare-api-bench.mjs --base <file> --next <file> [--threshold-req-drop 0.2] [--threshold-latency-increase 0.25]',
+    );
+    process.exit(0);
+  }
+
+  if (!args.base || !args.next) {
+    console.error('Both --base and --next are required.');
+    process.exit(2);
+  }
+
+  const base = readJson(args.base);
+  const next = readJson(args.next);
+
+  const baseById = new Map((base.scenarios || []).map((s) => [s.id, s]));
+  const nextById = new Map((next.scenarios || []).map((s) => [s.id, s]));
+
+  const thresholdReqDrop =
+    Number.isFinite(args.thresholdReqDrop) && args.thresholdReqDrop >= 0
+      ? args.thresholdReqDrop
+      : 0.2;
+  const thresholdLatencyIncrease =
+    Number.isFinite(args.thresholdLatencyIncrease) &&
+    args.thresholdLatencyIncrease >= 0
+      ? args.thresholdLatencyIncrease
+      : 0.25;
+
+  const allIds = Array.from(
+    new Set([...baseById.keys(), ...nextById.keys()]),
+  ).sort();
+
+  const regressions = [];
+
+  for (const id of allIds) {
+    const baseScenario = baseById.get(id);
+    const nextScenario = nextById.get(id);
+    if (!baseScenario || !nextScenario) continue;
+    const compared = compareScenario({
+      base: baseScenario,
+      next: nextScenario,
+      thresholdReqDrop,
+      thresholdLatencyIncrease,
+    });
+    if (compared.findings.length) {
+      regressions.push({ id, findings: compared.findings });
+    }
+  }
+
+  if (!regressions.length) {
+    console.log('[perf] no regression detected');
+    process.exit(0);
+  }
+
+  console.log('[perf] regression candidates detected:');
+  for (const item of regressions) {
+    console.log(`- ${item.id}`);
+    for (const finding of item.findings) {
+      console.log(`  - ${finding}`);
+    }
+  }
+
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+

--- a/scripts/perf/run-api-bench-ci.mjs
+++ b/scripts/perf/run-api-bench-ci.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const DEFAULT_PROJECT_ID = '00000000-0000-0000-0000-000000000001';
+const DEFAULT_CONNECTIONS = 10;
+const DEFAULT_DURATION_SECONDS = 20;
+const AUTOCANNON_VERSION = '8.0.0';
+
+function parseArgs(argv) {
+  const args = {
+    baseUrl: 'http://localhost:3003',
+    projectId: DEFAULT_PROJECT_ID,
+    outJson: 'tmp/perf-ci/result.json',
+    outMd: 'tmp/perf-ci/result.md',
+    connections: DEFAULT_CONNECTIONS,
+    durationSeconds: DEFAULT_DURATION_SECONDS,
+    userId: 'perf-user',
+    roles: 'admin',
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const value = argv[i];
+    if (value === '--base-url') {
+      args.baseUrl = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (value === '--project-id') {
+      args.projectId = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (value === '--out-json') {
+      args.outJson = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (value === '--out-md') {
+      args.outMd = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (value === '--connections') {
+      args.connections = Number(argv[i + 1]);
+      i += 1;
+      continue;
+    }
+    if (value === '--duration') {
+      args.durationSeconds = Number(argv[i + 1]);
+      i += 1;
+      continue;
+    }
+    if (value === '--user-id') {
+      args.userId = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (value === '--roles') {
+      args.roles = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (value === '--help' || value === '-h') {
+      args.help = true;
+    }
+  }
+  return args;
+}
+
+function normalizeUrl(value) {
+  const trimmed = String(value || '').trim().replace(/\/+$/, '');
+  if (!trimmed) throw new Error('baseUrl is required');
+  return trimmed;
+}
+
+function pickNumber(obj, pathParts) {
+  let current = obj;
+  for (const part of pathParts) {
+    if (!current || typeof current !== 'object') return null;
+    current = current[part];
+  }
+  if (typeof current === 'number' && Number.isFinite(current)) return current;
+  return null;
+}
+
+async function runAutocannon(options) {
+  const headerArgs = [];
+  for (const header of options.headers) {
+    headerArgs.push('-H', header);
+  }
+  const args = [
+    '--yes',
+    `autocannon@${AUTOCANNON_VERSION}`,
+    '-j',
+    '-c',
+    String(options.connections),
+    '-d',
+    String(options.durationSeconds),
+    ...headerArgs,
+    options.url,
+  ];
+
+  const child = spawn('npx', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+
+  const exitCode = await new Promise((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', (code) => resolve(code ?? 1));
+  });
+
+  if (stderr.trim()) {
+    process.stderr.write(stderr);
+  }
+
+  if (exitCode !== 0) {
+    throw new Error(`autocannon failed: exit=${exitCode}`);
+  }
+
+  try {
+    return JSON.parse(stdout.trim());
+  } catch (err) {
+    throw new Error(`autocannon JSON parse failed: ${(err && err.message) || err}`);
+  }
+}
+
+function buildMarkdown(result) {
+  const lines = [];
+  const meta = result.meta || {};
+  lines.push(`# Performance (api-bench)`);
+  lines.push('');
+  lines.push(`- generatedAt: ${meta.generatedAt || ''}`);
+  lines.push(`- commit: ${meta.commit || ''}`);
+  lines.push(`- node: ${meta.node || ''}`);
+  lines.push(`- autocannon: ${meta.autocannon || ''}`);
+  lines.push(`- connections: ${meta.connections ?? ''}`);
+  lines.push(`- durationSeconds: ${meta.durationSeconds ?? ''}`);
+  lines.push('');
+  lines.push('| scenario | req/s(avg) | latency(avg,ms) | latency(p99,ms) | non2xx | errors | timeouts |');
+  lines.push('|---|---:|---:|---:|---:|---:|---:|');
+  for (const scenario of result.scenarios || []) {
+    const r = scenario.autocannon || {};
+    const reqAvg = pickNumber(r, ['requests', 'average']);
+    const latAvg = pickNumber(r, ['latency', 'average']);
+    const latP99 = pickNumber(r, ['latency', 'p99']);
+    const non2xx = pickNumber(r, ['non2xx']);
+    const errors = pickNumber(r, ['errors']);
+    const timeouts = pickNumber(r, ['timeouts']);
+    lines.push(
+      `| ${scenario.id} | ${reqAvg ?? ''} | ${latAvg ?? ''} | ${latP99 ?? ''} | ${non2xx ?? ''} | ${errors ?? ''} | ${timeouts ?? ''} |`,
+    );
+  }
+  lines.push('');
+  return lines.join('\n') + '\n';
+}
+
+async function resolveCommit() {
+  const fromEnv = process.env.GITHUB_SHA || process.env.COMMIT_SHA;
+  if (fromEnv) return fromEnv;
+  try {
+    const { execSync } = await import('node:child_process');
+    return execSync('git rev-parse HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString('utf8')
+      .trim();
+  } catch {
+    return '';
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(
+      'Usage: node scripts/perf/run-api-bench-ci.mjs [--base-url <url>] [--project-id <uuid>] [--out-json <path>] [--out-md <path>]',
+    );
+    process.exit(0);
+  }
+
+  const baseUrl = normalizeUrl(args.baseUrl);
+  const projectId = String(args.projectId || DEFAULT_PROJECT_ID).trim();
+
+  const connections =
+    Number.isFinite(args.connections) && args.connections > 0
+      ? Math.floor(args.connections)
+      : DEFAULT_CONNECTIONS;
+  const durationSeconds =
+    Number.isFinite(args.durationSeconds) && args.durationSeconds > 0
+      ? Math.floor(args.durationSeconds)
+      : DEFAULT_DURATION_SECONDS;
+
+  const headers = [
+    `x-user-id: ${String(args.userId || 'perf-user').trim()}`,
+    `x-roles: ${String(args.roles || 'admin').trim()}`,
+  ];
+
+  const scenarios = [
+    {
+      id: 'projects',
+      method: 'GET',
+      path: '/projects',
+      url: `${baseUrl}/projects`,
+    },
+    {
+      id: 'project_profit',
+      method: 'GET',
+      path: `/reports/project-profit/${projectId}`,
+      url: `${baseUrl}/reports/project-profit/${projectId}`,
+    },
+    {
+      id: 'project_profit_by_user',
+      method: 'GET',
+      path: `/reports/project-profit/${projectId}/by-user`,
+      url: `${baseUrl}/reports/project-profit/${projectId}/by-user`,
+    },
+  ];
+
+  const commit = await resolveCommit();
+  const generatedAt = new Date().toISOString();
+
+  const results = [];
+  for (const scenario of scenarios) {
+    const autocannon = await runAutocannon({
+      url: scenario.url,
+      headers,
+      connections,
+      durationSeconds,
+    });
+    results.push({ ...scenario, autocannon });
+  }
+
+  const payload = {
+    meta: {
+      generatedAt,
+      commit,
+      node: process.version,
+      autocannon: AUTOCANNON_VERSION,
+      connections,
+      durationSeconds,
+    },
+    scenarios: results,
+  };
+
+  const outJsonPath = path.resolve(args.outJson);
+  fs.mkdirSync(path.dirname(outJsonPath), { recursive: true });
+  fs.writeFileSync(outJsonPath, JSON.stringify(payload, null, 2) + '\n');
+
+  const outMdPath = path.resolve(args.outMd);
+  fs.mkdirSync(path.dirname(outMdPath), { recursive: true });
+  fs.writeFileSync(outMdPath, buildMarkdown(payload));
+
+  console.log(`[perf] wrote: ${args.outJson}`);
+  console.log(`[perf] wrote: ${args.outMd}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+

--- a/scripts/perf/run-api-bench-ci.sh
+++ b/scripts/perf/run-api-bench-ci.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/tmp/perf-ci}"
+BACKEND_PORT="${BACKEND_PORT:-3003}"
+PROJECT_ID="${PROJECT_ID:-00000000-0000-0000-0000-000000000001}"
+
+DATABASE_URL="${DATABASE_URL:?DATABASE_URL is required}"
+PSQL_URL="${DATABASE_URL%%\?*}"
+
+BACKEND_LOG="${OUT_DIR}/backend.log"
+
+mkdir -p "$OUT_DIR"
+
+cleanup() {
+  if [[ -n "${BACKEND_PID:-}" ]] && kill -0 "$BACKEND_PID" >/dev/null 2>&1; then
+    kill "$BACKEND_PID" || true
+  fi
+}
+trap cleanup EXIT
+
+echo "== Install backend deps =="
+npm ci --prefix "$ROOT_DIR/packages/backend" >/dev/null
+
+echo "== Prisma generate =="
+npx --prefix "$ROOT_DIR/packages/backend" prisma generate --schema="$ROOT_DIR/packages/backend/prisma/schema.prisma" >/dev/null
+
+echo "== Prisma migrate deploy =="
+npx --prefix "$ROOT_DIR/packages/backend" prisma migrate deploy --schema="$ROOT_DIR/packages/backend/prisma/schema.prisma" >/dev/null
+
+echo "== Seed demo =="
+psql "$PSQL_URL" -v ON_ERROR_STOP=1 -f "$ROOT_DIR/scripts/seed-demo.sql" >/dev/null
+
+echo "== Seed perf =="
+psql "$PSQL_URL" -v ON_ERROR_STOP=1 -f "$ROOT_DIR/scripts/perf/seed-perf.sql" >/dev/null
+
+echo "== Build backend =="
+npm run build --prefix "$ROOT_DIR/packages/backend" >/dev/null
+
+echo "== Start backend =="
+cleanup
+PORT="$BACKEND_PORT" AUTH_MODE=header DATABASE_URL="$DATABASE_URL" \
+  node "$ROOT_DIR/packages/backend/dist/index.js" >"$BACKEND_LOG" 2>&1 &
+BACKEND_PID=$!
+
+for _ in $(seq 1 40); do
+  if curl -sf "http://localhost:${BACKEND_PORT}/healthz" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+if ! curl -sf "http://localhost:${BACKEND_PORT}/healthz" >/dev/null 2>&1; then
+  echo "backend not ready"
+  echo "backend log tail:"
+  tail -n 200 "$BACKEND_LOG" || true
+  exit 1
+fi
+
+echo "== Bench =="
+node "$ROOT_DIR/scripts/perf/run-api-bench-ci.mjs" \
+  --base-url "http://localhost:${BACKEND_PORT}" \
+  --project-id "$PROJECT_ID" \
+  --out-json "${OUT_DIR}/result.json" \
+  --out-md "${OUT_DIR}/result.md"
+
+echo "== Done =="
+echo "- json: ${OUT_DIR}/result.json"
+echo "- md: ${OUT_DIR}/result.md"
+echo "- backend log: ${BACKEND_LOG}"
+


### PR DESCRIPTION
Closes #599

## 変更概要
- 性能退行検知ポリシーを追加: `docs/performance/perf-regression-policy.md`
- CIでの定期計測（schedule/workflow_dispatch）を追加: `.github/workflows/perf.yml`
- CI互換の計測/比較スクリプトを追加
  - `scripts/perf/run-api-bench-ci.sh`
  - `scripts/perf/run-api-bench-ci.mjs`
  - `scripts/perf/compare-api-bench.mjs`
- テスト結果インデックスを更新（perf ベースラインを追記）

## 方針
- CIの比較は当面 non-blocking（continue-on-error）で運用し、安定後に fail へ移行
- ローカル（Podman）計測は従来の `scripts/perf/run-api-bench.sh` を利用
