### PR TITLE
vendor_invoice: submit actionKey への統一（/submit追加・/approve互換）

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -7108,6 +7108,25 @@
         }
       }
     },
+    "/vendor-invoices/{id}/submit": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
     "/vendor-quotes": {
       "get": {
         "responses": {

--- a/docs/requirements/domain-api-draft.md
+++ b/docs/requirements/domain-api-draft.md
@@ -65,7 +65,7 @@
 - Vendor Docs
   - `POST /vendor-quotes` {project_id, vendor_id, quote_no?, total_amount, currency, issue_date, document_url}
   - `POST /vendor-invoices` {project_id, vendor_id, vendor_invoice_no?, total_amount, currency, received_date, due_date, document_url}
-  - `POST /vendor-invoices/:id/approve`（承認フロー起動）
+  - `POST /vendor-invoices/:id/submit`（承認フロー起動、後方互換: `/approve` も残す）
 - Time
   - `POST /time-entries` {project_id, task_id?, work_date, minutes, work_type, location, notes}
   - `PATCH /time-entries/:id` 更新（重要項目変更は承認フロー起動）

--- a/docs/requirements/frontend-api-wire.md
+++ b/docs/requirements/frontend-api-wire.md
@@ -73,7 +73,7 @@
 - GET  `/purchase-orders/:id/send-logs`
 - POST `/vendor-quotes` { projectId, vendorId, quote_no?, ... }
 - POST `/vendor-invoices` { projectId, vendorId, vendor_invoice_no?, ... }
-- POST `/vendor-invoices/:id/approve`
+- POST `/vendor-invoices/:id/submit`（承認フロー起動、後方互換: `/approve` も残す）
 
 ## project chat
 - GET `/projects/:projectId/chat-messages?limit=&before=&tag=`

--- a/docs/requirements/workflow-generic.md
+++ b/docs/requirements/workflow-generic.md
@@ -50,7 +50,7 @@ ActionPolicy/WorkflowDefinition で参照する **共通キー**として扱う�
 - estimate: `submit` -> `POST /estimates/:id/submit`, `send` -> `POST /estimates/:id/send`
 - invoice: `submit` -> `POST /invoices/:id/submit`, `send` -> `POST /invoices/:id/send`, `mark_paid` -> `POST /invoices/:id/mark-paid`
 - purchase_order: `submit` -> `POST /purchase-orders/:id/submit`, `send` -> `POST /purchase-orders/:id/send`
-- vendor_invoice: `submit` 相当 -> `POST /vendor-invoices/:id/approve`（命名差分あり）
+- vendor_invoice: `submit` -> `POST /vendor-invoices/:id/submit`（後方互換: `/approve` も残す）
 - expense: `submit` -> `POST /expenses/:id/submit`
 - leave: `submit` -> `POST /leave-requests/:id/submit`
 - time: `submit` -> `POST /time-entries/:id/submit`, `edit` -> `PATCH /time-entries/:id`

--- a/packages/frontend/e2e/backend-manual-checklist.spec.ts
+++ b/packages/frontend/e2e/backend-manual-checklist.spec.ts
@@ -319,7 +319,7 @@ test('backend manual checklist: members/vendors/time/expenses/wellbeing @extende
   await ensureOk(vendorInvoiceRes);
   const vendorInvoice = await vendorInvoiceRes.json();
   const approveRes = await request.post(
-    `${apiBase}/vendor-invoices/${encodeURIComponent(vendorInvoice.id)}/approve`,
+    `${apiBase}/vendor-invoices/${encodeURIComponent(vendorInvoice.id)}/submit`,
     { headers: adminHeaders },
   );
   await ensureOk(approveRes);

--- a/packages/frontend/src/sections/VendorDocuments.tsx
+++ b/packages/frontend/src/sections/VendorDocuments.tsx
@@ -568,7 +568,7 @@ export const VendorDocuments: React.FC = () => {
     try {
       setInvoiceActionBusy(id, true);
       setInvoiceResult(null);
-      await api(`/vendor-invoices/${id}/approve`, { method: 'POST' });
+      await api(`/vendor-invoices/${id}/submit`, { method: 'POST' });
       setInvoiceResult({ text: '仕入請求を承認依頼しました', type: 'success' });
       loadVendorInvoices();
     } catch (err) {

--- a/scripts/smoke-backend.sh
+++ b/scripts/smoke-backend.sh
@@ -138,7 +138,7 @@ require_id "vendor_quote_id" "$vendor_quote_id"
 vendor_invoice_resp=$(post_json "$BASE_URL/vendor-invoices" "{\"projectId\":\"$project_id\",\"vendorId\":\"$vendor_id\",\"vendorInvoiceNo\":\"$PROJECT_CODE-VI\",\"receivedDate\":\"$work_date\",\"dueDate\":\"$work_date\",\"currency\":\"JPY\",\"totalAmount\":90000}")
 vendor_invoice_id=$(echo "$vendor_invoice_resp" | json_get "id")
 require_id "vendor_invoice_id" "$vendor_invoice_id"
-post_json "$BASE_URL/vendor-invoices/$vendor_invoice_id/approve" '{}' >/dev/null
+post_json "$BASE_URL/vendor-invoices/$vendor_invoice_id/submit" '{}' >/dev/null
 
 echo "[9/9] run alert job and approval check"
 post_json "$BASE_URL/jobs/alerts/run" '{}' >/dev/null


### PR DESCRIPTION
ISSUE #717 の一部対応（actionKey差分解消: vendor_invoice approve/submit）。

変更内容:
- Backend: POST /vendor-invoices/:id/submit を追加（既存 POST /vendor-invoices/:id/approve は後方互換として維持）
- Frontend: VendorDocuments の承認依頼を /submit に切替
- scripts/e2e/docs/openapi の呼び出し・記載を /submit に追従（後方互換注記付き）

動作確認:
- make lint / make format-check / make typecheck
- DATABASE_URL=... make test（ローカルでは DATABASE_URL が必要）
