### PR TITLE
docs(ops): AVスモーク結果の記録スクリプトを追加

### DIFF
--- a/docs/ops/antivirus.md
+++ b/docs/ops/antivirus.md
@@ -18,6 +18,7 @@
 ## 検証コマンド
 - clamd 疎通/EICAR 検証: `bash scripts/podman-clamav.sh check`
 - API 統合スモーク: `bash scripts/smoke-chat-attachments-av.sh`
+- 検証結果のMarkdown記録（staging向け）: `ENV_NAME=staging bash scripts/record-chat-attachments-av-smoke.sh`
 
 ## 監視対象と推奨しきい値（確定候補）
 1. 死活監視（必須）

--- a/docs/test-results/chat-attachments-av-staging-template.md
+++ b/docs/test-results/chat-attachments-av-staging-template.md
@@ -15,6 +15,7 @@
 - `CHAT_ATTACHMENT_AV_PROVIDER=clamav`
 - `CLAMAV_HOST` / `CLAMAV_PORT` 設定済み
 - clamd 起動済み（TCP 到達可能）
+- 補助: `ENV_NAME=staging bash scripts/record-chat-attachments-av-smoke.sh` で記録下書きを生成可能
 
 ## 結果サマリ
 - clean 添付（clamd 稼働中）:

--- a/scripts/record-chat-attachments-av-smoke.sh
+++ b/scripts/record-chat-attachments-av-smoke.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+RUN_DATE="${RUN_DATE:-$(date +%F)}"
+ENV_NAME="${ENV_NAME:-staging}"
+OPERATOR="${OPERATOR:-$(git config user.name || true)}"
+BACKEND_REVISION="${BACKEND_REVISION:-$(git rev-parse --short HEAD)}"
+CLAMD_IMAGE="${CLAMD_IMAGE:-docker.io/clamav/clamav:latest}"
+SMOKE_SCRIPT="${SMOKE_SCRIPT:-$ROOT_DIR/scripts/smoke-chat-attachments-av.sh}"
+SKIP_SMOKE="${SKIP_SMOKE:-0}"
+OUTPUT_FILE="${OUTPUT_FILE:-$ROOT_DIR/docs/test-results/${RUN_DATE}-chat-attachments-av-${ENV_NAME}.md}"
+
+if [[ -z "$OPERATOR" ]]; then
+  OPERATOR="unknown"
+fi
+
+extract_status() {
+  local pattern="$1"
+  local value
+  value="$(grep -E "$pattern" "$LOG_FILE" | tail -n 1 | sed -E 's/.*status=([0-9]+).*/\1/' || true)"
+  if [[ -z "$value" ]]; then
+    echo "-"
+  else
+    echo "$value"
+  fi
+}
+
+LOG_FILE="$(mktemp)"
+SMOKE_EXIT=0
+
+if [[ "$SKIP_SMOKE" == "1" ]]; then
+  echo "SKIP_SMOKE=1: smoke execution skipped" > "$LOG_FILE"
+else
+  if [[ ! -x "$SMOKE_SCRIPT" ]]; then
+    echo "smoke script not executable: $SMOKE_SCRIPT" >&2
+    exit 1
+  fi
+
+  set +e
+  bash "$SMOKE_SCRIPT" 2>&1 | tee "$LOG_FILE"
+  SMOKE_EXIT=${PIPESTATUS[0]}
+  set -e
+fi
+
+CLEAN_UP_STATUS="$(extract_status 'upload clean \(clamd up\): status=')"
+EICAR_STATUS="$(extract_status 'upload eicar \(clamd up\): status=')"
+DOWN_STATUS="$(extract_status 'upload clean \(clamd down\): status=')"
+ERROR_CODE="$(grep -E 'error_code=' "$LOG_FILE" | tail -n 1 | sed -E 's/.*error_code=([^[:space:]]+).*/\1/' || true)"
+
+if [[ -z "$ERROR_CODE" ]]; then
+  ERROR_CODE="-"
+fi
+
+if [[ "$SKIP_SMOKE" == "1" ]]; then
+  RESULT_SUMMARY="未実行（SKIP_SMOKE=1）"
+elif [[ "$SMOKE_EXIT" -eq 0 && "$CLEAN_UP_STATUS" == "200" && "$EICAR_STATUS" == "422" && "$DOWN_STATUS" == "503" ]]; then
+  RESULT_SUMMARY="期待通り（200/422/503）"
+elif [[ "$SMOKE_EXIT" -eq 0 ]]; then
+  RESULT_SUMMARY="実行完了（要結果確認）"
+else
+  RESULT_SUMMARY="失敗（exit=${SMOKE_EXIT}）"
+fi
+
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+
+cat > "$OUTPUT_FILE" <<MARKDOWN
+# チャット添付AV（${ENV_NAME}）検証
+
+## 目的
+- Issue #886 の本番有効化判定に必要な検証結果を記録する。
+
+## 実行情報
+- 実行日: ${RUN_DATE}
+- 実行者: ${OPERATOR}
+- 環境: ${ENV_NAME}
+- backend revision: ${BACKEND_REVISION}
+- clamd image / tag: ${CLAMD_IMAGE}
+- 実行コマンド: \`bash scripts/smoke-chat-attachments-av.sh\`
+
+## 結果サマリ
+- clean 添付（clamd 稼働中）: ${CLEAN_UP_STATUS}
+- EICAR 添付（clamd 稼働中）: ${EICAR_STATUS} / ${ERROR_CODE}
+- clean 添付（clamd 停止後）: ${DOWN_STATUS}
+- 結論: ${RESULT_SUMMARY}
+
+## 実行ログ（末尾）
+\`\`\`text
+$(tail -n 120 "$LOG_FILE")
+\`\`\`
+MARKDOWN
+
+rm -f "$LOG_FILE"
+
+echo "written: $OUTPUT_FILE"
+if [[ "$SMOKE_EXIT" -ne 0 ]]; then
+  exit "$SMOKE_EXIT"
+fi


### PR DESCRIPTION
## 概要
- `scripts/record-chat-attachments-av-smoke.sh` を追加
  - `scripts/smoke-chat-attachments-av.sh` 実行結果から主要ステータス（200/422/503）を抽出
  - `docs/test-results/YYYY-MM-DD-chat-attachments-av-<env>.md` 形式の記録ファイルを自動生成
  - `SKIP_SMOKE=1` でテンプレート下書き生成のみも可能
- `docs/ops/antivirus.md` に新スクリプトの利用コマンドを追記
- `docs/test-results/chat-attachments-av-staging-template.md` に補助導線を追記

## 目的
- #886 の残タスク「ステージングで同スモークを実行し、結果を docs/test-results に記録」を効率化し、記録フォーマットのばらつきを減らす。

## 確認
- `bash -n scripts/record-chat-attachments-av-smoke.sh`
- `SKIP_SMOKE=1 ENV_NAME=staging OUTPUT_FILE=/tmp/chat-av-smoke-test.md bash scripts/record-chat-attachments-av-smoke.sh`

Refs: #886
