### PR TITLE
chore(frontend): @itdo/design-system を 1.0.4 に更新

### DIFF
--- a/packages/frontend/package-lock.json
+++ b/packages/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@itdo/design-system": "1.0.3",
+        "@itdo/design-system": "1.0.4",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.6",
         "react": "^19.2.4",
@@ -1000,9 +1000,9 @@
       }
     },
     "node_modules/@itdo/design-system": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@itdo/design-system/-/design-system-1.0.3.tgz",
-      "integrity": "sha512-qSgUfFy1TmZQLaZ2Eo2ntgEOU0ThnHwxP3cvM3uWcaaW4rYzKcoashISHI4xJ64hps73G02B/u3vpKDMfJsmHg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@itdo/design-system/-/design-system-1.0.4.tgz",
+      "integrity": "sha512-B3OsbrNHyKo6cjlQIGbyof5EUunrk3SOsb96Qjy0l22kwPXyqhQIJOc3q6/I//DDMuC+UIJJ/v/icIGCNSrp8A==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -15,7 +15,7 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx,jsx,js,css,json,md}\""
   },
   "dependencies": {
-    "@itdo/design-system": "1.0.3",
+    "@itdo/design-system": "1.0.4",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.6",
     "react": "^19.2.4",


### PR DESCRIPTION
## 概要
- `@itdo/design-system` を `1.0.3` から `1.0.4` へ更新
- lockfile を同期

## 背景
- #933 の Phase 0（依存更新）対応
- 1.0.4 追加コンポーネント適用（Phase 1以降）の前提整備

## 変更ファイル
- `packages/frontend/package.json`
- `packages/frontend/package-lock.json`

## 検証
- `npm ls @itdo/design-system --prefix packages/frontend --depth=0`
  - `@itdo/design-system@1.0.4`
- `npm run typecheck --prefix packages/frontend`
  - pass

Refs: #933
