### PR TITLE
test: VI明細整合ロジックの数量検証をサービス化して異常系を追加

### DIFF
--- a/packages/backend/src/services/vendorInvoiceLineReconciliation.ts
+++ b/packages/backend/src/services/vendorInvoiceLineReconciliation.ts
@@ -1,0 +1,103 @@
+const EPSILON = 0.00001;
+
+type PurchaseOrderLineQuantityInput = {
+  id: string;
+  quantity: unknown;
+};
+
+type ExistingVendorInvoiceLineQuantityInput = {
+  purchaseOrderLineId: unknown;
+  quantity: unknown;
+};
+
+type RequestedVendorInvoiceLineQuantityInput = {
+  purchaseOrderLineId: string | null;
+  quantity: number;
+};
+
+export type ExceededPurchaseOrderLineQuantity = {
+  purchaseOrderLineId: string;
+  purchaseOrderQuantity: number;
+  existingQuantity: number;
+  requestedQuantity: number;
+};
+
+type FindExceededPurchaseOrderLineQuantitiesInput = {
+  purchaseOrderLines: PurchaseOrderLineQuantityInput[];
+  existingInvoiceLines: ExistingVendorInvoiceLineQuantityInput[];
+  requestedInvoiceLines: RequestedVendorInvoiceLineQuantityInput[];
+};
+
+function normalizeId(value: unknown) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function toFiniteNumber(value: unknown) {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  if (value && typeof value === 'object') {
+    const candidate = value as { toNumber?: () => number };
+    if (typeof candidate.toNumber === 'function') {
+      const parsed = candidate.toNumber();
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+  }
+  return null;
+}
+
+export function findExceededPurchaseOrderLineQuantities(
+  input: FindExceededPurchaseOrderLineQuantitiesInput,
+): ExceededPurchaseOrderLineQuantity[] {
+  const purchaseOrderQuantityByLine = new Map<string, number>();
+  for (const line of input.purchaseOrderLines) {
+    const lineId = normalizeId(line.id);
+    if (!lineId) continue;
+    purchaseOrderQuantityByLine.set(lineId, toFiniteNumber(line.quantity) ?? 0);
+  }
+
+  const existingQtyByLine = new Map<string, number>();
+  for (const line of input.existingInvoiceLines) {
+    const lineId = normalizeId(line.purchaseOrderLineId);
+    if (!lineId) continue;
+    const current = existingQtyByLine.get(lineId) || 0;
+    existingQtyByLine.set(
+      lineId,
+      current + (toFiniteNumber(line.quantity) ?? 0),
+    );
+  }
+
+  const requestedQtyByLine = new Map<string, number>();
+  for (const line of input.requestedInvoiceLines) {
+    const lineId = normalizeId(line.purchaseOrderLineId);
+    if (!lineId) continue;
+    const current = requestedQtyByLine.get(lineId) || 0;
+    requestedQtyByLine.set(lineId, current + line.quantity);
+  }
+
+  const exceeded: ExceededPurchaseOrderLineQuantity[] = [];
+  for (const [lineId, requestedQuantity] of requestedQtyByLine) {
+    const purchaseOrderQuantity = purchaseOrderQuantityByLine.get(lineId);
+    if (purchaseOrderQuantity == null) continue;
+    const existingQuantity = existingQtyByLine.get(lineId) || 0;
+    if (
+      existingQuantity + requestedQuantity - purchaseOrderQuantity >
+      EPSILON
+    ) {
+      exceeded.push({
+        purchaseOrderLineId: lineId,
+        purchaseOrderQuantity,
+        existingQuantity,
+        requestedQuantity,
+      });
+    }
+  }
+
+  return exceeded;
+}

--- a/packages/backend/test/vendorInvoiceLineReconciliation.test.js
+++ b/packages/backend/test/vendorInvoiceLineReconciliation.test.js
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { findExceededPurchaseOrderLineQuantities } from '../dist/services/vendorInvoiceLineReconciliation.js';
+
+test('findExceededPurchaseOrderLineQuantities: allows partial invoice within PO quantity', () => {
+  const exceeded = findExceededPurchaseOrderLineQuantities({
+    purchaseOrderLines: [{ id: 'po-line-1', quantity: 10 }],
+    existingInvoiceLines: [{ purchaseOrderLineId: 'po-line-1', quantity: 4 }],
+    requestedInvoiceLines: [
+      { purchaseOrderLineId: 'po-line-1', quantity: 2 },
+      { purchaseOrderLineId: 'po-line-1', quantity: 4 },
+    ],
+  });
+  assert.equal(exceeded.length, 0);
+});
+
+test('findExceededPurchaseOrderLineQuantities: detects exceeded quantity by line', () => {
+  const exceeded = findExceededPurchaseOrderLineQuantities({
+    purchaseOrderLines: [
+      { id: 'po-line-1', quantity: 10 },
+      { id: 'po-line-2', quantity: 5 },
+    ],
+    existingInvoiceLines: [
+      { purchaseOrderLineId: 'po-line-1', quantity: 3 },
+      { purchaseOrderLineId: 'po-line-2', quantity: 2 },
+    ],
+    requestedInvoiceLines: [
+      { purchaseOrderLineId: 'po-line-1', quantity: 4 },
+      { purchaseOrderLineId: 'po-line-1', quantity: 5 },
+      { purchaseOrderLineId: 'po-line-2', quantity: 1 },
+    ],
+  });
+  assert.deepEqual(exceeded, [
+    {
+      purchaseOrderLineId: 'po-line-1',
+      purchaseOrderQuantity: 10,
+      existingQuantity: 3,
+      requestedQuantity: 9,
+    },
+  ]);
+});
+
+test('findExceededPurchaseOrderLineQuantities: tolerates floating point boundary', () => {
+  const exceeded = findExceededPurchaseOrderLineQuantities({
+    purchaseOrderLines: [{ id: 'po-line-1', quantity: 0.3 }],
+    existingInvoiceLines: [{ purchaseOrderLineId: 'po-line-1', quantity: 0.1 }],
+    requestedInvoiceLines: [{ purchaseOrderLineId: 'po-line-1', quantity: 0.2 }],
+  });
+  assert.equal(exceeded.length, 0);
+});
+
+test('findExceededPurchaseOrderLineQuantities: ignores malformed and unknown line ids', () => {
+  const exceeded = findExceededPurchaseOrderLineQuantities({
+    purchaseOrderLines: [{ id: 'po-line-1', quantity: 2 }],
+    existingInvoiceLines: [
+      { purchaseOrderLineId: 'po-line-1', quantity: 'not-a-number' },
+      { purchaseOrderLineId: '  ', quantity: 100 },
+    ],
+    requestedInvoiceLines: [
+      { purchaseOrderLineId: null, quantity: 1 },
+      { purchaseOrderLineId: 'unknown', quantity: 100 },
+      { purchaseOrderLineId: 'po-line-1', quantity: 2 },
+    ],
+  });
+  assert.equal(exceeded.length, 0);
+});

--- a/packages/backend/test/vendorInvoiceLines.test.js
+++ b/packages/backend/test/vendorInvoiceLines.test.js
@@ -74,3 +74,45 @@ test('normalizeVendorInvoiceLines: keeps diff when autoAdjust disabled', () => {
   assert.equal(result.totals.grossTotal, 100);
   assert.equal(result.totals.diff, 20);
 });
+
+test('normalizeVendorInvoiceLines: uses explicit amount even when quantity*unitPrice differs', () => {
+  const result = normalizeVendorInvoiceLines(
+    [
+      {
+        lineNo: 1,
+        description: 'line-1',
+        quantity: 3,
+        unitPrice: 100,
+        amount: 310,
+        taxRate: 10,
+        taxAmount: null,
+      },
+    ],
+    341,
+  );
+  assert.equal(result.items[0].amount, 310);
+  assert.equal(result.items[0].taxAmount, 31);
+  assert.equal(result.items[0].grossAmount, 341);
+  assert.equal(result.totals.diff, 0);
+});
+
+test('normalizeVendorInvoiceLines: keeps diff when autoAdjust would make tax negative', () => {
+  const result = normalizeVendorInvoiceLines(
+    [
+      {
+        lineNo: 1,
+        description: 'line-1',
+        quantity: 1,
+        unitPrice: 100,
+        amount: 100,
+        taxRate: null,
+        taxAmount: 0,
+      },
+    ],
+    50,
+    { autoAdjust: true },
+  );
+  assert.equal(result.items[0].taxAmount, 0);
+  assert.equal(result.items[0].grossAmount, 100);
+  assert.equal(result.totals.diff, -50);
+});


### PR DESCRIPTION
## 概要
- `/vendor-invoices/:id/lines` の PO明細数量超過判定を `vendorInvoiceLineReconciliation` サービスへ切り出し
- 部分請求/超過/浮動小数誤差境界/不正データ混在の単体テストを追加
- `normalizeVendorInvoiceLines` に quantity×unitPrice差異ケースと autoAdjust異常系ケースを追加

## 変更点
- backend
  - `packages/backend/src/services/vendorInvoiceLineReconciliation.ts` を追加
  - `packages/backend/src/routes/vendorDocs.ts` の数量超過判定をサービス呼び出しへ置換
  - `packages/backend/test/vendorInvoiceLineReconciliation.test.js` を追加
  - `packages/backend/test/vendorInvoiceLines.test.js` を拡充

## テスト
- `npm run build --prefix packages/backend`
- `npm run lint --prefix packages/backend`
- `npm run format:check --prefix packages/backend`
- `npm run test --prefix packages/backend`

## 関連
- refs #920
