### PR TITLE
feat: ChatBreakGlassの対象期間入力をDateTimeRangePicker化

### DIFF
--- a/packages/frontend/src/sections/ChatBreakGlass.tsx
+++ b/packages/frontend/src/sections/ChatBreakGlass.tsx
@@ -129,13 +129,28 @@ export const ChatBreakGlass: React.FC = () => {
       setError('projectId または roomId を入力してください');
       return;
     }
+    const dateFormatErrors: string[] = [];
     if (targetFromInput && !targetFrom) {
-      setError('targetFrom の日時形式が不正です');
-      return;
+      dateFormatErrors.push('targetFrom の日時形式が不正です');
     }
     if (targetUntilInput && !targetUntil) {
-      setError('targetUntil の日時形式が不正です');
+      dateFormatErrors.push('targetUntil の日時形式が不正です');
+    }
+    if (dateFormatErrors.length > 0) {
+      setError(dateFormatErrors.join(' / '));
       return;
+    }
+    if (targetFrom && targetUntil) {
+      const fromAt = new Date(targetFrom);
+      const untilAt = new Date(targetUntil);
+      if (
+        !Number.isNaN(fromAt.getTime()) &&
+        !Number.isNaN(untilAt.getTime()) &&
+        fromAt.getTime() > untilAt.getTime()
+      ) {
+        setError('targetFrom は targetUntil 以前を指定してください');
+        return;
+      }
     }
     if (!form.reasonText.trim()) {
       setError('reasonText を入力してください');


### PR DESCRIPTION
## 概要
- Issue #941 の残タスク（`DateTimeRangePicker` 導入）の一部として、`ChatBreakGlass` 申請フォームの対象期間入力を置換

## 変更内容
- `packages/frontend/src/sections/ChatBreakGlass.tsx`
  - `targetFrom/targetUntil` の自由入力テキストを `DateTimeRangePicker` に変更
  - 保存時に `toIsoFromLocalInput` でローカル日時をUTC ISOに変換
  - 変換失敗時は `targetFrom/targetUntil` それぞれ個別にエラーメッセージを表示
  - APIへの送信仕様（`targetFrom/targetUntil` が未指定なら `undefined`）は維持

## 確認
- `npm run format:check --prefix packages/frontend`
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run build --prefix packages/frontend`
