### PR TITLE
test: add chat room access coverage for groupAccountIds

### DIFF
--- a/packages/backend/src/services/chatRoomAccess.ts
+++ b/packages/backend/src/services/chatRoomAccess.ts
@@ -27,7 +27,9 @@ export async function ensureChatRoomContentAccess(options: {
   projectIds: string[];
   groupIds?: string[];
   groupAccountIds?: string[];
+  client?: typeof prisma;
 }): Promise<ChatRoomContentAccessResult> {
+  const client = options.client ?? prisma;
   const isExternal = options.roles.includes('external_chat');
   const internalChatRoles = new Set(['admin', 'mgmt', 'exec', 'user', 'hr']);
   const hasInternalChatRole = options.roles.some((role) =>
@@ -44,7 +46,7 @@ export async function ensureChatRoomContentAccess(options: {
       .filter(Boolean),
   );
 
-  const room = await prisma.chatRoom.findUnique({
+  const room = await client.chatRoom.findUnique({
     where: { id: options.roomId },
     select: {
       id: true,
@@ -63,7 +65,7 @@ export async function ensureChatRoomContentAccess(options: {
       return { ok: true, room };
     }
     if (isExternal && room.allowExternalUsers) {
-      const member = await prisma.chatRoomMember.findFirst({
+      const member = await client.chatRoomMember.findFirst({
         where: { roomId: room.id, userId: options.userId, deletedAt: null },
         select: { role: true },
       });
@@ -105,7 +107,7 @@ export async function ensureChatRoomContentAccess(options: {
     }
   }
 
-  const member = await prisma.chatRoomMember.findFirst({
+  const member = await client.chatRoomMember.findFirst({
     where: { roomId: room.id, userId: options.userId, deletedAt: null },
     select: { role: true },
   });

--- a/packages/backend/test/chatRoomAccess.test.js
+++ b/packages/backend/test/chatRoomAccess.test.js
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { ensureChatRoomContentAccess } from '../dist/services/chatRoomAccess.js';
+
+function buildRoom(overrides = {}) {
+  return {
+    id: 'room1',
+    type: 'department',
+    groupId: 'deptA',
+    deletedAt: null,
+    allowExternalUsers: false,
+    ...overrides,
+  };
+}
+
+function createClient(room) {
+  return {
+    chatRoom: {
+      findUnique: async ({ where }) =>
+        where?.id === room.id ? { ...room } : null,
+    },
+    chatRoomMember: {
+      findFirst: async () => null,
+    },
+  };
+}
+
+test('ensureChatRoomContentAccess: department allows groupAccountIds match', async () => {
+  const room = buildRoom({ groupId: 'group-uuid-1' });
+  const client = createClient(room);
+
+  const res = await ensureChatRoomContentAccess({
+    roomId: room.id,
+    userId: 'u1',
+    roles: ['user'],
+    projectIds: [],
+    groupIds: [],
+    groupAccountIds: ['group-uuid-1'],
+    client,
+  });
+
+  assert.equal(res.ok, true);
+});
+
+test('ensureChatRoomContentAccess: department allows groupIds match', async () => {
+  const room = buildRoom({ groupId: 'dept-sales' });
+  const client = createClient(room);
+
+  const res = await ensureChatRoomContentAccess({
+    roomId: room.id,
+    userId: 'u1',
+    roles: ['user'],
+    projectIds: [],
+    groupIds: ['dept-sales'],
+    groupAccountIds: [],
+    client,
+  });
+
+  assert.equal(res.ok, true);
+});
+
+test('ensureChatRoomContentAccess: department denies when no group match', async () => {
+  const room = buildRoom({ groupId: 'dept-sales' });
+  const client = createClient(room);
+
+  const res = await ensureChatRoomContentAccess({
+    roomId: room.id,
+    userId: 'u1',
+    roles: ['user'],
+    projectIds: [],
+    groupIds: ['dept-hr'],
+    groupAccountIds: ['group-uuid-9'],
+    client,
+  });
+
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, 'forbidden_room_member');
+});


### PR DESCRIPTION
## 概要
- chatRoomAccess に client 注入（DI）を追加し、ユニットテストで dual-read（groupIds / groupAccountIds）を検証できるようにしました。

## 変更点
- ensureChatRoomContentAccess に `client` オプション追加
- department ルームの groupIds/groupAccountIds 判定のテスト追加

## テスト
- node:test（`packages/backend/test/chatRoomAccess.test.js`）

Refs: #785