### PR TITLE
feat(frontend): Expenses に注釈UIを追加

### DIFF
--- a/packages/frontend/src/sections/Expenses.tsx
+++ b/packages/frontend/src/sections/Expenses.tsx
@@ -305,6 +305,7 @@ export const Expenses: React.FC = () => {
             <div style={{ marginTop: 6 }}>
               <button
                 className="button secondary"
+                aria-label={`注釈（経費）: ${item.incurredOn.slice(0, 10)} ${item.category} ${item.amount} ${item.currency}`}
                 onClick={() =>
                   setAnnotationTarget({
                     kind: 'expense',


### PR DESCRIPTION
## 変更内容
- Expenses 画面の一覧から、注釈（メモ/外部URL/内部参照/履歴）を編集できる Dialog を追加
  - targetKind=expense
  - projectId を渡し、内部参照候補検索（ref-candidates）が利用可能

## 動作確認
- npm run format:check --prefix packages/frontend
- npm run lint --prefix packages/frontend
- npm run typecheck --prefix packages/frontend

## 関連
- #714
