### PR TITLE
docs: external_chat棚卸しメモの現行方針反映

### DIFF
--- a/docs/requirements/external-chat-inventory.md
+++ b/docs/requirements/external-chat-inventory.md
@@ -15,8 +15,8 @@
 - `packages/frontend/src/pages/App.tsx`: deep link は projectIds/ロールで project-chat / room-chat を切替
 
 ## docs
-- `docs/requirements/access-control.md`, `docs/requirements/chat-rooms.md`, `docs/requirements/project-chat.md`, `docs/manual/*` で
-  `external_chat=外部ユーザ/チャットのみ` を前提
+- `docs/requirements/access-control.md`, `docs/requirements/chat-rooms.md`, `docs/requirements/project-chat.md`, `docs/manual/*` は
+  「チャット権限はグループACLで制御、external_chat は非チャット抑止の暫定用途」を前提
 
 ---
 


### PR DESCRIPTION
## 変更概要\n- external_chat の棚卸しメモを現行方針（チャットはACL、external_chatは非チャット抑止の暫定）に合わせて更新\n\n## 背景\n- #785: 文書の整合性確保\n