### PR TITLE
Add user reference checks to migration integrity

### DIFF
--- a/scripts/checks/migration-po-integrity.sql
+++ b/scripts/checks/migration-po-integrity.sql
@@ -22,17 +22,6 @@ from "Invoice"
 group by "projectId"
 order by "projectId";
 
--- 2.5) user references (should be resolved via UserAccount.id)
-select e.id, e."userId"
-from "Expense" e
-left join "UserAccount" u on u.id = e."userId"
-where u.id is null;
-
-select te.id, te."userId"
-from "TimeEntry" te
-left join "UserAccount" u on u.id = te."userId"
-where u.id is null;
-
 select "projectId", sum(amount) as expense_total
 from "Expense"
 group by "projectId"
@@ -57,6 +46,17 @@ select "projectId", sum("totalAmount") as vendor_invoice_total
 from "VendorInvoice"
 group by "projectId"
 order by "projectId";
+
+-- 2.5) user references (should be resolved via UserAccount.id)
+select e.id, e."userId"
+from "Expense" e
+left join "UserAccount" u on u.id = e."userId"
+where u.id is null;
+
+select te.id, te."userId"
+from "TimeEntry" te
+left join "UserAccount" u on u.id = te."userId"
+where u.id is null;
 
 -- 3) referential integrity (cross-project mismatches)
 -- Invoice.estimateId -> Estimate.projectId mismatch


### PR DESCRIPTION
## Summary
- Add integrity checks to detect Expense/TimeEntry userId values missing in UserAccount

## Testing
- Not run (SQL check only)
