### PR TITLE
test: 承認/期日ルールの境界ケースを拡張

### DIFF
--- a/packages/backend/test/dueDateRule.test.js
+++ b/packages/backend/test/dueDateRule.test.js
@@ -24,14 +24,27 @@ test('parseDueDateRule: invalid payload throws', () => {
 });
 
 test('parseDueDateRule: accepts numeric string and boundaries', () => {
-  assert.deepEqual(parseDueDateRule({ type: 'periodEndPlusOffset', offsetDays: 0 }), {
-    type: 'periodEndPlusOffset',
-    offsetDays: 0,
-  });
-  assert.deepEqual(parseDueDateRule({ type: 'periodEndPlusOffset', offsetDays: '365' }), {
-    type: 'periodEndPlusOffset',
-    offsetDays: 365,
-  });
+  assert.deepEqual(
+    parseDueDateRule({ type: 'periodEndPlusOffset', offsetDays: 0 }),
+    {
+      type: 'periodEndPlusOffset',
+      offsetDays: 0,
+    },
+  );
+  assert.deepEqual(
+    parseDueDateRule({ type: 'periodEndPlusOffset', offsetDays: '0' }),
+    {
+      type: 'periodEndPlusOffset',
+      offsetDays: 0,
+    },
+  );
+  assert.deepEqual(
+    parseDueDateRule({ type: 'periodEndPlusOffset', offsetDays: '365' }),
+    {
+      type: 'periodEndPlusOffset',
+      offsetDays: 365,
+    },
+  );
 });
 
 test('computeDueDate: end of month + offset', () => {
@@ -56,3 +69,26 @@ test('computeDueDate: offset moves to next month', () => {
   assert.equal(result.getDate(), 1);
 });
 
+test('computeDueDate: max offset can cross year boundary', () => {
+  const runAt = new Date(2026, 11, 5, 10, 0, 0);
+  const rule = { type: 'periodEndPlusOffset', offsetDays: 365 };
+  const result = computeDueDate(runAt, rule);
+  assert.ok(result);
+  assert.equal(result.getFullYear(), 2027);
+  assert.equal(result.getMonth(), 11);
+  assert.equal(result.getDate(), 31);
+  assert.equal(result.getHours(), 23);
+  assert.equal(result.getMinutes(), 59);
+});
+
+test('computeDueDate: leap year February end is handled correctly', () => {
+  const runAt = new Date(2024, 1, 10, 8, 0, 0);
+  const rule = { type: 'periodEndPlusOffset', offsetDays: 0 };
+  const result = computeDueDate(runAt, rule);
+  assert.ok(result);
+  assert.equal(result.getFullYear(), 2024);
+  assert.equal(result.getMonth(), 1);
+  assert.equal(result.getDate(), 29);
+  assert.equal(result.getHours(), 23);
+  assert.equal(result.getMinutes(), 59);
+});


### PR DESCRIPTION
## 背景
品質向上の継続として、優先度Aのルール計算系テスト（承認条件判定・支払期日計算）の境界ケースを拡張します。

## 変更内容
- `packages/backend/test/approvalLogic.test.js`
  - `normalizeRuleSteps` の sequential入力（明示 order なし）の正規化を追加
  - `matchesRuleCondition` の以下を追加
    - `projectType` / `customerId` / `orgUnitId` の一致/不一致判定
    - `appliesTo`（配列指定）で flowType 判定
- `packages/backend/test/dueDateRule.test.js`
  - `parseDueDateRule` の `offsetDays: '0'`（文字列最小境界）を追加
  - `computeDueDate` の最大オフセット365日（年跨ぎ）を追加
  - うるう年2月末（2024-02-29）を追加

## 確認
- `npx prettier --check packages/backend/test/approvalLogic.test.js packages/backend/test/dueDateRule.test.js`
- `npm run test --prefix packages/backend -- test/dueDateRule.test.js test/approvalLogic.test.js`
