### PR TITLE
Dashboard: 通知からチャット発言へ遷移

### DIFF
--- a/packages/frontend/src/sections/Dashboard.tsx
+++ b/packages/frontend/src/sections/Dashboard.tsx
@@ -225,9 +225,6 @@ export const Dashboard: React.FC = () => {
       navigateToOpen({ kind: 'chat_message', id: item.messageId });
       return;
     }
-    if (item.projectId && item.kind.startsWith('chat_')) {
-      navigateToOpen({ kind: 'project_chat', id: item.projectId });
-    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
ISSUE #669/#675 関連。\n\n- Dashboard の通知カードに「開く」ボタンを追加し、messageId がある通知（chat_mention/chat_ack_required）から対象発言へ deep link 遷移できるようにしました。\n- 既読化は従来通り手動（開く=既読にはしない）です。\n\n確認: 
> erp4-frontend-poc@0.1.0 lint
> eslint "src/**/*.{ts,tsx,jsx,js}" / 
> erp4-frontend-poc@0.1.0 format:check
> prettier --check "src/**/*.{ts,tsx,jsx,js,css,json,md}"

Checking formatting...
All matched files use Prettier code style!