### PR TITLE
chore(ci): bump Node.js to 20.19.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 20.19.0
       - run: npm install
         working-directory: packages/backend
       - run: npx prisma generate --schema=./prisma/schema.prisma
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 20.19.0
       - run: npm install --prefix packages/frontend
       - run: npm run typecheck --prefix packages/frontend
       - run: npm run build --prefix packages/frontend
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 20.19.0
       - run: npm install --prefix packages/backend
       - run: npm run lint --prefix packages/backend
       - run: npm run format:check --prefix packages/backend
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 20.19.0
       - run: npm ci --prefix packages/backend
       - run: npm ci --prefix packages/frontend
       - name: Generate SBOM (CycloneDX)
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 20.19.0
       - run: npm install --prefix packages/backend
       - run: npm install --prefix packages/frontend
       - run: npx --prefix packages/backend ts-node --project packages/backend/tsconfig.json scripts/data-quality-check.ts || true
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 20.19.0
       - run: npm ci --prefix packages/backend
       - run: npm ci --prefix packages/frontend
       - run: sudo apt-get update
@@ -141,7 +141,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 20.19.0
       - run: npm ci --prefix packages/backend
       - run: npx --prefix packages/backend prisma generate --schema=packages/backend/prisma/schema.prisma
       - run: npm run build --prefix packages/backend

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20.19.0
       - run: sudo apt-get update
       - run: sudo apt-get install -y postgresql-client
       - name: Run api bench
@@ -56,4 +56,3 @@ jobs:
           path: tmp/perf-ci/*
           if-no-files-found: error
           retention-days: 90
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 20.19.0
       - name: Prepare metadata
         run: |
           echo "TAG=${{ inputs.tag }}" >> "$GITHUB_ENV"

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -33,7 +33,7 @@
 ### CI での生成（artifact）
 - workflow: `.github/workflows/ci.yml`
 - job: `security-audit`
-- 生成ツール: `@cyclonedx/cyclonedx-npm@2.1.0`（Node.js 18 互換）
+- 生成ツール: `@cyclonedx/cyclonedx-npm@2.1.0`（Node.js >=14）
 - 出力:
   - `tmp/sbom/backend.cdx.json`
   - `tmp/sbom/frontend.cdx.json`


### PR DESCRIPTION
Node.js 18 系の依存更新（Vite 7 / Prisma 7 など）が CI 上でブロックされているため、CI/Release/Perf の Node.js を 20.19.0 に更新します。

- 変更対象: `.github/workflows/ci.yml`, `.github/workflows/release.yml`, `.github/workflows/perf.yml`
- ドキュメント: `docs/security/supply-chain.md` の注記を Node.js 要件（>=14）に更新

目的:
- Dependabot PR #610（Vite 7）/#622（Prisma 7）等の解消
