### PR TITLE
feat(backend): enforce ActionPolicy on purchase order submit

### DIFF
--- a/packages/backend/src/routes/purchaseOrders.ts
+++ b/packages/backend/src/routes/purchaseOrders.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { nextNumber } from '../services/numbering.js';
 import { submitApprovalWithUpdate } from '../services/approval.js';
+import { evaluateActionPolicyWithFallback } from '../services/actionPolicy.js';
 import { FlowTypeValue, DocStatusValue } from '../types.js';
 import { purchaseOrderSchema } from './validators.js';
 import { requireRole } from '../services/rbac.js';
@@ -92,8 +93,52 @@ export async function registerPurchaseOrderRoutes(app: FastifyInstance) {
   app.post(
     '/purchase-orders/:id/submit',
     { preHandler: requireRole(['admin', 'mgmt']) },
-    async (req) => {
+    async (req, reply) => {
       const { id } = req.params as { id: string };
+      const body = req.body as any;
+      const reasonText =
+        typeof body?.reasonText === 'string' ? body.reasonText.trim() : '';
+      const po = await prisma.purchaseOrder.findUnique({
+        where: { id },
+        select: { status: true, projectId: true },
+      });
+      if (po) {
+        const policyRes = await evaluateActionPolicyWithFallback({
+          flowType: FlowTypeValue.purchase_order,
+          actionKey: 'submit',
+          actor: {
+            userId: req.user?.userId ?? null,
+            roles: req.user?.roles || [],
+            groupIds: req.user?.groupIds || [],
+          },
+          reasonText,
+          state: { status: po.status, projectId: po.projectId },
+          targetTable: 'purchase_orders',
+          targetId: id,
+        });
+        if (policyRes.policyApplied && !policyRes.allowed) {
+          if (policyRes.reason === 'reason_required') {
+            return reply.status(400).send({
+              error: {
+                code: 'REASON_REQUIRED',
+                message: 'reasonText is required for override',
+                details: { matchedPolicyId: policyRes.matchedPolicyId ?? null },
+              },
+            });
+          }
+          return reply.status(403).send({
+            error: {
+              code: 'ACTION_POLICY_DENIED',
+              message: 'Purchase order cannot be submitted',
+              details: {
+                reason: policyRes.reason,
+                matchedPolicyId: policyRes.matchedPolicyId ?? null,
+                guardFailures: policyRes.guardFailures ?? null,
+              },
+            },
+          });
+        }
+      }
       const { updated } = await submitApprovalWithUpdate({
         flowType: FlowTypeValue.purchase_order,
         targetTable: 'purchase_orders',


### PR DESCRIPTION
ISSUE #717 Phase 3（段階導入）の継続。

- PurchaseOrder: POST /purchase-orders/:id/submit に ActionPolicy 評価を追加（no_matching_policy の場合は既存挙動を維持する fallback）
- reasonText は body から任意で受け取り評価に渡す（OpenAPIは未更新）

備考:
- 実際にブロック/許可するかは ActionPolicy（DB定義）次第。未定義の環境では従来通り動作します。
