### PR TITLE
refactor: approval関連E2E helperの重複を共通化

### DIFF
--- a/packages/frontend/e2e/approval-e2e-helpers.ts
+++ b/packages/frontend/e2e/approval-e2e-helpers.ts
@@ -1,0 +1,118 @@
+type ApiResponse = {
+  ok(): boolean;
+  status(): number;
+  text(): Promise<string>;
+  json(): Promise<any>;
+};
+
+type ApiRequest = {
+  get(url: string, options?: any): Promise<ApiResponse>;
+  post(url: string, options?: any): Promise<ApiResponse>;
+};
+
+type CreateProjectAndEstimateOptions = {
+  request: ApiRequest;
+  apiBase: string;
+  headers: Record<string, string>;
+  project: {
+    code: string;
+    name: string;
+    status?: string;
+  };
+  estimate: {
+    totalAmount: number;
+    currency?: string;
+    notes?: string;
+  };
+};
+
+type SubmitAndFindApprovalInstanceOptions = {
+  request: ApiRequest;
+  apiBase: string;
+  headers: Record<string, string>;
+  flowType: string;
+  projectId: string;
+  targetTable: string;
+  targetId: string;
+};
+
+async function ensureOk(res: ApiResponse) {
+  if (res.ok()) return;
+  const body = await res.text();
+  throw new Error(`[e2e] api failed: ${res.status()} ${body}`);
+}
+
+export async function createProjectAndEstimate(
+  options: CreateProjectAndEstimateOptions,
+) {
+  const projectRes = await options.request.post(`${options.apiBase}/projects`, {
+    data: {
+      code: options.project.code,
+      name: options.project.name,
+      status: options.project.status ?? 'active',
+    },
+    headers: options.headers,
+  });
+  await ensureOk(projectRes);
+  const projectPayload = await projectRes.json();
+  const projectId = (projectPayload?.id ?? projectPayload?.project?.id ?? '') as string;
+  if (!projectId) {
+    throw new Error(`[e2e] project id missing: ${JSON.stringify(projectPayload)}`);
+  }
+
+  const estimateRes = await options.request.post(
+    `${options.apiBase}/projects/${encodeURIComponent(projectId)}/estimates`,
+    {
+      data: {
+        totalAmount: options.estimate.totalAmount,
+        currency: options.estimate.currency ?? 'JPY',
+        notes: options.estimate.notes ?? '',
+      },
+      headers: options.headers,
+    },
+  );
+  await ensureOk(estimateRes);
+  const estimatePayload = await estimateRes.json();
+  const estimateId = (estimatePayload?.id ?? estimatePayload?.estimate?.id ?? '') as string;
+  if (!estimateId) {
+    throw new Error(
+      `[e2e] estimate id missing: ${JSON.stringify(estimatePayload)}`,
+    );
+  }
+
+  return { projectId, estimateId };
+}
+
+export async function submitAndFindApprovalInstance(
+  options: SubmitAndFindApprovalInstanceOptions,
+) {
+  const submitRes = await options.request.post(
+    `${options.apiBase}/${options.targetTable}/${encodeURIComponent(options.targetId)}/submit`,
+    {
+      headers: options.headers,
+    },
+  );
+  await ensureOk(submitRes);
+
+  const instancesRes = await options.request.get(
+    `${options.apiBase}/approval-instances?flowType=${encodeURIComponent(options.flowType)}&projectId=${encodeURIComponent(options.projectId)}`,
+    { headers: options.headers },
+  );
+  await ensureOk(instancesRes);
+  const instancesPayload = await instancesRes.json();
+  const approval = (instancesPayload?.items ?? []).find(
+    (item: any) =>
+      item?.targetTable === options.targetTable &&
+      item?.targetId === options.targetId &&
+      item?.status !== 'approved' &&
+      item?.status !== 'rejected' &&
+      item?.status !== 'cancelled',
+  );
+
+  if (!approval?.id) {
+    throw new Error(
+      `[e2e] approval instance missing: ${JSON.stringify(instancesPayload)}`,
+    );
+  }
+  return approval as { id: string; currentStep?: number | null; status?: string };
+}


### PR DESCRIPTION
## 背景
PR #974 のレビューで、`backend-action-policy-ack-guard.spec.ts` と
`backend-notification-suppression.spec.ts` に同種の helper が重複している指摘がありました。

このPRは、その重複を共通化して将来の API 変更時のドリフトを防ぐための後続対応です。

## 変更内容
- 追加: `packages/frontend/e2e/approval-e2e-helpers.ts`
  - `createProjectAndEstimate(...)`
  - `submitAndFindApprovalInstance(...)`
- 置換:
  - `packages/frontend/e2e/backend-action-policy-ack-guard.spec.ts`
  - `packages/frontend/e2e/backend-notification-suppression.spec.ts`
  で重複実装を削除し、上記 helper を利用するよう変更

## 影響
- テストロジック（判定条件）は維持
- 変更は E2E テストコードのリファクタのみ（プロダクトコード影響なし）

## 確認
- `npm run lint --prefix packages/frontend`
- `npm run format:check --prefix packages/frontend`
- `E2E_SCOPE=core E2E_CAPTURE=0 E2E_GREP="action policy chat_ack_completed|approval_pending notifications: global mute bypass delivers notification" ./scripts/e2e-frontend.sh`
