### PR TITLE
chore: ignore local PO manuals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ packages/frontend/.env
 data/audit-exports
 pg_dump*.sql
 pg_dump*.sql:Zone.Identifier
+/PO_Manuals
+*:Zone.Identifier


### PR DESCRIPTION
PO_Manuals は社内マニュアルのため GitHub へアップ禁止。誤コミット防止のため .gitignore に /PO_Manuals と *:Zone.Identifier を追加します。\n\n- 変更: .gitignore\n- 影響: リポジトリ追跡外のローカルファイルのみ\n- 検証: なし（.gitignore 追加のみ）