### PR TITLE
docs: AV本番有効化の判定ゲートとRunbookを明確化

### DIFF
--- a/docs/ops/antivirus.md
+++ b/docs/ops/antivirus.md
@@ -3,13 +3,29 @@
 ## 入口
 詳細は `docs/requirements/chat-attachments-antivirus.md` を参照。
 
-## 検証用スモーク
-添付スキャンのスモークテスト:
-- `scripts/smoke-chat-attachments-av.sh`
+## 運用モード
+1. `disabled`（既定）
+   - スキャンなし。導入前/方針未確定時の運用。
+2. `clamav`
+   - clamd 連携でスキャン。利用不能時は 503（fail closed）。
+
+## 本番有効化チェックリスト（Issue #886）
+- [ ] `CHAT_ATTACHMENT_AV_PROVIDER` 方針を確定（`disabled` 維持 or `clamav` 有効化）
+- [ ] fail closed を業務上許容するかを確定（不可の場合は代替フローを定義）
+- [ ] 定義更新方式を確定（`freshclam --daemon` / 定期ジョブ / イメージ更新）
+- [ ] 監視/アラート閾値を確定（clamd死活、`chat_attachment_scan_failed`、タイムアウト）
+- [ ] 復旧Runbookを確定（検知→切り分け→復旧→再検証）
+- [ ] ステージング検証結果を `docs/test-results/` に記録
 
 過去の検証結果:
 - `docs/test-results/2026-01-16-chat-attachments-av.md`
 
-## 定義更新（ClamAV）
-検証では `docker.io/clamav/clamav` が `freshclam` を同一コンテナ内で起動し、定義更新を行うことを確認しています。
-詳細は `docs/requirements/chat-attachments-antivirus.md` を参照。
+## 検証コマンド
+- clamd 疎通/EICAR 検証: `bash scripts/podman-clamav.sh check`
+- API統合スモーク: `bash scripts/smoke-chat-attachments-av.sh`
+
+## 復旧時の最小手順
+1. clamd の死活確認（コンテナ/プロセス/TCP 3310）
+2. `chat_attachment_scan_failed` の件数を確認して影響範囲を把握
+3. clamd を復旧後、`bash scripts/podman-clamav.sh check` を実行
+4. API統合スモークを再実行し、正常化を確認

--- a/docs/plan/todo.md
+++ b/docs/plan/todo.md
@@ -3,7 +3,7 @@
 ## 残作業（運用確定）
 - [ ] #544 S3 バケット/リージョン/KMS の確定値を `docs/requirements/backup-restore.md` に反映
 - [ ] #544 S3/OSS 移行の時期を決定（`docs/requirements/backup-restore.md`）
-- [ ] （後続）GitHub Packages 配布復旧後に `@itdojp/design-system@1.0.2`（または最新）へ依存を戻す（現状: `github:itdojp/itdo-design-system#bump-1.0.2`）
+- [ ] #887 GitHub Packages 配布復旧後に `@itdojp/design-system@1.0.2`（または最新）へ依存を戻す（現状: `github:itdojp/itdo-design-system#bump-1.0.2`）
 - [x] #648 E2E/統合テストの拡充（手動チェックの自動化開始）
 - [x] #650 依存関係更新の運用ルール整備（`docs/quality/dependency-update-policy.md`）
 - [x] #649 監査ログ/操作ログ 基盤の整理（PIIマスキング・相関ID）
@@ -33,8 +33,8 @@
     - [x] 運用設計（叩き台）を docs に追加（PR #566）
     - [x] Podman で clamd を起動/停止/疎通できる補助スクリプトを追加（PR #567）
     - [x] readiness 改善（PING/PONG）+ 統合スモーク + テスト結果記録（PR #568）
-  - [ ] （運用判断）AVスキャン本番有効化方針（`disabled` 継続 or `clamav`）の決定
-  - [ ] （運用判断）定義更新/監視/障害時の運用方針の最終決定（`docs/requirements/chat-attachments-antivirus.md`）
+  - [ ] #886 AVスキャン本番有効化方針（`disabled` 継続 or `clamav`）の決定
+  - [ ] #886 定義更新/監視/障害時の運用方針の最終決定（`docs/requirements/chat-attachments-antivirus.md`）
   - [x] FE: SCIM 設定/状態のUI（/scim/status）
 
 ## 次アクション（プロジェクト運用/レポート）

--- a/docs/requirements/chat-attachments-antivirus.md
+++ b/docs/requirements/chat-attachments-antivirus.md
@@ -73,6 +73,22 @@ ClamAV 定義更新は以下のいずれかを採用する前提で運用を確�
   - 本実装はスキャナ利用不能時に 503 で拒否（fail closed）
   - 影響（添付不可）を許容できない場合は、運用として「復旧優先度」を定義する
 
+### 本番有効化の判定ゲート（Issue #886）
+
+`CHAT_ATTACHMENT_AV_PROVIDER=clamav` を本番で有効化する前に、以下を満たすことを必須とする。
+
+1. セキュリティ要件
+   - 外部ユーザを含む添付利用で「スキャンなし」を許容しないことが、運用責任者/セキュリティ責任者で合意されている。
+2. 可用性要件
+   - fail closed（スキャナ停止時は 503）を業務として許容するか、許容しない場合の代替フロー（受付窓口/一次保管）が定義されている。
+3. 運用要件
+   - 定義更新方式（`freshclam --daemon` / 定期ジョブ / イメージ更新）を選定し、担当/頻度/障害時手順が確定している。
+   - 監視対象（clamd死活、`chat_attachment_scan_failed`、タイムアウト増加）に対するアラート閾値と一次対応手順が確定している。
+4. 検証要件
+   - ステージングで `bash scripts/smoke-chat-attachments-av.sh` を実行し、結果を `docs/test-results/` に記録している。
+
+上記が未確定の場合は `CHAT_ATTACHMENT_AV_PROVIDER=disabled` を維持する。
+
 ## テスト（手動）
 
 1. backend を `CHAT_ATTACHMENT_AV_PROVIDER=eicar` で起動


### PR DESCRIPTION
Refs: #886, #887

## 変更内容
- `docs/requirements/chat-attachments-antivirus.md` に「本番有効化の判定ゲート（Issue #886）」を追加
  - 有効化前の必須条件（セキュリティ/可用性/運用/検証）を明文化
  - 未確定時は `CHAT_ATTACHMENT_AV_PROVIDER=disabled` 維持と明記
- `docs/ops/antivirus.md` を運用Runbookとして拡張
  - 運用モード整理（disabled/clamav）
  - 本番有効化チェックリスト、検証コマンド、復旧最小手順を追記
- `docs/plan/todo.md` の残タスクを Issue 番号と紐付け
  - design-system 依存戻しを `#887`
  - AV運用確定タスクを `#886`

## 検証
- `make format-check` pass

## 補足
- #887 については GitHub Packages 取得確認を実施済み（2026-02-06 時点で 404）。