### PR TITLE
docs: expand e2e troubleshooting

### DIFF
--- a/docs/manual/e2e-evidence-howto.md
+++ b/docs/manual/e2e-evidence-howto.md
@@ -22,6 +22,10 @@ CI では `E2E_CAPTURE=0`（証跡なし）で実行します。
 E2E_CAPTURE=1 E2E_SCOPE=core ./scripts/e2e-frontend.sh
 ```
 
+補足:
+- Podman DB のポート（既定: 55433）が使用中の場合、`E2E_PODMAN_HOST_PORT` 未指定なら空きポートへ自動フォールバックします。
+- ポートを固定したい場合は `E2E_PODMAN_HOST_PORT=55435` のように明示指定します（競合時はエラーで停止）。
+
 保存先（既定）:
 - `docs/test-results/<YYYY-MM-DD>-frontend-e2e/`
 
@@ -30,6 +34,25 @@ E2E_CAPTURE=1 E2E_SCOPE=core ./scripts/e2e-frontend.sh
 E2E_CAPTURE=1 E2E_SCOPE=core \
 E2E_EVIDENCE_DIR="$PWD/docs/test-results/2026-01-19-frontend-e2e-r1" \
 ./scripts/e2e-frontend.sh
+```
+
+## 失敗ケースだけ再実行（E2E_GREP）
+例: vendor docs の smoke（extended）のみ再実行
+```bash
+E2E_GREP="vendor docs create" E2E_CAPTURE=0 ./scripts/e2e-frontend.sh
+```
+
+## DB を direct で使う（E2E_DB_MODE=direct）
+`psql` が利用できるローカルDBがある場合:
+```bash
+E2E_DB_MODE=direct DATABASE_URL="postgresql://..." \
+E2E_CAPTURE=0 E2E_SCOPE=core ./scripts/e2e-frontend.sh
+```
+
+## Playwright install をスキップ（任意）
+Playwright のブラウザが既にインストール済みであれば:
+```bash
+E2E_SKIP_PLAYWRIGHT_INSTALL=1 E2E_CAPTURE=0 E2E_SCOPE=core ./scripts/e2e-frontend.sh
 ```
 
 ## 失敗時の診断（最小）

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -25,6 +25,16 @@
 - `psql` が利用できる（direct mode の場合）
 - `playwright install chromium` が完了している
 
+よくある原因/対処:
+- Podman DB のポート競合:
+  - `E2E_PODMAN_HOST_PORT` 未指定の場合、`scripts/e2e-frontend.sh` が空きポートへ自動フォールバックします（ログに表示）。
+  - ポートを固定したい場合は `E2E_PODMAN_HOST_PORT=55435` のように明示指定します（競合時はエラーで停止）。
+- `E2E_DB_MODE=direct`:
+  - `DATABASE_URL` が必須です（例: `postgresql://...`）。
+  - `psql` が必要です（未導入の場合は `E2E_DB_MODE=podman` を利用）。
+- Playwright のインストール:
+  - 既にインストール済みであれば `E2E_SKIP_PLAYWRIGHT_INSTALL=1` でスキップできます。
+
 ローカル実行手順は [e2e-evidence-howto](e2e-evidence-howto.md) を参照。
 
 ## 4. チャット添付が失敗する


### PR DESCRIPTION
Closes #862

## 変更内容
- `docs/manual/troubleshooting.md` の「E2E が落ちる（Playwright）」に、ポート競合・direct mode・Playwright install の要点を追記
- `docs/manual/e2e-evidence-howto.md` に、`E2E_GREP` / `E2E_PODMAN_HOST_PORT` / `E2E_DB_MODE=direct` / `E2E_SKIP_PLAYWRIGHT_INSTALL` の再実行例を追記

## 確認
- `npm run format:check --prefix packages/frontend`
