### PR TITLE
fix: companyルームのack対象検証をグループ解決に統一

### DIFF
--- a/packages/backend/test/chatAckRecipients.test.js
+++ b/packages/backend/test/chatAckRecipients.test.js
@@ -232,7 +232,9 @@ test('validateChatAckRequiredRecipientsForRoom: company with viewerGroupIds enfo
       findMany: async () => [{ userName: 'u1' }, { userName: 'u2' }],
     },
     chatRoomMember: { findMany: async () => [] },
-    groupAccount: createGroupAccountStub([]),
+    groupAccount: createGroupAccountStub([
+      { id: 'group-uuid', displayName: 'group-uuid' },
+    ]),
     userGroup: {
       findMany: async () => [{ groupId: 'group-uuid', user: { userName: 'u1' } }],
     },


### PR DESCRIPTION
## 変更概要\n- companyルームのack対象検証で viewerGroupIds をグループ解決経由に統一\n- 既存テストをUUID解決前提に更新\n\n## 背景\n- #785: groupId(displayName/UUID)互換運用の一貫性確保\n