### PR TITLE
feat(frontend): RoomChat投稿導線をMentionComposerへ移行

### DIFF
--- a/packages/frontend/src/sections/RoomChat.tsx
+++ b/packages/frontend/src/sections/RoomChat.tsx
@@ -356,6 +356,9 @@ export const RoomChat: React.FC = () => {
         ackGroupLabelMap.get(groupId) ||
         mentionGroupLabelMap.get(groupId);
       if (label && label !== groupId) {
+        if (label.includes(groupId)) {
+          return label;
+        }
         return `${label} (${groupId})`;
       }
       return groupId;
@@ -1909,9 +1912,7 @@ export const RoomChat: React.FC = () => {
               onAddFiles={(files) => setAttachmentFile(files[0] || null)}
               onRemoveAttachment={() => setAttachmentFile(null)}
               fetchCandidates={fetchMentionComposerCandidates}
-              onSubmit={() => {
-                void postMessage('message');
-              }}
+              onSubmit={() => postMessage('message')}
               onCancel={clearComposer}
               placeholder="Markdownで入力"
               mentionPlaceholder="メンション対象を検索（ユーザ/グループ）"


### PR DESCRIPTION
## 概要
- Issue #941 の `MentionComposer` 導入タスクとして、RoomChat の投稿UIを design-system `MentionComposer` ベースへ移行
- 旧メンション入力（ユーザ/グループ Combobox + 手動トークン管理）を撤去し、候補検索/選択を `MentionComposer` へ統一
- ACK対象のうちグループは `MentionComposer` の Ack groups 入力と同期、ユーザ/ロールは既存入力を維持

## 変更点
- `packages/frontend/src/sections/RoomChat.tsx`
  - `MentionComposer` / `MentionTarget` を導入
  - 投稿コンポーザ（本文・添付・メンション・確認対象グループ）を `MentionComposer` へ移行
  - `@all` は既存フローを維持（別トグル）
  - label劣化防止として mention/ack group の override state を追加
  - group候補API呼び出しに `keyword.length < 2` の早期returnを追加

## テスト
- `npm run format:check --prefix packages/frontend`
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run build --prefix packages/frontend`

Refs #941
