### PR TITLE
feat(frontend): Issue #933 Phase2 SavedViewBar/Tabs を適用

### DIFF
--- a/packages/frontend/src/sections/AdminJobs.tsx
+++ b/packages/frontend/src/sections/AdminJobs.tsx
@@ -70,12 +70,9 @@ const JOB_DEFINITIONS: JobDescriptor[] = [
 ];
 
 const JOB_KEY_SET = new Set<JobKey>(JOB_DEFINITIONS.map((item) => item.key));
-const JOB_GROUP_SET = new Set<JobGroup>([
-  '運用',
-  'レポート',
-  '通知',
-  '定期/連携',
-]);
+const JOB_GROUP_SET = new Set<JobGroup>(
+  JOB_DEFINITIONS.map((item) => item.group),
+);
 
 const formatJson = (value: unknown) => {
   try {
@@ -156,14 +153,15 @@ export const AdminJobs: React.FC = () => {
   const [chatRoomAclLimit, setChatRoomAclLimit] = useState('200');
   const [dailyReportDryRun, setDailyReportDryRun] = useState(false);
   const [dailyReportTargetDate, setDailyReportTargetDate] = useState('');
+  const initialSavedViewTimestamp = useMemo(() => new Date().toISOString(), []);
   const savedViews = useSavedViews<SavedFilterPayload>({
     initialViews: [
       {
         id: 'default',
         name: '既定',
         payload: { search: '', groupFilter: 'all' },
-        createdAt: '2026-02-11T00:00:00.000Z',
-        updatedAt: '2026-02-11T00:00:00.000Z',
+        createdAt: initialSavedViewTimestamp,
+        updatedAt: initialSavedViewTimestamp,
       },
     ],
     initialActiveViewId: 'default',

--- a/packages/frontend/src/sections/AuditLogs.tsx
+++ b/packages/frontend/src/sections/AuditLogs.tsx
@@ -134,14 +134,15 @@ export const AuditLogs: React.FC = () => {
   const [listError, setListError] = useState('');
   const [message, setMessage] = useState('');
   const [isDownloading, setIsDownloading] = useState(false);
+  const initialSavedViewTimestamp = useMemo(() => new Date().toISOString(), []);
   const savedViews = useSavedViews<SavedFilterPayload>({
     initialViews: [
       {
         id: 'default',
         name: '既定',
         payload: toSavedFilterPayload(defaultFilters),
-        createdAt: '2026-02-11T00:00:00.000Z',
-        updatedAt: '2026-02-11T00:00:00.000Z',
+        createdAt: initialSavedViewTimestamp,
+        updatedAt: initialSavedViewTimestamp,
       },
     ],
     initialActiveViewId: 'default',

--- a/packages/frontend/src/sections/DocumentSendLogs.tsx
+++ b/packages/frontend/src/sections/DocumentSendLogs.tsx
@@ -94,6 +94,7 @@ export const DocumentSendLogs: React.FC = () => {
   const [isOpeningPdf, setIsOpeningPdf] = useState(false);
   const [retryTargetLogId, setRetryTargetLogId] = useState<string | null>(null);
 
+  const initialSavedViewTimestamp = useMemo(() => new Date().toISOString(), []);
   const trimmedLogId = logId.trim();
   const savedViews = useSavedViews<SavedFilterPayload>({
     initialViews: [
@@ -101,8 +102,8 @@ export const DocumentSendLogs: React.FC = () => {
         id: 'default',
         name: '既定',
         payload: { logId: '' },
-        createdAt: '2026-02-11T00:00:00.000Z',
-        updatedAt: '2026-02-11T00:00:00.000Z',
+        createdAt: initialSavedViewTimestamp,
+        updatedAt: initialSavedViewTimestamp,
       },
     ],
     initialActiveViewId: 'default',
@@ -484,13 +485,13 @@ export const DocumentSendLogs: React.FC = () => {
               (view) => view.id === viewId,
             );
             if (!selected) return;
-            setLogId(selected.payload.logId);
+            setLogId((selected.payload?.logId || '').trim());
           }}
           onSaveAs={(name) => {
-            savedViews.createView(name, { logId });
+            savedViews.createView(name, { logId: trimmedLogId });
           }}
           onUpdateView={(viewId) => {
-            savedViews.updateView(viewId, { payload: { logId } });
+            savedViews.updateView(viewId, { payload: { logId: trimmedLogId } });
           }}
           onDuplicateView={(viewId) => {
             savedViews.duplicateView(viewId);


### PR DESCRIPTION
## 概要
Issue #933 の Phase 2 対応として、一覧系画面へ design-system 1.0.4 追加部品を適用しました。

## 変更内容
- `AuditLogs.tsx`
  - `SavedViewBar + useSavedViews` を導入
  - 代表フィルタ条件を保存/復元可能化
- `DocumentSendLogs.tsx`
  - `SavedViewBar + useSavedViews` を導入
  - `sendLogId` の保存/復元を追加
- `AdminJobs.tsx`
  - `SavedViewBar + useSavedViews` を導入
  - `search/groupFilter` の保存/復元を追加
- `VendorDocuments.tsx`
  - `Tabs` で `発注書/仕入見積/仕入請求` を切替表示
  - 仕入請求フィルタ（検索語・状態）を `SavedViewBar` で保存/復元

## 検証
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run build --prefix packages/frontend`

Refs #933