### PR TITLE
feat(frontend): AppにCommandPaletteと主要操作アクションを導入

### DIFF
--- a/packages/frontend/src/sections/GlobalSearch.tsx
+++ b/packages/frontend/src/sections/GlobalSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { api, getAuthState } from '../api';
 import { navigateToOpen } from '../utils/deepLink';
 
@@ -168,6 +168,7 @@ function openChatTarget(message: ChatMessageResult) {
 export const GlobalSearch: React.FC = () => {
   const auth = getAuthState();
   const currentUserId = auth?.userId || 'demo-user';
+  const queryInputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState('');
   const [limit, setLimit] = useState(10);
   const [erpResult, setErpResult] = useState<ErpSearchResponse | null>(null);
@@ -223,6 +224,17 @@ export const GlobalSearch: React.FC = () => {
     }
   };
 
+  useEffect(() => {
+    const handleFocus = () => {
+      queryInputRef.current?.focus();
+      queryInputRef.current?.select();
+    };
+    window.addEventListener('erp4_global_search_focus', handleFocus);
+    return () => {
+      window.removeEventListener('erp4_global_search_focus', handleFocus);
+    };
+  }, []);
+
   return (
     <div>
       <h2>検索（ERP横断）</h2>
@@ -230,6 +242,7 @@ export const GlobalSearch: React.FC = () => {
         <label>
           検索語
           <input
+            ref={queryInputRef}
             type="text"
             value={query}
             onChange={(e) => setQuery(e.target.value)}


### PR DESCRIPTION
## 概要
Issue #933 の Phase 3 対応として、`App.tsx` に `CommandPalette` を導入し、主要操作アクションを登録しました。

## 変更内容
- `App.tsx`
  - `CommandPalette` を追加（`Ctrl/Cmd + K` またはメニューのボタンで起動）
  - 主要操作アクションを登録
    - 再取得: アプリ再読み込み
    - 検索: グローバル検索を開いて入力欄へフォーカス
    - 作成: 案件 / 見積 / 請求 / 仕入発注 画面へ遷移
  - 全画面遷移アクションを登録（セクション一覧をアクション化）
- `GlobalSearch.tsx`
  - `erp4_global_search_focus` イベントを受けて検索入力へフォーカスする処理を追加

## 検証
- `npm run lint --prefix packages/frontend`
- `npm run format:check --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run build --prefix packages/frontend`

Refs #933
