### PR TITLE
feat: show ack dueAt on Dashboard (#675)

### DIFF
--- a/packages/frontend/src/sections/Dashboard.tsx
+++ b/packages/frontend/src/sections/Dashboard.tsx
@@ -123,6 +123,12 @@ function resolveReportDate(payload: unknown) {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
 }
 
+function resolveDueAt(payload: unknown) {
+  if (!payload || typeof payload !== 'object') return null;
+  const value = (payload as { dueAt?: unknown }).dueAt;
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
 const FLOW_TYPE_LABEL_MAP: Record<string, string> = {
   estimate: '見積',
   invoice: '請求',
@@ -421,6 +427,7 @@ export const Dashboard: React.FC = () => {
               ? `${item.project.code} / ${item.project.name}`
               : item.projectId || 'N/A';
             const excerpt = resolveExcerpt(item.payload);
+            const dueAt = resolveDueAt(item.payload);
             const canOpen =
               ((item.kind === 'chat_mention' ||
                 item.kind === 'chat_ack_required') &&
@@ -441,6 +448,16 @@ export const Dashboard: React.FC = () => {
                     <div style={{ fontSize: 12, color: '#475569' }}>
                       {projectLabel} / {formatDateTime(item.createdAt)}
                     </div>
+                    {item.kind === 'chat_ack_required' && dueAt && (
+                      <div
+                        style={{
+                          fontSize: 12,
+                          color: '#475569',
+                        }}
+                      >
+                        期限: {formatDateTime(dueAt)}
+                      </div>
+                    )}
                     {excerpt && (
                       <div style={{ fontSize: 12, color: '#475569' }}>
                         {excerpt}


### PR DESCRIPTION
# やったこと\n- Dashboard の通知カード（chat_ack_required）に dueAt を表示\n\n# 補足\n- 期限超過判定（色/文言）は render purity lint に抵触するため今回は表示のみ\n\nRefs #675