### PR TITLE
docs: 依存関係更新の運用ルールを追加

### DIFF
--- a/docs/plan/todo.md
+++ b/docs/plan/todo.md
@@ -4,6 +4,7 @@
 - [ ] #544 S3 バケット/リージョン/KMS の確定値を `docs/requirements/backup-restore.md` に反映
 - [ ] #544 S3/OSS 移行の時期を決定（`docs/requirements/backup-restore.md`）
 - [ ] #547 GitHub Packages 配布復旧後に `@itdojp/design-system@1.0.0` へ依存を戻す（暫定: git tag 参照）
+- [ ] #650 依存関係更新の運用ルール整備（`docs/quality/dependency-update-policy.md`）
 
 ## 次アクション（未実装対応: FE/BE）
 - [x] #551 #552 未実装項目の解消（優先度A: 管理/監査UI）

--- a/docs/quality/dependency-update-policy.md
+++ b/docs/quality/dependency-update-policy.md
@@ -1,0 +1,47 @@
+# 依存関係更新の運用ルール
+
+## 目的
+依存関係の更新を「安全に・継続的に」実施するための基準を定める。
+
+## 適用範囲
+- Backend: `packages/backend`
+- Frontend: `packages/frontend`
+- CI/Workflow: `.github/workflows/*`
+
+## 分類
+- 種別: `runtime` / `dev`
+- 重大度: `patch` / `minor` / `major`
+- 影響: `低`（互換性維持が想定）/ `中` / `高`（破壊的変更）
+
+## 対応原則
+1. **小さく頻繁に**：patch/minor を優先して継続的に取り込む。
+2. **統合アップグレードが必要なものは分割しない**（例: Prisma CLI と Client）。
+3. **破壊的更新（major）は段階導入**：別Issueで設計/検証を行う。
+
+## 自動マージの基準（原則）
+以下を満たす場合は自動マージ対象とする。
+- GitHub Actions / CI ツールの `patch/minor`
+- `devDependencies` の `patch/minor`
+- すべての必須CIが成功
+
+※ 実際の自動化（bot/設定）は別Issueで導入する。
+
+## 手動レビューが必要なケース
+- `runtime` 依存の `minor/major`
+- Prisma/DB/認証/暗号化/ファイル処理など基盤系
+- セキュリティ修正を含む更新（差分確認と影響範囲の記録）
+
+## 運用フロー（標準）
+1. Dependabot PR を確認
+2. 変更影響の分類（上記の分類）
+3. CI 結果確認（`docs/quality/quality-gates.md` に準拠）
+4. 必要なら検証結果を `docs/test-results/` に記録
+5. マージ（必要に応じてロールバック手順を記載）
+
+## 例外
+- 重大な脆弱性は **即時対応**（緊急Issue作成→最短で対応）
+- CI が落ちる場合は **原因を明記**して保留し、別Issueに切り出す
+
+## 関連
+- `docs/quality/quality-gates.md`
+- Issue #650

--- a/docs/quality/quality-goals.md
+++ b/docs/quality/quality-goals.md
@@ -62,6 +62,7 @@ PoC導線の手動確認ドキュメントを、品質スコープの起点と�
 - 監査ログが「いつ/誰が/何を」行ったか追跡できる（閲覧/エクスポート含む）
 - 外部連携（Webhook等）で既知の危険（SSRF/過大payload等）を作らない
 - 重要運用（バックアップ/リストア/移行）の手順が docs にあり、検証結果が `docs/test-results/` に残る
+- 依存関係更新の運用ルールが明文化され、継続的に更新できる（`docs/quality/dependency-update-policy.md`）
 
 ### P2（改善: 体験/保守性）
 - UIの状態表現（loading/error/empty/disabled）が一貫している


### PR DESCRIPTION
## 概要
- 依存関係更新の運用ルールを新規作成
- 品質目標とTODOに追記

## 変更点
- docs/quality/dependency-update-policy.md を追加
- docs/quality/quality-goals.md に運用ルールを追記
- docs/plan/todo.md に #650 を追加

## 検証
- なし（ドキュメントのみ）

## 関連
- #650