### PR TITLE
docs(security): clarify ClamAV definition updates

### DIFF
--- a/docs/ops/antivirus.md
+++ b/docs/ops/antivirus.md
@@ -10,3 +10,6 @@
 過去の検証結果:
 - `docs/test-results/2026-01-16-chat-attachments-av.md`
 
+## 定義更新（ClamAV）
+検証では `docker.io/clamav/clamav` が `freshclam` を同一コンテナ内で起動し、定義更新を行うことを確認しています。
+詳細は `docs/requirements/chat-attachments-antivirus.md` を参照。

--- a/docs/requirements/chat-attachments-antivirus.md
+++ b/docs/requirements/chat-attachments-antivirus.md
@@ -54,11 +54,14 @@
 
 ClamAV 定義更新は以下のいずれかを採用する前提で運用を確定する。
 
-- コンテナが自動更新する構成（イメージ/エントリポイントに依存）
+- コンテナ内の `freshclam` で自動更新する構成（イメージ/エントリポイントに依存）
 - 定期ジョブで `freshclam` を実行する構成（例: 日次）
 - 定期的にイメージを更新して入れ替える構成
 
-※ `clamav/clamav` イメージがどの方式かは、本ドキュメント作成時点では検証していません。採用前に検証環境で確認してください。
+検証メモ:
+- `docker.io/clamav/clamav:latest` は `clamd` と `freshclam --daemon` が同一コンテナで起動し、定義更新も実行されることを確認しました。
+  - 例: `podman exec erp4-clamav ps -eo pid,comm,args` で `freshclam --daemon` を確認
+  - 例: `podman logs erp4-clamav` に `ClamAV update process started` が出力されることを確認
 
 ### 監視/障害時
 


### PR DESCRIPTION
Closes #560

## 変更概要
- `clamav/clamav` イメージの定義更新方式（freshclam daemon 起動）を検証結果として明文化
- Runbook 側にも定義更新の注記を追記

## 検証
- `bash scripts/podman-clamav.sh start` → `podman exec erp4-clamav ps ...` で `freshclam --daemon` を確認
- `podman logs erp4-clamav` に定義更新ログが出ることを確認
