### PR TITLE
feat(frontend): ProjectChat/RoomChatにds104部品を適用

### DIFF
--- a/packages/frontend/src/sections/ProjectChat.tsx
+++ b/packages/frontend/src/sections/ProjectChat.tsx
@@ -14,6 +14,7 @@ import {
 import { copyToClipboard } from '../utils/clipboard';
 import { toIsoFromLocalInput, toLocalDateTimeValue } from '../utils/datetime';
 import { buildOpenHash } from '../utils/deepLink';
+import { resolveAttachmentKind } from '../utils/attachments';
 
 type ChatMessage = {
   id: string;
@@ -166,15 +167,6 @@ function transformLinkUri(uri?: string) {
 
 function sanitizeFilename(value: string) {
   return value.replace(/["\\\r\n]/g, '_').replace(/[/\\]/g, '_');
-}
-
-function resolveAttachmentKind(
-  mimeType: string | null | undefined,
-): AttachmentRecord['kind'] {
-  const normalized = (mimeType || '').toLowerCase();
-  if (normalized.startsWith('image/')) return 'image';
-  if (normalized === 'application/pdf') return 'pdf';
-  return 'file';
 }
 
 function toAttachmentRecord(attachment: {
@@ -2140,10 +2132,14 @@ export const ProjectChat: React.FC = () => {
                       {canRevoke && (
                         <button
                           className="button secondary"
+                          disabled={!!pendingUndoRevokeAck}
                           onClick={() =>
-                            setPendingUndoRevokeAck({
-                              requestId: item.ackRequest!.id,
-                            })
+                            setPendingUndoRevokeAck(
+                              (prev) =>
+                                prev ?? {
+                                  requestId: item.ackRequest!.id,
+                                },
+                            )
                           }
                         >
                           OK取消

--- a/packages/frontend/src/sections/RoomChat.tsx
+++ b/packages/frontend/src/sections/RoomChat.tsx
@@ -19,6 +19,7 @@ import {
 import { copyToClipboard } from '../utils/clipboard';
 import { buildOpenHash } from '../utils/deepLink';
 import { toIsoFromLocalInput, toLocalDateTimeValue } from '../utils/datetime';
+import { resolveAttachmentKind } from '../utils/attachments';
 
 type ChatRoom = {
   id: string;
@@ -161,15 +162,6 @@ function transformLinkUri(uri?: string) {
 
 function sanitizeFilename(value: string) {
   return value.replace(/["\\\r\n]/g, '_').replace(/[/\\]/g, '_');
-}
-
-function resolveAttachmentKind(
-  mimeType: string | null | undefined,
-): AttachmentRecord['kind'] {
-  const normalized = (mimeType || '').toLowerCase();
-  if (normalized.startsWith('image/')) return 'image';
-  if (normalized === 'application/pdf') return 'pdf';
-  return 'file';
 }
 
 function toAttachmentRecord(attachment: {
@@ -2393,11 +2385,15 @@ export const RoomChat: React.FC = () => {
                         {canRevoke && (
                           <button
                             className="button secondary"
-                            onClick={() =>
+                            disabled={!!pendingUndoRevokeAck}
+                            onClick={() => {
+                              if (pendingUndoRevokeAck) {
+                                return;
+                              }
                               setPendingUndoRevokeAck({
                                 requestId: ackRequest.id,
-                              })
-                            }
+                              });
+                            }}
                           >
                             OK取消
                           </button>

--- a/packages/frontend/src/utils/attachments.ts
+++ b/packages/frontend/src/utils/attachments.ts
@@ -1,0 +1,10 @@
+export type AttachmentKind = 'image' | 'pdf' | 'file';
+
+export function resolveAttachmentKind(
+  mimeType: string | null | undefined,
+): AttachmentKind {
+  const normalized = (mimeType || '').toLowerCase();
+  if (normalized.startsWith('image/')) return 'image';
+  if (normalized === 'application/pdf') return 'pdf';
+  return 'file';
+}


### PR DESCRIPTION
## 概要
- `ProjectChat` / `RoomChat` の投稿フォームで design-system 1.0.4 の新規部品を適用
- 添付入力を `AttachmentField` に置換
- 候補入力を `Combobox` に置換（ack対象/mention対象）
- `OK取消` の確認導線を `window.confirm` から `UndoToast` に置換

## 変更詳細
- `packages/frontend/src/sections/ProjectChat.tsx`
  - `AttachmentField` / `Combobox` / `UndoToast` を導入
  - mention / ack 候補入力の datalist 実装を廃止
  - `OK取消` を遅延確定 + Undo可能フローに変更
- `packages/frontend/src/sections/RoomChat.tsx`
  - `AttachmentField` / `Combobox` / `UndoToast` を導入
  - ack 候補入力の datalist 実装を廃止
  - `OK取消` を遅延確定 + Undo可能フローに変更

## 検証
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run build --prefix packages/frontend`

Refs #933
