### PR TITLE
test: delivery due範囲外データ除外のE2Eを追加

### DIFF
--- a/packages/frontend/e2e/backend-delivery-due.spec.ts
+++ b/packages/frontend/e2e/backend-delivery-due.spec.ts
@@ -49,6 +49,24 @@ test('delivery due report @core', async ({ request }) => {
   await ensureOk(milestoneRes);
   const milestone = await milestoneRes.json();
 
+  const outOfRangeDate = new Date(dueDate);
+  outOfRangeDate.setUTCDate(outOfRangeDate.getUTCDate() + 1);
+  const outOfRangeDateStr = outOfRangeDate.toISOString().slice(0, 10);
+  const outOfRangeMilestoneRes = await request.post(
+    `${apiBase}/projects/${project.id}/milestones`,
+    {
+      data: {
+        name: `OutOfRange ${suffix}`,
+        amount: 2000,
+        billUpon: 'date',
+        dueDate: outOfRangeDateStr,
+      },
+      headers: authHeaders,
+    },
+  );
+  await ensureOk(outOfRangeMilestoneRes);
+  const outOfRangeMilestone = await outOfRangeMilestoneRes.json();
+
   const reportRes = await request.get(
     `${apiBase}/reports/delivery-due?projectId=${encodeURIComponent(project.id)}&from=${dueDateStr}&to=${dueDateStr}`,
     { headers: authHeaders },
@@ -59,5 +77,7 @@ test('delivery due report @core', async ({ request }) => {
   expect(items.some((item: any) => item.milestoneId === milestone.id)).toBe(
     true,
   );
+  expect(
+    items.some((item: any) => item.milestoneId === outOfRangeMilestone.id),
+  ).toBe(false);
 });
-


### PR DESCRIPTION
## 背景
`delivery due report` のE2Eは、指定期間内のマイルストーンが返ることのみ確認しており、範囲外データの除外は未検証でした。

## 変更内容
- `packages/frontend/e2e/backend-delivery-due.spec.ts`
  - 対象日(`from=to`)の翌日を `out-of-range` として追加作成
  - レポート結果に `out-of-range` マイルストーンが含まれないことを検証

## 確認
- `npx prettier --check packages/frontend/e2e/backend-delivery-due.spec.ts`
- `npm run lint --prefix packages/frontend`
- `E2E_SCOPE=core E2E_CAPTURE=0 E2E_GREP='delivery due report @core' ./scripts/e2e-frontend.sh`
