### PR TITLE
refactor: ack required通知/監査ログ処理の共通化

### DIFF
--- a/packages/backend/src/routes/chatRooms.ts
+++ b/packages/backend/src/routes/chatRooms.ts
@@ -5,7 +5,10 @@ import { prisma } from '../services/db.js';
 import { requireRole } from '../services/rbac.js';
 import { ensureChatRoomContentAccess } from '../services/chatRoomAccess.js';
 import { auditContextFromRequest, logAudit } from '../services/audit.js';
-import { createChatAckRequiredNotifications } from '../services/appNotifications.js';
+import {
+  logChatAckRequestCreated,
+  tryCreateChatAckRequiredNotificationsWithAudit,
+} from '../services/chatAckNotifications.js';
 import {
   getChatExternalLlmConfig,
   getChatExternalLlmRateLimit,
@@ -2267,65 +2270,27 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
         throw new Error('Expected ackRequest to be created for chat message');
       }
 
-      await logAudit({
-        action: 'chat_ack_request_created',
-        targetTable: 'chat_ack_requests',
-        targetId: message.ackRequest.id,
-        metadata: {
-          projectId,
-          roomId: access.room.id,
-          messageId: message.id,
-          requiredUserCount: requiredUserIds.length,
-          dueAt: message.ackRequest.dueAt
-            ? message.ackRequest.dueAt.toISOString()
-            : null,
-        } as Prisma.InputJsonValue,
-        ...auditContextFromRequest(req),
+      await logChatAckRequestCreated({
+        req,
+        actorUserId: userId,
+        projectId,
+        roomId: access.room.id,
+        messageId: message.id,
+        ackRequestId: message.ackRequest.id,
+        requiredUserIds,
+        dueAt: message.ackRequest.dueAt,
       });
 
-      try {
-        const notificationResult = await createChatAckRequiredNotifications({
-          projectId,
-          messageId: message.id,
-          messageBody: message.body,
-          senderUserId: userId,
-          requiredUserIds,
-          dueAt: dueAt ? dueAt.toISOString() : null,
-        });
-
-        if (notificationResult.created > 0) {
-          await logAudit({
-            action: 'chat_ack_required_notifications_created',
-            targetTable: 'chat_messages',
-            targetId: message.id,
-            metadata: {
-              projectId,
-              roomId: access.room.id,
-              messageId: message.id,
-              createdCount: notificationResult.created,
-              recipientCount: notificationResult.recipients.length,
-              recipientUserIds: notificationResult.recipients.slice(0, 20),
-              recipientsTruncated: notificationResult.truncated,
-              requiredUserCount: requiredUserIds.length,
-              senderExcluded:
-                notificationResult.recipients.includes(userId) === false &&
-                requiredUserIds.includes(userId),
-            } as Prisma.InputJsonValue,
-            ...auditContextFromRequest(req),
-          });
-        }
-      } catch (err) {
-        req.log?.warn(
-          {
-            err,
-            projectId,
-            roomId: access.room.id,
-            messageId: message.id,
-            requiredUserCount: requiredUserIds.length,
-          },
-          'Failed to create chat ack required notifications',
-        );
-      }
+      await tryCreateChatAckRequiredNotificationsWithAudit({
+        req,
+        actorUserId: userId,
+        projectId,
+        roomId: access.room.id,
+        messageId: message.id,
+        messageBody: message.body,
+        requiredUserIds,
+        dueAt: message.ackRequest.dueAt,
+      });
 
       if (mentionsAll || mentionUserIds.length || mentionGroupIds.length) {
         await logAudit({

--- a/packages/backend/src/services/chatAckNotifications.ts
+++ b/packages/backend/src/services/chatAckNotifications.ts
@@ -1,0 +1,91 @@
+import type { Prisma } from '@prisma/client';
+import type { FastifyRequest } from 'fastify';
+import { auditContextFromRequest, logAudit } from './audit.js';
+import { createChatAckRequiredNotifications } from './appNotifications.js';
+
+type LogChatAckRequestCreatedOptions = {
+  req: FastifyRequest;
+  actorUserId: string;
+  projectId: string | null;
+  roomId: string;
+  messageId: string;
+  ackRequestId: string;
+  requiredUserIds: string[];
+  dueAt: Date | null;
+};
+
+export async function logChatAckRequestCreated(
+  options: LogChatAckRequestCreatedOptions,
+) {
+  await logAudit({
+    action: 'chat_ack_request_created',
+    targetTable: 'chat_ack_requests',
+    targetId: options.ackRequestId,
+    metadata: {
+      projectId: options.projectId,
+      roomId: options.roomId,
+      messageId: options.messageId,
+      requiredUserCount: options.requiredUserIds.length,
+      dueAt: options.dueAt ? options.dueAt.toISOString() : null,
+    } as Prisma.InputJsonValue,
+    ...auditContextFromRequest(options.req, { userId: options.actorUserId }),
+  });
+}
+
+type TryCreateChatAckRequiredNotificationsWithAuditOptions = {
+  req: FastifyRequest;
+  actorUserId: string;
+  projectId: string | null;
+  roomId: string;
+  messageId: string;
+  messageBody: string;
+  requiredUserIds: string[];
+  dueAt: Date | null;
+};
+
+export async function tryCreateChatAckRequiredNotificationsWithAudit(
+  options: TryCreateChatAckRequiredNotificationsWithAuditOptions,
+) {
+  try {
+    const notificationResult = await createChatAckRequiredNotifications({
+      projectId: options.projectId,
+      messageId: options.messageId,
+      messageBody: options.messageBody,
+      senderUserId: options.actorUserId,
+      requiredUserIds: options.requiredUserIds,
+      dueAt: options.dueAt ? options.dueAt.toISOString() : null,
+    });
+    if (notificationResult.created <= 0) return;
+
+    await logAudit({
+      action: 'chat_ack_required_notifications_created',
+      targetTable: 'chat_messages',
+      targetId: options.messageId,
+      metadata: {
+        projectId: options.projectId,
+        roomId: options.roomId,
+        messageId: options.messageId,
+        createdCount: notificationResult.created,
+        recipientCount: notificationResult.recipients.length,
+        recipientUserIds: notificationResult.recipients.slice(0, 20),
+        recipientsTruncated: notificationResult.truncated,
+        requiredUserCount: options.requiredUserIds.length,
+        senderExcluded:
+          notificationResult.recipients.includes(options.actorUserId) ===
+            false && options.requiredUserIds.includes(options.actorUserId),
+      } as Prisma.InputJsonValue,
+      ...auditContextFromRequest(options.req, { userId: options.actorUserId }),
+    });
+  } catch (err) {
+    options.req.log?.warn(
+      {
+        err,
+        projectId: options.projectId,
+        roomId: options.roomId,
+        messageId: options.messageId,
+        requiredUserCount: options.requiredUserIds.length,
+      },
+      'Failed to create chat ack required notifications',
+    );
+  }
+}


### PR DESCRIPTION
# 変更内容
- ack required 作成時の「監査ログ（chat_ack_request_created）」と「通知生成 + 監査ログ（chat_ack_required_notifications_created）」処理を共通ヘルパーに切り出し、`chat.ts`/`chatRooms.ts` の重複を解消しました。

# 実装
- 追加: `packages/backend/src/services/chatAckNotifications.ts`
  - `logChatAckRequestCreated()`
  - `tryCreateChatAckRequiredNotificationsWithAudit()`
- 置換: `packages/backend/src/routes/chat.ts`
- 置換: `packages/backend/src/routes/chatRooms.ts`

# 目的
- #675: RoomChat/ProjectChat で同一の通知/監査仕様を維持しやすくする（今後の仕様変更時の更新漏れ防止）

# 動作確認
- `npm run format:check --prefix packages/backend`
- `npm run lint --prefix packages/backend`
- `npm run typecheck --prefix packages/backend`

