### PR TITLE
docs: UI証跡リンク/日付の整合

### DIFF
--- a/docs/manual/ui-manual-admin.md
+++ b/docs/manual/ui-manual-admin.md
@@ -3,8 +3,10 @@
 ## 前提
 
 - 本書は PoC 環境の UI 操作に関する詳細ガイドです。
-- 画面キャプチャは 2026-01-19 実行の E2E（r1）で取得しています。
+- 画面キャプチャは 2026-02-05 実行の E2E（r1）で取得しています。
   - 証跡: `docs/test-results/2026-02-05-frontend-e2e-r1/`
+- UI証跡の再取得手順: [ui-evidence-quickstart](ui-evidence-quickstart.md)（詳細: [e2e-evidence-howto](e2e-evidence-howto.md)）
+- Push通知の証跡のみ `docs/test-results/2026-01-19-frontend-e2e-pwa-push/` で取得しています。
 - 画面の表示内容は demo seed に基づきます（データ差分あり）。
 - 対象ロールの目安: admin / mgmt / exec / hr
 - 利用者向けの操作は `docs/manual/ui-manual-user.md` を参照してください。

--- a/docs/manual/ui-manual-user.md
+++ b/docs/manual/ui-manual-user.md
@@ -5,6 +5,7 @@
 - 画面キャプチャは 2026-02-05 実行の E2E（r1）で取得しています。
   - 証跡: `docs/test-results/2026-02-05-frontend-e2e-r1/`
 - UI証跡の再取得手順: [ui-evidence-quickstart](ui-evidence-quickstart.md)（詳細: [e2e-evidence-howto](e2e-evidence-howto.md)）
+- Push通知の証跡のみ `docs/test-results/2026-01-19-frontend-e2e-pwa-push/` で取得しています。
 - 画面の表示内容は demo seed に基づきます（データ差分あり）。
 - 対象ロールの目安: user
 - 管理者向けの操作は `docs/manual/ui-manual-admin.md` を参照してください。


### PR DESCRIPTION
- ui-manual-admin の画面キャプチャ取得日付を 2026-02-05（E2E r1）に合わせる\n- UI証跡の再取得手順（quickstart/howto）へのリンクを追加\n- Push通知の証跡のみ 2026-01-19 の別ディレクトリ取得である旨を明記（user/admin 両方）\n\nformat-check: OK