### PR TITLE
feat: use groupAccountIds in auth/UI gating

### DIFF
--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -353,7 +353,13 @@ function applyHeaderAuth(req: any) {
     .split(',')
     .map((g: string) => g.trim())
     .filter(Boolean);
-  req.user = { userId, roles, orgId, projectIds, groupIds };
+  const groupAccountIdsHeader =
+    (req.headers['x-group-account-ids'] as string) || '';
+  const groupAccountIds = groupAccountIdsHeader
+    .split(',')
+    .map((g: string) => g.trim())
+    .filter(Boolean);
+  req.user = { userId, roles, orgId, projectIds, groupIds, groupAccountIds };
 }
 
 function respondUnauthorized(req: any, reply: any, reason?: string) {

--- a/packages/frontend/src/sections/Approvals.tsx
+++ b/packages/frontend/src/sections/Approvals.tsx
@@ -85,7 +85,15 @@ const formatDateTime = (value?: string | null) => {
 export const Approvals: React.FC = () => {
   const auth = getAuthState();
   const userId = auth?.userId ?? '';
-  const userGroupIds = auth?.groupIds ?? [];
+  const userGroupIds = useMemo(() => auth?.groupIds ?? [], [auth?.groupIds]);
+  const userGroupAccountIds = useMemo(
+    () => auth?.groupAccountIds ?? [],
+    [auth?.groupAccountIds],
+  );
+  const actorGroupIds = useMemo(
+    () => new Set([...userGroupIds, ...userGroupAccountIds]),
+    [userGroupIds, userGroupAccountIds],
+  );
   const isPrivileged = (auth?.roles ?? []).some((role) =>
     ['admin', 'mgmt', 'exec'].includes(role),
   );
@@ -177,7 +185,7 @@ export const Approvals: React.FC = () => {
     return currentSteps.some((step) => {
       if (step.approverUserId) return step.approverUserId === userId;
       if (step.approverGroupId) {
-        return userGroupIds.includes(step.approverGroupId);
+        return actorGroupIds.has(step.approverGroupId);
       }
       return true;
     });

--- a/packages/frontend/src/sections/CurrentUser.tsx
+++ b/packages/frontend/src/sections/CurrentUser.tsx
@@ -1,5 +1,11 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { api, AuthState, getAuthState, setAuthState } from '../api';
+import {
+  api,
+  AuthState,
+  getAuthState,
+  refreshAuthStateFromServer,
+  setAuthState,
+} from '../api';
 import {
   listOfflineItems,
   processOfflineQueue,
@@ -399,6 +405,7 @@ export const CurrentUser: React.FC = () => {
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new Event('erp4:auth-updated'));
     }
+    refreshAuthStateFromServer().catch(() => undefined);
   }, []);
 
   useEffect(() => {

--- a/packages/frontend/src/sections/Dashboard.tsx
+++ b/packages/frontend/src/sections/Dashboard.tsx
@@ -292,6 +292,8 @@ export const Dashboard: React.FC = () => {
   const visibleAlerts = showAll ? alerts : alerts.slice(0, 5);
   const myPendingApprovals = useMemo(() => {
     const groupIds = auth?.groupIds ?? [];
+    const groupAccountIds = auth?.groupAccountIds ?? [];
+    const actorGroupIds = new Set([...groupIds, ...groupAccountIds]);
     if (!approvals.length) return 0;
     return approvals.filter((item) => {
       if (!item.currentStep) return false;
@@ -303,12 +305,12 @@ export const Dashboard: React.FC = () => {
       return currentSteps.some((step) => {
         if (step.approverUserId) return step.approverUserId === userId;
         if (step.approverGroupId) {
-          return groupIds.includes(step.approverGroupId);
+          return actorGroupIds.has(step.approverGroupId);
         }
         return true;
       });
     }).length;
-  }, [approvals, auth?.groupIds, userId]);
+  }, [approvals, auth?.groupIds, auth?.groupAccountIds, userId]);
 
   useEffect(() => {
     api<{ items: AlertItem[] }>('/alerts')


### PR DESCRIPTION
## 概要\n- AuthState に groupAccountIds を追加し、/me で更新して保持\n- header auth に x-group-account-ids を追加\n- 承認UI/ダッシュボードの承認判定で groupAccountIds を考慮\n\n## 影響範囲\n- backend: auth header\n- frontend: api/auth, CurrentUser, Approvals, Dashboard\n\n## 動作確認\n- npm run lint --prefix packages/backend\n- npm run lint --prefix packages/frontend\n\nRefs: #785