### PR TITLE
feat: chat access check supports groupAccountIds

### DIFF
--- a/packages/backend/src/routes/chat.ts
+++ b/packages/backend/src/routes/chat.ts
@@ -1033,12 +1033,16 @@ export async function registerChatRoutes(app: FastifyInstance) {
       const groupIds = Array.isArray(req.user?.groupIds)
         ? req.user.groupIds
         : [];
+      const groupAccountIds = Array.isArray(req.user?.groupAccountIds)
+        ? req.user.groupAccountIds
+        : [];
       const access = await ensureChatRoomContentAccess({
         roomId: requestItem.roomId,
         userId,
         roles,
         projectIds,
         groupIds,
+        groupAccountIds,
       });
       if (!access.ok) {
         return reply.status(access.reason === 'not_found' ? 404 : 403).send({
@@ -1146,12 +1150,16 @@ export async function registerChatRoutes(app: FastifyInstance) {
       const groupIds = Array.isArray(req.user?.groupIds)
         ? req.user.groupIds
         : [];
+      const groupAccountIds = Array.isArray(req.user?.groupAccountIds)
+        ? req.user.groupAccountIds
+        : [];
       const access = await ensureChatRoomContentAccess({
         roomId: requestItem.roomId,
         userId,
         roles,
         projectIds,
         groupIds,
+        groupAccountIds,
       });
       if (!access.ok) {
         return reply.status(access.reason === 'not_found' ? 404 : 403).send({
@@ -1250,12 +1258,16 @@ export async function registerChatRoutes(app: FastifyInstance) {
       const groupIds = Array.isArray(req.user?.groupIds)
         ? req.user.groupIds
         : [];
+      const groupAccountIds = Array.isArray(req.user?.groupAccountIds)
+        ? req.user.groupAccountIds
+        : [];
       const access = await ensureChatRoomContentAccess({
         roomId: requestItem.roomId,
         userId,
         roles,
         projectIds,
         groupIds,
+        groupAccountIds,
       });
       if (!access.ok) {
         return reply.status(access.reason === 'not_found' ? 404 : 403).send({
@@ -1345,12 +1357,16 @@ export async function registerChatRoutes(app: FastifyInstance) {
       const groupIds = Array.isArray(req.user?.groupIds)
         ? req.user.groupIds
         : [];
+      const groupAccountIds = Array.isArray(req.user?.groupAccountIds)
+        ? req.user.groupAccountIds
+        : [];
       const access = await ensureChatRoomContentAccess({
         roomId: message.roomId,
         userId,
         roles,
         projectIds,
         groupIds,
+        groupAccountIds,
       });
       if (!access.ok) {
         return reply.status(access.reason === 'not_found' ? 404 : 403).send({
@@ -1447,12 +1463,16 @@ export async function registerChatRoutes(app: FastifyInstance) {
       const groupIds = Array.isArray(req.user?.groupIds)
         ? req.user.groupIds
         : [];
+      const groupAccountIds = Array.isArray(req.user?.groupAccountIds)
+        ? req.user.groupAccountIds
+        : [];
       const access = await ensureChatRoomContentAccess({
         roomId: message.roomId,
         userId,
         roles,
         projectIds,
         groupIds,
+        groupAccountIds,
       });
       if (!access.ok) {
         return reply.status(access.reason === 'not_found' ? 404 : 403).send({
@@ -1640,12 +1660,16 @@ export async function registerChatRoutes(app: FastifyInstance) {
       const groupIds = Array.isArray(req.user?.groupIds)
         ? req.user.groupIds
         : [];
+      const groupAccountIds = Array.isArray(req.user?.groupAccountIds)
+        ? req.user.groupAccountIds
+        : [];
       const access = await ensureChatRoomContentAccess({
         roomId: attachment.message.roomId,
         userId,
         roles,
         projectIds,
         groupIds,
+        groupAccountIds,
       });
       if (!access.ok) {
         return reply.status(access.reason === 'not_found' ? 404 : 403).send({

--- a/packages/backend/src/routes/chatBreakGlass.ts
+++ b/packages/backend/src/routes/chatBreakGlass.ts
@@ -105,12 +105,16 @@ export async function registerChatBreakGlassRoutes(app: FastifyInstance) {
         const groupIds = Array.isArray(req.user?.groupIds)
           ? req.user.groupIds
           : [];
+        const groupAccountIds = Array.isArray(req.user?.groupAccountIds)
+          ? req.user.groupAccountIds
+          : [];
         const access = await ensureChatRoomContentAccess({
           roomId,
           userId,
           roles,
           projectIds,
           groupIds,
+          groupAccountIds,
         });
         if (!access.ok) {
           return reply.status(access.reason === 'not_found' ? 404 : 403).send({

--- a/packages/backend/src/routes/chatRooms.ts
+++ b/packages/backend/src/routes/chatRooms.ts
@@ -131,6 +131,7 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
     roles: string[];
     projectIds: string[];
     groupIds: string[];
+    groupAccountIds: string[];
   }) {
     const isExternal = options.roles.includes('external_chat');
     const internalChatRoles = new Set(['admin', 'mgmt', 'exec', 'user', 'hr']);
@@ -138,15 +139,22 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
       internalChatRoles.has(role),
     );
     const roomIds = new Set<string>();
+    const groupSelectors = Array.from(
+      new Set(
+        [...options.groupIds, ...options.groupAccountIds]
+          .map((value) => value.trim())
+          .filter(Boolean),
+      ),
+    );
 
     if (!isExternal && hasInternalChatRole) {
       roomIds.add(companyRoomId);
-      if (options.groupIds.length > 0) {
+      if (groupSelectors.length > 0) {
         const departmentRooms = await prisma.chatRoom.findMany({
           where: {
             type: 'department',
             deletedAt: null,
-            groupId: { in: options.groupIds },
+            groupId: { in: groupSelectors },
           },
           select: { id: true },
           take: 200,
@@ -438,7 +446,11 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
         dedupe: true,
         max: 50,
       });
-      const groupIdSet = new Set(groupIds);
+      const groupAccountIds = normalizeStringArray(req.user?.groupAccountIds, {
+        dedupe: true,
+        max: 50,
+      });
+      const groupIdSet = new Set([...groupIds, ...groupAccountIds]);
       const canSeeAllMeta =
         roles.includes('admin') ||
         roles.includes('mgmt') ||
@@ -777,12 +789,16 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
       const groupIds = normalizeStringArray(req.user?.groupIds, {
         dedupe: true,
       });
+      const groupAccountIds = normalizeStringArray(req.user?.groupAccountIds, {
+        dedupe: true,
+      });
 
       const roomIds = await resolveSearchRoomIds({
         userId,
         roles,
         projectIds,
         groupIds,
+        groupAccountIds,
       });
       if (roomIds.length === 0) {
         return { items: [] };
@@ -900,6 +916,10 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
         dedupe: true,
         max: 50,
       });
+      const groupAccountIds = normalizeStringArray(req.user?.groupAccountIds, {
+        dedupe: true,
+        max: 50,
+      });
 
       const access = await ensureChatRoomContentAccess({
         roomId: message.roomId,
@@ -907,6 +927,7 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
         roles,
         projectIds,
         groupIds,
+        groupAccountIds,
       });
       if (!access.ok) {
         return reply.status(access.reason === 'not_found' ? 404 : 403).send({
@@ -1423,12 +1444,16 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
       const groupIds = Array.isArray(req.user?.groupIds)
         ? req.user.groupIds
         : [];
+      const groupAccountIds = Array.isArray(req.user?.groupAccountIds)
+        ? req.user.groupAccountIds
+        : [];
       const access = await ensureChatRoomContentAccess({
         roomId,
         userId,
         roles,
         projectIds,
         groupIds,
+        groupAccountIds,
       });
       if (!access.ok) {
         return reply
@@ -1496,12 +1521,16 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
       const groupIds = Array.isArray(req.user?.groupIds)
         ? req.user.groupIds
         : [];
+      const groupAccountIds = Array.isArray(req.user?.groupAccountIds)
+        ? req.user.groupAccountIds
+        : [];
       const access = await ensureChatRoomContentAccess({
         roomId,
         userId,
         roles,
         projectIds,
         groupIds,
+        groupAccountIds,
       });
       if (!access.ok) {
         return reply
@@ -1542,12 +1571,16 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
       const groupIds = Array.isArray(req.user?.groupIds)
         ? req.user.groupIds
         : [];
+      const groupAccountIds = Array.isArray(req.user?.groupAccountIds)
+        ? req.user.groupAccountIds
+        : [];
       const access = await ensureChatRoomContentAccess({
         roomId,
         userId,
         roles,
         projectIds,
         groupIds,
+        groupAccountIds,
       });
       if (!access.ok) {
         return reply
@@ -1591,12 +1624,16 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
       const groupIds = Array.isArray(req.user?.groupIds)
         ? req.user.groupIds
         : [];
+      const groupAccountIds = Array.isArray(req.user?.groupAccountIds)
+        ? req.user.groupAccountIds
+        : [];
       const access = await ensureChatRoomContentAccess({
         roomId,
         userId,
         roles,
         projectIds,
         groupIds,
+        groupAccountIds,
       });
       if (!access.ok) {
         return reply
@@ -1700,12 +1737,16 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
       const groupIds = Array.isArray(req.user?.groupIds)
         ? req.user.groupIds
         : [];
+      const groupAccountIds = Array.isArray(req.user?.groupAccountIds)
+        ? req.user.groupAccountIds
+        : [];
       const access = await ensureChatRoomContentAccess({
         roomId,
         userId,
         roles,
         projectIds,
         groupIds,
+        groupAccountIds,
       });
       if (!access.ok) {
         return reply
@@ -1900,12 +1941,16 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
       const groupIds = Array.isArray(req.user?.groupIds)
         ? req.user.groupIds
         : [];
+      const groupAccountIds = Array.isArray(req.user?.groupAccountIds)
+        ? req.user.groupAccountIds
+        : [];
       const access = await ensureChatRoomContentAccess({
         roomId,
         userId,
         roles,
         projectIds,
         groupIds,
+        groupAccountIds,
       });
       if (!access.ok) {
         return reply
@@ -2122,12 +2167,16 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
       const groupIds = Array.isArray(req.user?.groupIds)
         ? req.user.groupIds
         : [];
+      const groupAccountIds = Array.isArray(req.user?.groupAccountIds)
+        ? req.user.groupAccountIds
+        : [];
       const access = await ensureChatRoomContentAccess({
         roomId,
         userId,
         roles,
         projectIds,
         groupIds,
+        groupAccountIds,
       });
       if (!access.ok) {
         return reply
@@ -2204,12 +2253,16 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
       const groupIds = Array.isArray(req.user?.groupIds)
         ? req.user.groupIds
         : [];
+      const groupAccountIds = Array.isArray(req.user?.groupAccountIds)
+        ? req.user.groupAccountIds
+        : [];
       const access = await ensureChatRoomContentAccess({
         roomId,
         userId,
         roles,
         projectIds,
         groupIds,
+        groupAccountIds,
       });
       if (!access.ok) {
         return reply

--- a/packages/backend/src/services/chatRoomAccess.ts
+++ b/packages/backend/src/services/chatRoomAccess.ts
@@ -26,6 +26,7 @@ export async function ensureChatRoomContentAccess(options: {
   roles: string[];
   projectIds: string[];
   groupIds?: string[];
+  groupAccountIds?: string[];
 }): Promise<ChatRoomContentAccessResult> {
   const isExternal = options.roles.includes('external_chat');
   const internalChatRoles = new Set(['admin', 'mgmt', 'exec', 'user', 'hr']);
@@ -34,6 +35,11 @@ export async function ensureChatRoomContentAccess(options: {
   );
   const groupIdSet = new Set(
     (Array.isArray(options.groupIds) ? options.groupIds : [])
+      .map((value) => (typeof value === 'string' ? value.trim() : ''))
+      .filter(Boolean),
+  );
+  const groupAccountIdSet = new Set(
+    (Array.isArray(options.groupAccountIds) ? options.groupAccountIds : [])
       .map((value) => (typeof value === 'string' ? value.trim() : ''))
       .filter(Boolean),
   );
@@ -89,7 +95,10 @@ export async function ensureChatRoomContentAccess(options: {
       }
       const groupId =
         typeof room.groupId === 'string' ? room.groupId.trim() : '';
-      if (!groupId || !groupIdSet.has(groupId)) {
+      if (
+        !groupId ||
+        (!groupIdSet.has(groupId) && !groupAccountIdSet.has(groupId))
+      ) {
         return { ok: false, reason: 'forbidden_room_member' };
       }
       return { ok: true, room };


### PR DESCRIPTION
## 概要\n- チャットの閲覧/投稿アクセス判定で groupAccountIds(UUID) を参照できるようにし、department/company ルームの暗黙アクセスや検索の判定に UUID を利用可能にしました。\n- displayName と UUID の併用（dual-read）を許容する移行ステップです。\n\n## 変更点\n- ensureChatRoomContentAccess に groupAccountIds を追加\n- chat/chatRooms/chatBreakGlass の各ルートで groupAccountIds を渡す\n- 検索/暗黙アクセスの groupId 判定に groupAccountIds を含める\n\n## テスト\n- 未実施（必要なら 
> erp4-backend-poc@0.1.0 typecheck
> tsc -p tsconfig.json --noEmit）\n\nRefs: #785