### PR TITLE
feat: 日報UIの日付選択と履歴表示

### DIFF
--- a/packages/frontend/e2e/frontend-smoke.spec.ts
+++ b/packages/frontend/e2e/frontend-smoke.spec.ts
@@ -168,9 +168,10 @@ test('frontend smoke core @core', async ({ page }) => {
     .locator('h3', { hasText: '日報履歴' })
     .locator('..');
   await historySection
-    .getByRole('button', { name: '履歴を読み込み', exact: true })
+    .getByRole('button', { name: /^履歴を読み込み$/ })
     .click();
-  const dailyHistoryItem = historySection.getByText(dailyReportText);
+  const historyList = dailySection.locator('[data-e2e="daily-history-list"]');
+  const dailyHistoryItem = historyList.getByText(dailyReportText);
   await dailyHistoryItem.scrollIntoViewIfNeeded();
   await expect(dailyHistoryItem).toBeVisible();
   await captureSection(dailySection, '02-core-daily-report.png');

--- a/packages/frontend/src/sections/DailyReport.tsx
+++ b/packages/frontend/src/sections/DailyReport.tsx
@@ -657,7 +657,10 @@ export const DailyReport: React.FC = () => {
         </Button>
       )}
       {historyMessage && <p style={{ fontSize: 12 }}>{historyMessage}</p>}
-      <div style={{ display: 'grid', gap: 8, marginTop: 8 }}>
+      <div
+        style={{ display: 'grid', gap: 8, marginTop: 8 }}
+        data-e2e="daily-history-list"
+      >
         {historyItems.length === 0 && (
           <EmptyState title="まだ日報はありません" />
         )}


### PR DESCRIPTION
## 目的\n- 日報/ウェルビーイングを日付選択で編集できるUIに刷新\n\n## 変更点\n- 対象日選択・再読み込み\n- 日報の編集ロック表示/管理者理由入力\n- 選択日の編集履歴（DailyReportRevision）表示\n- 下書きを日付単位で保存\n\n## 依存\n- backend: PR #667（/daily-reports?reportDate と /daily-reports/:id/revisions, /worklog-settings）\n