### PR TITLE
Add PR comment export script

### DIFF
--- a/scripts/gh-pr-export-comments.sh
+++ b/scripts/gh-pr-export-comments.sh
@@ -24,7 +24,18 @@ USAGE
 pr_number="${1:-}"
 out_dir="${2:-}"
 
-if [[ -z "$pr_number" || "$pr_number" == "-h" || "$pr_number" == "--help" ]]; then
+if [[ "$pr_number" == "-h" || "$pr_number" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ -z "$pr_number" ]]; then
+  usage
+  exit 1
+fi
+
+if ! [[ "$pr_number" =~ ^[0-9]+$ ]] || [[ "$pr_number" -le 0 ]]; then
+  echo "Error: pr_number must be a positive integer, got: '$pr_number'." >&2
   usage
   exit 1
 fi
@@ -33,9 +44,22 @@ if [[ -z "$out_dir" ]]; then
   out_dir="$ROOT_DIR/tmp/pr-${pr_number}"
 fi
 
+if [[ "$out_dir" == -* ]]; then
+  echo "Error: out_dir must not start with '-': '$out_dir'" >&2
+  exit 1
+fi
+if [[ "$out_dir" == *".."* ]]; then
+  echo "Error: out_dir must not contain '..': '$out_dir'" >&2
+  exit 1
+fi
+
 mkdir -p "$out_dir"
 
 repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+if [[ -z "$repo" || "$repo" != */* ]]; then
+  echo "Error: failed to determine GitHub repository (expected OWNER/REPO), got: '$repo'." >&2
+  exit 1
+fi
 
 pr_json="$out_dir/pr.json"
 issue_comments_json="$out_dir/issue-comments.json"
@@ -43,9 +67,15 @@ review_comments_json="$out_dir/review-comments.json"
 reviews_json="$out_dir/reviews.json"
 summary_md="$out_dir/summary.md"
 
+echo "Exporting PR #${pr_number} comments for ${repo}..."
+
+echo "- fetching PR details"
 gh api "repos/${repo}/pulls/${pr_number}" > "$pr_json"
+echo "- fetching issue comments"
 gh api "repos/${repo}/issues/${pr_number}/comments" --paginate > "$issue_comments_json"
+echo "- fetching review comments (inline)"
 gh api "repos/${repo}/pulls/${pr_number}/comments" --paginate > "$review_comments_json"
+echo "- fetching reviews"
 gh api "repos/${repo}/pulls/${pr_number}/reviews" --paginate > "$reviews_json"
 
 exported_at_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -126,7 +156,7 @@ fi
     "### " + (.user.login // "unknown") + " (" + (.created_at // "") + ")\n" +
     "- url: " + (.html_url // "") + "\n" +
     "- file: " + (.path // "") + "\n" +
-    "- line: " + ((.line // .original_line // 0) | tostring) + "\n\n" +
+    "- line: " + (if .line != null then (.line|tostring) elif .original_line != null then (.original_line|tostring) else "unknown" end) + "\n\n" +
     (.body // "") + "\n"
   ' "$review_comments_json"
 } >"$summary_md"
@@ -134,4 +164,3 @@ fi
 echo "exported:"
 echo "- $out_dir"
 echo "- $summary_md"
-


### PR DESCRIPTION
## 変更内容
- `gh pr view <num> --comments` が GraphQL の `projectCards` 参照で失敗する場合でも、PRレビュー/コメントを取得できるスクリプトを追加
  - `scripts/gh-pr-export-comments.sh`
  - REST API（`gh api`）で PR本文 / issue comments / reviews / review comments を取得し、JSON保存 + `summary.md` を生成

## 確認
```bash
./scripts/gh-pr-export-comments.sh 871 tmp/pr-871-export-test
```

Fixes #874
