### PR TITLE
docs: AGENTS に ui-evidence / pr-comments の使い方を追記

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,17 @@ E2E_SCOPE=core E2E_CAPTURE=0 ./scripts/e2e-frontend.sh
 - Podman DBのポート（既定: 55433）が使用中の場合、`E2E_PODMAN_HOST_PORT` が未指定なら空きポートへ自動フォールバックします。
 - ポートを固定したい場合は `E2E_PODMAN_HOST_PORT=55435` のように明示指定してください（競合時はエラーで停止します）。
 
+### UI証跡（スクショ）再取得（任意）
+```bash
+make ui-evidence
+```
+
+### PRレビューコメント出力（任意）
+GraphQL互換問題（Projects classic等）で `gh pr view --comments` が失敗する場合の代替です。
+```bash
+make pr-comments PR=123
+```
+
 ## PR作成前の最小チェック
 - lint / format / typecheck / test を通す
 - 依存更新がある場合、`make audit`（high/critical）を通す


### PR DESCRIPTION
- Makefile に追加した補助ターゲットの利用方法を AGENTS.md に追記
  - make ui-evidence: UI証跡（スクショ）再取得
  - make pr-comments PR=123: PRコメント出力（gh pr view --comments の代替）
- PR作成前の最小チェック（lint/format/typecheck/test 等）は従来通り

format-check: OK