### PR TITLE
feat(frontend): DocumentSendLogsをdesign-system統一UIへ移行

### DIFF
--- a/packages/frontend/src/sections/DocumentSendLogs.tsx
+++ b/packages/frontend/src/sections/DocumentSendLogs.tsx
@@ -470,6 +470,7 @@ export const DocumentSendLogs: React.FC = () => {
                   setLogError('');
                   setEventsError('');
                   setMessage(null);
+                  setRetryTargetLogId(null);
                 }}
               >
                 クリア
@@ -505,7 +506,15 @@ export const DocumentSendLogs: React.FC = () => {
         </FilterBar>
         {message && (
           <div style={{ marginTop: 8 }}>
-            <Alert variant={message.type === 'error' ? 'error' : 'info'}>
+            <Alert
+              variant={
+                message.type === 'error'
+                  ? 'error'
+                  : message.type === 'success'
+                    ? 'success'
+                    : 'info'
+              }
+            >
               {message.text}
             </Alert>
           </div>


### PR DESCRIPTION
## 概要
- `DocumentSendLogs` 画面を design-system ベースの一覧UIへ統一
- 送信ログ/送信イベントを `CrudList + DataTable + AsyncStatePanel` 構成へ移行
- 再送操作を `ConfirmActionDialog` 経由に変更し、状態表示を `StatusBadge` へ統一

## 変更点
- `packages/frontend/src/sections/DocumentSendLogs.tsx`
  - フィルタ操作を `FilterBar` へ移行
  - ログ/イベントをテーブル化（metadata, templateId 含む）
  - 取得失敗/空状態/初期状態を `AsyncStatePanel` で統一
  - 再送の確認ダイアログを追加

## 確認
- `npm run format:check --prefix packages/frontend`
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run build --prefix packages/frontend`