### PR TITLE
Docs: manual-test-checklist を現行実装に追従

### DIFF
--- a/docs/manual/manual-test-checklist.md
+++ b/docs/manual/manual-test-checklist.md
@@ -1,31 +1,88 @@
 # 手動確認チェックリスト（PoC）
 
 ## バックエンド API
+### 基本（案件/請求/工数）
 - [ ] POST /projects → /projects/:id/estimates → /projects/:id/invoices → /invoices/:id/send のハッピーパスが通る
-- [ ] POST/GET /time-entries （非管理ロールなら自分のデータのみ取得）
-- [ ] POST/GET /expenses （非管理ロールなら自分のデータのみ取得）
+- [ ] POST/GET /time-entries（非管理ロールは自分のデータのみ取得できる）
 - [ ] /alert-settings CRUD と /jobs/alerts/run で alert が保存される
 - [ ] /jobs/approval-escalations/run で承認期限エスカレーションが保存される
+- [ ] /approval-rules CRUD のハッピーパス
+- [ ] /projects/:id/members の GET/POST/DELETE が動作する
+- [ ] /projects/:id/member-candidates?q= の候補検索が動作する
+- [ ] /projects/:id/members/bulk で複数メンバーの追加が動作する
 - [ ] /pdf-templates と /template-settings CRUD が動作する
 - [ ] /document-send-logs/:id と /document-send-logs/:id/events が取得できる
 - [ ] /document-send-logs/:id/retry で再送が記録される
 - [ ] /report-subscriptions CRUD → /report-subscriptions/:id/run で report_deliveries が作成される
 - [ ] /jobs/report-subscriptions/run と /jobs/report-deliveries/retry が動作する
-- [ ] /approval-rules CRUD のハッピーパス
-- [ ] /projects/:id/members のGET/POST/DELETEが動作する
-- [ ] /projects/:id/member-candidates?q= の候補検索が動作する
-- [ ] /projects/:id/members/bulk で複数メンバーの追加が動作する
-- [ ] /vendor-quotes 作成と /vendor-invoices 作成→approve が通る
-- [ ] /wellbeing-entries POST → HR/AdminでGETできる
+
+### チャット（確認依頼 ack required）
+- [ ] GET /projects/:projectId/chat-ack-candidates?q= で候補（users/groups）が取得できる（q は2文字以上）
+- [ ] POST /projects/:projectId/chat-ack-requests/preview で requiredUserIds の展開結果が確認できる
+- [ ] POST /projects/:projectId/chat-ack-requests（dueAt 任意）で確認依頼を作成できる（message.ackRequest が作成される）
+- [ ] GET /chat-ack-requests/:id で dueAt/canceledAt/acks が取得できる
+- [ ] POST /chat-ack-requests/:id/ack で requiredUserIds のユーザが OK できる（冪等）
+- [ ] POST /chat-ack-requests/:id/revoke で OK 取消できる
+- [ ] POST /chat-ack-requests/:id/cancel で作成者または admin/mgmt が撤回できる（canceledAt/canceledBy）
+
+### 通知ジョブ（運用）
+- [ ] POST /jobs/chat-ack-reminders/run（dryRun/limit）で期限到来（dueAt<=now）の未完了確認依頼に対し、通知候補/生成件数が返る
+- [ ] POST /jobs/leave-upcoming/run（targetDate/dryRun）で休暇開始日の通知（leave_upcoming）が生成される（本人+admin/mgmt）
+
+### 経費（支払状態）
+- [ ] POST/GET /expenses（非管理ロールは自分のデータのみ取得できる）
+- [ ] POST /expenses/:id/submit で承認依頼できる
+- [ ] （承認後）POST /expenses/:id/mark-paid で settlementStatus=paid / paidAt / paidBy が設定される（監査ログ、通知 expense_mark_paid）
+- [ ] POST /expenses/:id/unmark-paid は reasonText 必須で、settlementStatus=unpaid に戻る（paidAt/paidBy クリア、監査ログ）
+
+### 仕入/発注（PO↔VI、配賦明細）
+- [ ] /vendor-quotes 作成と /vendor-invoices 作成 → /vendor-invoices/:id/submit → /vendor-invoices/:id/approve のハッピーパスが通る
+- [ ] POST /vendor-invoices/:id/link-po で PO を紐づけできる（案件/業者一致、監査ログ）
+- [ ] POST /vendor-invoices/:id/unlink-po で PO 紐づけを解除できる（監査ログ）
+- [ ] PUT /vendor-invoices/:id/allocations で配賦明細を更新できる（合計=請求合計、autoAdjust による端数調整）
+- [ ] allocations を空配列で送ると配賦明細をクリアできる（監査ログ）
+- [ ] purchaseOrderLineId 指定時、VI が PO 未紐づけの場合は 400、別 PO の line は 400、存在しない line は 404
+
+### その他
+- [ ] /wellbeing-entries POST → HR/Admin で GET できる
+- [ ] /notifications の取得/既読化が動作する（unread-count、read）
+- [ ] /audit-logs で主要操作の監査ログが参照できる（chat_ack_*、expense_mark_paid/expense_unmark_paid、vendor_invoice_*、*_run）
 
 ## フロント PoC
+### ダッシュボード/通知
 - [ ] ダッシュボード: アラートカードが最新5件表示される（なければプレースホルダ）
+- [ ] ダッシュボード: 通知カードが表示され、クリックで該当画面に遷移できる（chat/休暇/経費）
+
+### チャット
+- [ ] チャット: 確認依頼を作成できる（対象ユーザ/グループ/ロール、期限 dueAt 任意）
+- [ ] チャット: 期限表示と「期限超過」表示が条件に応じて切り替わる
+- [ ] チャット: OK / OK取消 / 撤回 が権限条件に応じて操作できる
+
+### 日報+工数
 - [ ] 日報+WB: Good/Not Good 送信、Not Good時タグ/コメント/ヘルプ導線
 - [ ] 工数入力: プロジェクト/タスク/日付/時間/作業種別/場所を入力→一覧に反映
+
+### 請求
 - [ ] 請求: 作成→送信、詳細モックの表示
+
+### 案件
 - [ ] 案件: メンバー管理（一覧/追加/削除/権限更新）が動作する
 - [ ] 案件: メンバー候補検索で候補が表示され、選択できる
 - [ ] 案件: CSVインポート/エクスポートが動作する
+
+### 経費
+- [ ] 経費入力: プロジェクト/区分/日付/金額/通貨/共通経費/領収書URL を入力→一覧に反映
+- [ ] 経費: 支払完了通知（expense_mark_paid）が通知カードに表示され、対象経費に遷移できる
+
+### 仕入/発注（PO↔VI）
+- [ ] 仕入/発注: VI 一覧が取得でき、PO 連携状態が表示される
+- [ ] 仕入/発注: VI の PO 紐づけ/解除ができる（ステータスにより理由入力の要否が変わる）
+- [ ] 仕入/発注: VI の配賦明細が表示/更新できる（合計、差分、端数調整の挙動）
+- [ ] 仕入/発注: 必要に応じて PO/VI のPDFを参照できる（stub の場合は警告表示）
+
+### 運用ジョブ（AdminJobs）
+- [ ] AdminJobs: chat ack reminders / leave upcoming を dryRun/実行でき、結果(JSON)が表示される
+- [ ] 実行後、通知カードに反映される（必要に応じて /notifications で確認）
 
 ## 環境・その他
 - [ ] CI (backend/frontend/lint/lychee) が緑


### PR DESCRIPTION
## 変更内容
- `docs/manual/manual-test-checklist.md` を現行実装に合わせて更新
  - チャット確認依頼（ack required / dueAt / 期限超過 / OK・取消・撤回）
  - 通知ジョブ（`/jobs/chat-ack-reminders/run`、`/jobs/leave-upcoming/run`）
  - 経費（`mark-paid` / `unmark-paid`）
  - 仕入請求（VI）の PO 紐づけ、配賦明細（更新/クリア、purchaseOrderLineId の整合など）

## 確認
- `make format-check`

Closes #854
