### PR TITLE
test: チャット添付AVスモーク再実行結果を記録

### DIFF
--- a/docs/test-results/2026-02-06-chat-attachments-av-r2.md
+++ b/docs/test-results/2026-02-06-chat-attachments-av-r2.md
@@ -1,0 +1,38 @@
+# チャット添付AV（ClamAV/clamd）再検証（r2）
+
+## 目的
+- Issue #886 の「有効化する場合の検証」項目に対して、現行スモークを再実行し挙動を確認する。
+
+## 実行情報
+- 実行日: 2026-02-06
+- 実行コマンド: `bash scripts/smoke-chat-attachments-av.sh`
+- 前提:
+  - Podman が利用可能
+  - backend build 実行済み（スクリプト内で不足時に実行）
+  - `CHAT_ATTACHMENT_AV_PROVIDER=clamav`
+
+## 結果サマリ
+- clean 添付（clamd 稼働中）: `200`
+- EICAR 添付（clamd 稼働中）: `422` / `VIRUS_DETECTED`
+- clean 添付（clamd 停止後）: `503`
+- 結論: 期待通り（`FOUND` は拒否、スキャナ停止時は fail closed）
+
+## 実行ログ（要点）
+```text
+[4/7] start backend (PORT=3003)
+backend ready
+[5/7] create private group room
+room_id=cd3fb9f6-ade4-46a7-a549-19e5864a7027
+[6/7] post message
+message_id=c03808e3-2f0e-4f52-a37b-11d05f1d08fb
+[7/7] attachment scan cases
+upload clean (clamd up): status=200
+upload eicar (clamd up): status=422
+error_code=VIRUS_DETECTED
+stop clamd and expect 503
+upload clean (clamd down): status=503
+smoke ok
+```
+
+## 補足
+- 再検証時に `scripts/smoke-chat-attachments-av.sh` の `DATABASE_URL` が `npm run prisma:generate` へ伝播しない不具合を確認したため、`DATABASE_URL` を export する修正を適用した。

--- a/docs/test-results/README.md
+++ b/docs/test-results/README.md
@@ -10,6 +10,9 @@
 ### Performance
 - 入口: docs/test-results/perf/README.md
 
+### 2026-02-06
+- チャット添付AV（ClamAV/clamd）再検証 r2: docs/test-results/2026-02-06-chat-attachments-av-r2.md
+
 ### 2026-02-05
 - フロントE2E(UIエビデンス r1): docs/test-results/2026-02-05-frontend-e2e-r1.md
 - 証跡: docs/test-results/2026-02-05-frontend-e2e-r1/

--- a/scripts/smoke-chat-attachments-av.sh
+++ b/scripts/smoke-chat-attachments-av.sh
@@ -9,6 +9,7 @@ BASE_URL="${BASE_URL:-http://localhost:${BACKEND_PORT}}"
 DB_CONTAINER_NAME="${DB_CONTAINER_NAME:-erp4-pg-smoke-chat-av}"
 DB_HOST_PORT="${DB_HOST_PORT:-55436}"
 DATABASE_URL="${DATABASE_URL:-postgresql://postgres:postgres@localhost:${DB_HOST_PORT}/postgres?schema=public}"
+export DATABASE_URL
 
 CLAMAV_CONTAINER_NAME="${CLAMAV_CONTAINER_NAME:-erp4-clamav-smoke}"
 CLAMAV_HOST_PORT="${CLAMAV_HOST_PORT:-3311}"


### PR DESCRIPTION
Refs: #886

## 変更内容
- `scripts/smoke-chat-attachments-av.sh`
  - `DATABASE_URL` を export し、`npm run prisma:generate` 実行時にも同一DBを参照するよう修正
- `docs/test-results/2026-02-06-chat-attachments-av-r2.md`
  - ClamAV/clamd スモーク再実行結果を追加
- `docs/test-results/README.md`
  - 2026-02-06 のAV再検証記録をインデックスへ追加

## 検証
- `bash scripts/smoke-chat-attachments-av.sh`
  - clean添付（clamd up）: 200
  - EICAR添付（clamd up）: 422 (`VIRUS_DETECTED`)
  - clean添付（clamd down）: 503
- `make format-check`

## 目的
- #886 の「ステージング検証結果を記録」タスクを前進させる。