### PR TITLE
chore(frontend): itdo-design-system v1.0.2 取り込み

### DIFF
--- a/packages/frontend/package-lock.json
+++ b/packages/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@itdojp/design-system": "git+https://github.com/itdojp/itdo-design-system.git#bump-1.0.1",
+        "@itdojp/design-system": "github:itdojp/itdo-design-system#bump-1.0.2",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.6",
         "react": "^19.2.3",
@@ -1000,14 +1000,16 @@
       }
     },
     "node_modules/@itdojp/design-system": {
-      "version": "1.0.1",
-      "resolved": "git+ssh://git@github.com/itdojp/itdo-design-system.git#1cda74fa1f534049c3480f24f751dbdc9129f0a5",
-      "integrity": "sha512-LHh70xtWdjO3R1TInPTS3YxpeRJ1aAhll4YKV1c+2aXOfVHX02m1PKz+1LQoCZQMauEUy42sAAA4LClJsG+jqg==",
+      "version": "1.0.2",
+      "resolved": "git+ssh://git@github.com/itdojp/itdo-design-system.git#f141503b9a76751cc12a6ac394809abaea217a36",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.0",
         "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "react-dom": ">=16.8.0",
+        "react-markdown": "^10.1.0",
+        "remark-breaks": "^4.0.0",
+        "remark-gfm": "^4.0.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -15,7 +15,7 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx,jsx,js,css,json,md}\""
   },
   "dependencies": {
-    "@itdojp/design-system": "git+https://github.com/itdojp/itdo-design-system.git#bump-1.0.1",
+    "@itdojp/design-system": "github:itdojp/itdo-design-system#bump-1.0.2",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.6",
     "react": "^19.2.3",


### PR DESCRIPTION
## 目的
- itdo-design-system の更新（bump-1.0.2 / v1.0.2）を取り込み、今後のUI実装（#714 など）で利用可能にします。

## 変更点
- `packages/frontend/package.json` の `@itdojp/design-system` を `bump-1.0.2` に更新
- `packages/frontend/package-lock.json` を追従更新

## 確認
- `npm run format:check --prefix packages/frontend`
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
