### PR TITLE
fix: WorklogSetting migration duplication

### DIFF
--- a/packages/backend/prisma/migrations/20260124004000_add_worklog_setting/migration.sql
+++ b/packages/backend/prisma/migrations/20260124004000_add_worklog_setting/migration.sql
@@ -11,6 +11,6 @@ CREATE TABLE IF NOT EXISTS "WorklogSetting" (
 );
 
 -- Seed default
-INSERT INTO "WorklogSetting" ("id", "editableDays")
-VALUES ('default', 14)
+INSERT INTO "WorklogSetting" ("id", "editableDays", "createdAt", "updatedAt")
+VALUES ('default', 14, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
 ON CONFLICT ("id") DO NOTHING;


### PR DESCRIPTION
マイグレーション  と  の重複により、空DBで migrate deploy が失敗していました（WorklogSetting already exists）。\n\n後者の migration を idempotent にして、既存テーブルがある場合は作成をスキップするよう修正しています。