### PR TITLE
fix: stabilize eslint10 readiness watcher issue-comment check

### DIFF
--- a/.github/workflows/eslint10-readiness-watch.yml
+++ b/.github/workflows/eslint10-readiness-watch.yml
@@ -61,7 +61,7 @@ jobs:
           PARSER_PEER: ${{ steps.check.outputs.parser_peer }}
         run: |
           marker="<!-- eslint10-readiness-watch -->"
-          if gh issue view 914 --json comments --jq '.comments[].body' | grep -F "${marker}" >/dev/null 2>&1; then
+          if gh api "repos/${GITHUB_REPOSITORY}/issues/914/comments" --paginate --jq '.[].body' | grep -F "${marker}" >/dev/null 2>&1; then
             echo "Issue #914 already has readiness notification."
             exit 0
           fi


### PR DESCRIPTION
## 概要
Issue #914 の監視ワークフローで、コメント重複検出に GraphQL ベースの `gh issue view` を使っていた箇所を REST API に置換しました。

## 背景
`gh issue view` は一部環境で Projects classic 廃止に伴う GraphQL エラーを返すことがあり、ready 検知時の通知処理が失敗するリスクがあります。

## 変更
- `.github/workflows/eslint10-readiness-watch.yml`
  - `gh issue view 914 --json comments ...` を
  - `gh api repos/${GITHUB_REPOSITORY}/issues/914/comments --paginate ...` に変更

## 期待効果
- eslint10 readiness 検知時の issue 通知処理の安定化

Refs #914
