### PR TITLE
docs: チャット画面の対象ロール表記を更新

### DIFF
--- a/docs/manual/screen-coverage.md
+++ b/docs/manual/screen-coverage.md
@@ -39,7 +39,7 @@
 | 監査ログ | admin / mgmt | `docs/test-results/2026-01-19-frontend-e2e-r1/29-audit-logs.png` | `docs/manual/ui-manual-admin.md` |
 | 期間締め | admin / mgmt | `docs/test-results/2026-01-19-frontend-e2e-r1/30-period-locks.png` | `docs/manual/ui-manual-admin.md` |
 | プロジェクトチャット | user | `docs/test-results/2026-01-19-frontend-e2e-r1/12-project-chat.png` | `docs/manual/ui-manual-user.md` / `docs/manual/chat-guide.md` |
-| チャット（全社/部門/private_group/DM） | user / hr / external_chat | `docs/test-results/2026-01-19-frontend-e2e-r1/14-room-chat.png` | `docs/manual/ui-manual-user.md` / `docs/manual/chat-guide.md` |
+| チャット（全社/部門/private_group/DM） | user / hr / 外部ユーザ（グループACL） | `docs/test-results/2026-01-19-frontend-e2e-r1/14-room-chat.png` | `docs/manual/ui-manual-user.md` / `docs/manual/chat-guide.md` |
 | 匿名集計（人事向け） | hr | `docs/test-results/2026-01-19-frontend-e2e-r1/13-hr-analytics.png` | `docs/manual/ui-manual-admin.md` / `docs/manual/hr-guide.md` |
 
 ## 管理設定（詳細カード）


### PR DESCRIPTION
## 変更概要\n- 画面カバレッジのチャット対象ロールをグループACL前提に更新\n\n## 背景\n- #785 の方針（チャット権限はグループACLで制御）に合わせて表記を整理\n