### PR TITLE
chore: AVステージング証跡の一括記録コマンドを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint format-check typecheck build test e2e ui-evidence pr-comments audit design-system-package-check
+.PHONY: lint format-check typecheck build test e2e ui-evidence pr-comments audit design-system-package-check av-staging-evidence
 
 lint:
 	npm run lint --prefix packages/backend
@@ -35,3 +35,6 @@ audit:
 
 design-system-package-check:
 	./scripts/check-design-system-package.sh
+
+av-staging-evidence:
+	./scripts/record-chat-attachments-av-staging.sh

--- a/docs/ops/antivirus-decision-proposal.md
+++ b/docs/ops/antivirus-decision-proposal.md
@@ -60,13 +60,11 @@
   - backend とは別コンテナでリソース制限を明示
 
 ## 実行ステップ（決定まで）
-1. ステージングで `bash scripts/smoke-chat-attachments-av.sh` を実行
-2. `docs/test-results/chat-attachments-av-staging-template.md` で結果記録
-3. 監査ログ集計を実行して閾値適合を確認
-   - `ENV_NAME=staging bash scripts/record-chat-attachments-av-metrics.sh`
-4. 本メモの推奨値との差分を評価
-5. `Issue #886` の未チェック項目を更新
-6. `CHAT_ATTACHMENT_AV_PROVIDER` 本番値を確定
+1. ステージングで `make av-staging-evidence` を実行
+2. `docs/test-results/chat-attachments-av-staging-template.md` に沿って結果を確認
+3. 本メモの推奨値との差分を評価
+4. `Issue #886` の未チェック項目を更新
+5. `CHAT_ATTACHMENT_AV_PROVIDER` 本番値を確定
 
 ## 保留中の論点
 - 外部ユーザ添付の想定比率（本番環境実績）

--- a/docs/ops/antivirus.md
+++ b/docs/ops/antivirus.md
@@ -18,6 +18,7 @@
 ## 検証コマンド
 - clamd 疎通/EICAR 検証: `bash scripts/podman-clamav.sh check`
 - API 統合スモーク: `bash scripts/smoke-chat-attachments-av.sh`
+- ステージング証跡をまとめて記録（推奨）: `make av-staging-evidence`
 - 検証結果のMarkdown記録（staging向け）: `ENV_NAME=staging bash scripts/record-chat-attachments-av-smoke.sh`
 - 監査ログ集計（監視代替/閾値確認）:
   - `node scripts/report-chat-attachments-av-metrics.mjs --from=2026-02-07T00:00:00Z --to=2026-02-08T00:00:00Z --window-minutes=10`
@@ -75,3 +76,4 @@
 ## 検証結果の記録
 - 直近の検証（ローカル/PoC）: `docs/test-results/2026-02-06-chat-attachments-av-r2.md`
 - 記録テンプレート: `docs/test-results/chat-attachments-av-staging-template.md`
+- 補助: `scripts/record-chat-attachments-av-staging.sh`（smoke + audit metrics の同時記録）

--- a/docs/test-results/chat-attachments-av-staging-template.md
+++ b/docs/test-results/chat-attachments-av-staging-template.md
@@ -15,6 +15,7 @@
 - `CHAT_ATTACHMENT_AV_PROVIDER=clamav`
 - `CLAMAV_HOST` / `CLAMAV_PORT` 設定済み
 - clamd 起動済み（TCP 到達可能）
+- 推奨実行: `make av-staging-evidence`
 - 補助: `ENV_NAME=staging bash scripts/record-chat-attachments-av-smoke.sh` で記録下書きを生成可能
 - 補助: `ENV_NAME=staging bash scripts/record-chat-attachments-av-metrics.sh` で監査ログ集計を記録可能
 

--- a/scripts/record-chat-attachments-av-staging.sh
+++ b/scripts/record-chat-attachments-av-staging.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+RUN_DATE="${RUN_DATE:-$(date +%F)}"
+ENV_NAME="${ENV_NAME:-staging}"
+TO_ISO="${TO_ISO:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+FROM_ISO="${FROM_ISO:-}"
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/docs/test-results}"
+SMOKE_OUTPUT_FILE="${SMOKE_OUTPUT_FILE:-$OUT_DIR/${RUN_DATE}-chat-attachments-av-${ENV_NAME}.md}"
+METRICS_OUTPUT_FILE="${METRICS_OUTPUT_FILE:-$OUT_DIR/${RUN_DATE}-chat-attachments-av-audit-${ENV_NAME}.md}"
+
+if [[ -z "$FROM_ISO" ]]; then
+  FROM_ISO="$(node -e "const to=new Date(process.argv[1]);const from=new Date(to.getTime()-24*60*60*1000);console.log(from.toISOString());" "$TO_ISO")"
+fi
+
+mkdir -p "$OUT_DIR"
+
+echo "[1/2] record smoke evidence"
+(
+  cd "$ROOT_DIR"
+  RUN_DATE="$RUN_DATE" \
+  ENV_NAME="$ENV_NAME" \
+  OUTPUT_FILE="$SMOKE_OUTPUT_FILE" \
+  SKIP_SMOKE="${SKIP_SMOKE:-0}" \
+  bash scripts/record-chat-attachments-av-smoke.sh
+)
+
+echo "[2/2] record audit metrics evidence"
+(
+  cd "$ROOT_DIR"
+  RUN_DATE="$RUN_DATE" \
+  ENV_NAME="$ENV_NAME" \
+  TO_ISO="$TO_ISO" \
+  FROM_ISO="$FROM_ISO" \
+  OUTPUT_FILE="$METRICS_OUTPUT_FILE" \
+  bash scripts/record-chat-attachments-av-metrics.sh
+)
+
+echo "done:"
+echo "- smoke: $SMOKE_OUTPUT_FILE"
+echo "- metrics: $METRICS_OUTPUT_FILE"


### PR DESCRIPTION
## 概要
- `#886` のステージング検証手順を1コマンド化しました。
- smoke証跡と監査ログ集計証跡を同一実行で生成できるようにしています。

## 変更内容
- 追加: `scripts/record-chat-attachments-av-staging.sh`
  - `record-chat-attachments-av-smoke.sh` と `record-chat-attachments-av-metrics.sh` を連続実行
  - 出力先を `docs/test-results`（または `OUT_DIR`）で統一
  - `TO_ISO` / `FROM_ISO` を共通化して時点ズレを防止
- 追加: `Makefile`
  - `make av-staging-evidence` ターゲット
- 更新:
  - `docs/ops/antivirus.md`
  - `docs/ops/antivirus-decision-proposal.md`
  - `docs/test-results/chat-attachments-av-staging-template.md`

## 使い方
- 推奨: `make av-staging-evidence`
- 例: `DATABASE_URL=... ENV_NAME=staging TO_ISO=2026-02-07T06:00:00Z make av-staging-evidence`

## 検証
- `bash -n scripts/record-chat-attachments-av-staging.sh scripts/record-chat-attachments-av-metrics.sh scripts/record-chat-attachments-av-smoke.sh`
- `make -n av-staging-evidence`
- 一時DBで実行:
  - `DATABASE_URL=... RUN_DATE=2026-02-07 ENV_NAME=staging TO_ISO=2026-02-07T06:00:00Z OUT_DIR=/tmp SKIP_SMOKE=1 bash scripts/record-chat-attachments-av-staging.sh`

Refs #886
