### PR TITLE
fix: RoomChatのack required通知/監査ログ

### DIFF
--- a/packages/backend/src/services/appNotifications.ts
+++ b/packages/backend/src/services/appNotifications.ts
@@ -12,7 +12,8 @@ type ChatMentionNotificationOptions = {
 };
 
 type ChatAckRequiredNotificationOptions = {
-  projectId?: string | null;
+  // Always pass explicitly. Use `null` for non-project rooms.
+  projectId: string | null;
   messageId: string;
   messageBody: string;
   senderUserId: string;

--- a/packages/backend/src/services/chatAckReminders.ts
+++ b/packages/backend/src/services/chatAckReminders.ts
@@ -139,9 +139,8 @@ export async function runChatAckReminders(
       continue;
     }
     const excerpt = buildExcerpt(request.message?.body ?? '');
+    const projectId = request.room.type === 'project' ? request.roomId : null;
     for (const userId of incompleteUserIds) {
-      const projectId =
-        request.room?.type === 'project' ? request.roomId : null;
       candidates.push({
         userId,
         projectId,


### PR DESCRIPTION
# 変更内容
- RoomChat の ack required 作成（`/chat-rooms/:roomId/ack-requests`）で、AppNotification（`kind=chat_ack_required`）生成 + 監査ログを追加しました。
- dueAt リマインドジョブで、非プロジェクトルームに対して `AppNotification.projectId` を誤って `roomId` で作成してしまうケース（FK整合）を回避するため、ルーム種別に応じて `projectId` を `null` にします。

# 実装詳細
- `packages/backend/src/routes/chatRooms.ts`
  - `chat_ack_request_created` / `chat_ack_required_notifications_created` を記録
  - ルームが `type=project` の場合のみ `projectId=roomId` を設定（それ以外は `null`）
- `packages/backend/src/services/appNotifications.ts`
  - `createChatAckRequiredNotifications()` の `projectId` を nullable 化
- `packages/backend/src/services/chatAckReminders.ts`
  - `ChatAckRequest.room.type` を参照して `projectId` を決定

# 目的
- #675: ack required の通知/監査ログを RoomChat 側でも一貫させる

# 動作確認
- `npm run lint --prefix packages/backend`
- `npm run typecheck --prefix packages/backend`
（`npm run test --prefix packages/backend` は `DATABASE_URL` が必要なためローカルでは未実施）