### PR TITLE
fix: 日報未提出通知の userId を userName に統一

### DIFF
--- a/packages/backend/src/services/dailyReportMissing.ts
+++ b/packages/backend/src/services/dailyReportMissing.ts
@@ -94,9 +94,10 @@ export async function runDailyReportMissingNotifications(
 
   const users = await prisma.userAccount.findMany({
     where: { active: true, deletedAt: null },
-    select: { id: true },
+    select: { userName: true },
   });
-  const userIds = users.map((user) => user.id);
+  // Domain `userId` is aligned with auth principal (`UserAccount.userName`).
+  const userIds = users.map((user) => user.userName.trim()).filter(Boolean);
   if (!userIds.length) {
     return {
       ok: true,


### PR DESCRIPTION
# 変更内容
- 日報未提出通知（`daily_report_missing`）の対象ユーザ抽出で `UserAccount.id` を使っていたため、`/notifications` の `userId`（auth principal）と一致せず通知が届かない/表示されない可能性がありました。
- `UserAccount.userName` を domain の `userId` として扱い、未提出判定と AppNotification.userId を `userName` に統一します。

# 背景/根拠
- 認可/通知取得は `req.user.userId`（header: `x-user-id`、jwt: sub等）でフィルタしている
  - `packages/backend/src/routes/notifications.ts`
  - `packages/backend/src/plugins/auth.ts`（DB照合も `UserAccount.userName` 前提）
- 日報未提出ジョブが `UserAccount.id` を利用していた
  - `packages/backend/src/services/dailyReportMissing.ts`

# 影響
- これまで `daily_report_missing` が `UserAccount.id` で作成されていた環境では、修正後に `UserAccount.userName` で新規通知が作成されます（messageIdは同一でも userId が異なるため）。

# 動作確認
- `npm run format:check --prefix packages/backend`
- `npm run lint --prefix packages/backend`
- `npm run typecheck --prefix packages/backend`

Refs: #669
