### PR TITLE
docs: 通知の現行実装を明文化

### DIFF
--- a/docs/requirements/notifications.md
+++ b/docs/requirements/notifications.md
@@ -10,6 +10,7 @@
 - 外部連携: Slack/Webhook（主にアラート系で利用、運用は allowlist）
 
 ## 現行実装（MVP）
+※ 2026-01-24 時点（PR #681 で日報未提出通知を追加済み）
 ### AppNotification の発火イベント（実装済み）
 - `chat_mention`: チャットのメンション通知（Chat で作成）
 - `daily_report_missing`: 日報未提出通知（ジョブで作成）


### PR DESCRIPTION
## 目的\n- #669 の整理を進めるため、通知の現行実装（MVP）をドキュメントに明記\n\n## 変更点\n- AppNotification の実装済みイベントとメール配信対象を追記\n- Push/外部連携の未実装範囲を明記\n\n## 関連\n- #669