### PR TITLE
chore: make に ui-evidence / pr-comments を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint format-check typecheck build test e2e audit
+.PHONY: lint format-check typecheck build test e2e ui-evidence pr-comments audit
 
 lint:
 	npm run lint --prefix packages/backend
@@ -21,6 +21,13 @@ test:
 
 e2e:
 	./scripts/e2e-frontend.sh
+
+ui-evidence:
+	./scripts/e2e-ui-evidence.sh
+
+pr-comments:
+	@test -n "$(PR)" || (echo "Usage: make pr-comments PR=<number> [OUT_DIR=...]" >&2; exit 1)
+	./scripts/gh-pr-export-comments.sh "$(PR)" "$(OUT_DIR)"
 
 audit:
 	npm audit --prefix packages/backend --audit-level=high

--- a/docs/manual/e2e-evidence-howto.md
+++ b/docs/manual/e2e-evidence-howto.md
@@ -28,6 +28,11 @@ E2E_CAPTURE=1 E2E_SCOPE=core ./scripts/e2e-frontend.sh
 ./scripts/e2e-ui-evidence.sh
 ```
 
+Makefile を使う場合:
+```bash
+make ui-evidence
+```
+
 補足:
 - Podman DB のポート（既定: 55433）が使用中、または Podman の既存コンテナにより予約されている場合、`E2E_PODMAN_HOST_PORT` 未指定なら空きポートへ自動フォールバックします。
 - ポートを固定したい場合は `E2E_PODMAN_HOST_PORT=55435` のように明示指定します（競合時はエラーで停止）。

--- a/docs/manual/ui-evidence-quickstart.md
+++ b/docs/manual/ui-evidence-quickstart.md
@@ -12,6 +12,11 @@
 ./scripts/e2e-ui-evidence.sh
 ```
 
+Makefile を使う場合:
+```bash
+make ui-evidence
+```
+
 生成物:
 - `docs/test-results/<YYYY-MM-DD>-frontend-e2e-rN/`（証跡ディレクトリ）
 - `docs/test-results/<YYYY-MM-DD>-frontend-e2e-rN.md`（実行ログ）
@@ -30,4 +35,3 @@ E2E_GREP="frontend smoke" ./scripts/e2e-ui-evidence.sh
 ## 注意
 - 既存の証跡を上書きしない方針です（同名が存在する場合はエラーになります）
 - 取得した証跡を UI マニュアルに反映する場合は、`docs/manual/ui-manual-*.md` の参照先（画像パス）も更新してください
-

--- a/docs/quality/definition-of-done.md
+++ b/docs/quality/definition-of-done.md
@@ -32,3 +32,6 @@ PR（変更単位）で「完了」と見なす条件を定義し、レビュー
 - 「デフォルト安全」を優先する（例: 外部送信は allowlist、スキャナ停止時は fail closed 等）
 - シークレット/トークンをリポジトリにコミットしない（例: `.env`、鍵、認証情報）
 
+## レビュー補助（任意）
+- PR のレビュー本文/インラインコメント（suggestion含む）の全件確認には、`make pr-comments PR=<number>` を利用できます
+  - 生成物: `tmp/pr-<number>/summary.md`（REST API で取得するため、GraphQL 互換問題の影響を受けません）

--- a/docs/quality/quality-gates.md
+++ b/docs/quality/quality-gates.md
@@ -95,6 +95,7 @@ CIで何を検査しているか、どれを「必須ゲート（ブロック）
 - `make typecheck`
 - `make test`
 - `make e2e`
+- `make ui-evidence`（UI証跡の再取得。任意）
 
 ### Lint/Format
 - backend: `npm run lint --prefix packages/backend && npm run format:check --prefix packages/backend`


### PR DESCRIPTION
- Makefile に以下を追加
  - `make ui-evidence`: UI証跡（スクショ）を `scripts/e2e-ui-evidence.sh` で再取得
  - `make pr-comments PR=<number>`: PRの本文/レビュー/インラインコメント（suggestion含む）を `tmp/pr-<number>/summary.md` に出力
- 関連ドキュメントを更新（manual/quality）

format-check: OK