### PR TITLE
chore: default DATABASE_URL for backend tests

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -7,8 +7,8 @@
     "dev": "ts-node-dev --respawn src/index.ts",
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public npm run build && DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public node --test",
-    "test:ci": "DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public node --test",
+    "test": "npm run build && node scripts/run-tests.js",
+    "test:ci": "node scripts/run-tests.js",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,md}\"",
     "prisma:generate": "prisma generate"

--- a/packages/backend/scripts/run-tests.js
+++ b/packages/backend/scripts/run-tests.js
@@ -1,0 +1,17 @@
+import { spawnSync } from 'node:child_process';
+
+const DEFAULT_DATABASE_URL =
+  'postgresql://user:pass@localhost:5432/postgres?schema=public';
+
+// Keep developer overrides. Only provide a default when missing/empty.
+if (!process.env.DATABASE_URL) {
+  process.env.DATABASE_URL = DEFAULT_DATABASE_URL;
+}
+
+const result = spawnSync(process.execPath, ['--test', ...process.argv.slice(2)], {
+  stdio: 'inherit',
+  env: { ...process.env },
+});
+
+process.exit(result.status ?? 1);
+


### PR DESCRIPTION
Closes #846

- backend tests 実行時のみ、`DATABASE_URL` 未設定なら既定値（CIと同値）を補完して `node --test` を実行（`packages/backend/scripts/run-tests.js`）
- `packages/backend/package.json` の `test` / `test:ci` は上記 wrapper を利用（POSIXの `KEY=value` 構文に依存しない）

既定値:
- `postgresql://user:pass@localhost:5432/postgres?schema=public`
