### PR TITLE
feat(frontend): #941 phase1 DateRangePicker導入

### DIFF
--- a/packages/frontend/package-lock.json
+++ b/packages/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@itdo/design-system": "1.0.4",
+        "@itdo/design-system": "^1.1.0",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.6",
         "react": "^19.2.4",
@@ -1000,9 +1000,9 @@
       }
     },
     "node_modules/@itdo/design-system": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@itdo/design-system/-/design-system-1.0.4.tgz",
-      "integrity": "sha512-B3OsbrNHyKo6cjlQIGbyof5EUunrk3SOsb96Qjy0l22kwPXyqhQIJOc3q6/I//DDMuC+UIJJ/v/icIGCNSrp8A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@itdo/design-system/-/design-system-1.1.0.tgz",
+      "integrity": "sha512-1u19yOko9trVjQ8Y98xgx0odtfUQy8Uw+BrLvmNI1ntNQt/aFKnCxo3A5M21lEBEIgVlUtVQJKaahQoh9vAN2w==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -15,7 +15,7 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx,jsx,js,css,json,md}\""
   },
   "dependencies": {
-    "@itdo/design-system": "1.0.4",
+    "@itdo/design-system": "^1.1.0",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.6",
     "react": "^19.2.4",

--- a/packages/frontend/src/sections/AuditLogs.tsx
+++ b/packages/frontend/src/sections/AuditLogs.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   CrudList,
   DataTable,
+  DateRangePicker,
   FilterBar,
   Input,
   SavedViewBar,
@@ -347,21 +348,18 @@ export const AuditLogs: React.FC = () => {
                   alignItems: 'flex-end',
                 }}
               >
-                <Input
-                  label="from"
-                  type="date"
-                  value={filters.from}
-                  onChange={(e) =>
-                    setFilters({ ...filters, from: e.target.value })
-                  }
-                />
-                <Input
-                  label="to"
-                  type="date"
-                  value={filters.to}
-                  onChange={(e) =>
-                    setFilters({ ...filters, to: e.target.value })
-                  }
+                <DateRangePicker
+                  label="期間"
+                  fromLabel="from"
+                  toLabel="to"
+                  value={{ from: filters.from, to: filters.to }}
+                  onChange={(next) => {
+                    setFilters({
+                      ...filters,
+                      from: next.from ?? '',
+                      to: next.to ?? '',
+                    });
+                  }}
                 />
                 <Input
                   label="userId"

--- a/packages/frontend/src/sections/HRAnalytics.tsx
+++ b/packages/frontend/src/sections/HRAnalytics.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { api } from '../api';
+import { DateRangePicker } from '../ui';
 
 type AnalyticsItem = {
   bucket: string;
@@ -154,24 +155,16 @@ export const HRAnalytics: React.FC = () => {
         className="row"
         style={{ gap: 8, alignItems: 'center', flexWrap: 'wrap' }}
       >
-        <label>
-          開始日
-          <input
-            type="date"
-            value={from}
-            onChange={(e) => setFrom(e.target.value)}
-            style={{ marginLeft: 6 }}
-          />
-        </label>
-        <label>
-          終了日
-          <input
-            type="date"
-            value={to}
-            onChange={(e) => setTo(e.target.value)}
-            style={{ marginLeft: 6 }}
-          />
-        </label>
+        <DateRangePicker
+          label="集計期間"
+          fromLabel="開始日"
+          toLabel="終了日"
+          value={{ from, to }}
+          onChange={(next) => {
+            setFrom(next.from ?? '');
+            setTo(next.to ?? '');
+          }}
+        />
         <label>
           閾値
           <input


### PR DESCRIPTION
## 概要
Issue #941 の初回導入として、design-system v1.1.0 の依存更新と、期間検索UIの先行置換を実施しました。

## 変更内容
- `@itdo/design-system` を `^1.1.0` に更新
- `AuditLogs` の `from/to` を `DateRangePicker` に置換
- `HRAnalytics` の `開始日/終了日` を `DateRangePicker` に置換

## 非対象（次PR以降）
- `DateTimeRangePicker` の導入
- `EntityReferencePicker` / `MentionComposer` / `Drawer` / `PolicyFormBuilder` / `AuditTimeline` / `DiffViewer` の導入

## 検証
- `npm run lint --prefix packages/frontend`
- `npm run format:check --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run build --prefix packages/frontend`
- `npm audit --prefix packages/frontend --audit-level=high`

Refs: #941
