### PR TITLE
fix: companyルームの通知対象をviewerGroupIds優先に

### DIFF
--- a/packages/backend/src/services/chatMentionRecipients.ts
+++ b/packages/backend/src/services/chatMentionRecipients.ts
@@ -67,6 +67,9 @@ export async function resolveRoomAudienceUserIds(options: {
       members.forEach((userId) => audience.add(userId));
     }
   } else if (room.type === 'company') {
+    if (viewerGroupIds.length > 0) {
+      return viewerMemberSet;
+    }
     const members = await resolveChatAckRequiredRecipientUserIds({
       requiredUserIds: [],
       requiredRoles: ['admin', 'mgmt', 'exec', 'user', 'hr'],

--- a/packages/backend/test/chatMentionRecipients.test.js
+++ b/packages/backend/test/chatMentionRecipients.test.js
@@ -104,6 +104,24 @@ test('resolveRoomAudienceUserIds: department resolves group members', async () =
   assert.deepEqual(Array.from(res), ['u1']);
 });
 
+test('resolveRoomAudienceUserIds: company uses viewerGroupIds when set', async () => {
+  const client = createClient({
+    groupAccounts: [{ id: 'group-uuid', displayName: 'group-uuid' }],
+    memberships: [{ groupId: 'group-uuid', userId: 'u1' }],
+  });
+  const res = await resolveRoomAudienceUserIds({
+    room: {
+      id: 'company',
+      type: 'company',
+      groupId: null,
+      viewerGroupIds: ['group-uuid'],
+      allowExternalUsers: false,
+    },
+    client,
+  });
+  assert.deepEqual(Array.from(res), ['u1']);
+});
+
 test('expandRoomMentionRecipients: skips group members when audience empty', async () => {
   const client = createClient({
     groupAccounts: [{ id: 'deptB-id', displayName: 'deptB' }],


### PR DESCRIPTION
## 変更概要\n- company ルームで viewerGroupIds が設定されている場合、通知対象（audience）をグループ所属に限定\n- 期待動作のテストを追加\n\n## 背景\n- #785: グループACLに統一したため、company ルームでも allow-list を優先して通知対象を解決する\n