### PR TITLE
feat: add ack target candidate UI in project chat (#675)

### DIFF
--- a/packages/frontend/src/sections/ProjectChat.tsx
+++ b/packages/frontend/src/sections/ProjectChat.tsx
@@ -474,7 +474,7 @@ export const ProjectChat: React.FC = () => {
     const value = ackTargetInput.trim();
     if (!value) return;
     const current = parseUserIds(ackTargets);
-    const next = Array.from(new Set([...current, value]));
+    const next = Array.from(new Set([...current, value])).slice(0, 50);
     setAckTargets(next.join(','));
     setAckTargetInput('');
   };
@@ -736,7 +736,7 @@ export const ProjectChat: React.FC = () => {
       }
       setBody('');
       setTags('');
-      setAckTargets('');
+      resetAckTargets();
       setAttachmentFile(null);
       resetMentions();
       setMessage('確認依頼を投稿しました');


### PR DESCRIPTION
Refs: #675

- ProjectChat の確認依頼（ack required）で、確認対象ユーザIDの入力支援（候補/datalist + 追加/削除）を追加します。
- 既存の「確認対象ユーザID (comma separated)」入力は残し、手入力/貼り付けも継続可能です（e2e互換維持）。

確認:
- `npm run lint --prefix packages/frontend`
- `npm run format:check --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
