### PR TITLE
chore(security): bump fastify patch

### DIFF
--- a/packages/backend/package-lock.json
+++ b/packages/backend/package-lock.json
@@ -16,7 +16,7 @@
         "@prisma/client": "^7.3.0",
         "@sinclair/typebox": "^0.34.48",
         "@types/web-push": "^3.6.4",
-        "fastify": "^5.7.2",
+        "fastify": "^5.7.4",
         "fastify-plugin": "^5.1.0",
         "googleapis": "^171.0.0",
         "jose": "^6.1.3",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -25,7 +25,7 @@
     "@prisma/client": "^7.3.0",
     "@sinclair/typebox": "^0.34.48",
     "@types/web-push": "^3.6.4",
-    "fastify": "^5.7.2",
+    "fastify": "^5.7.4",
     "fastify-plugin": "^5.1.0",
     "googleapis": "^171.0.0",
     "jose": "^6.1.3",


### PR DESCRIPTION
Closes #850

## 変更内容
- `packages/backend/package.json` の Fastify を `^5.7.4` へ更新
- `packages/backend/package-lock.json` の Fastify 解決バージョンを 5.7.4 へ更新（5.7.x内のパッチ更新）

## 背景
- Dependabot で Fastify の advisory（high/low）が検出されたため、修正が含まれる patch へ更新。

## 確認
- `npm run lint --prefix packages/backend`
- `npm run test:ci --prefix packages/backend`
- `npm audit --prefix packages/backend --audit-level=high`（moderate は別途）
