### PR TITLE
test: 期日ルールと承認条件の境界テストを追加

### DIFF
--- a/packages/backend/test/approvalLogic.test.js
+++ b/packages/backend/test/approvalLogic.test.js
@@ -165,6 +165,33 @@ test('matchesRuleCondition: amount range and flow flags', () => {
   );
 });
 
+test('matchesRuleCondition: amountMin/amountMax boundaries are inclusive', () => {
+  assert.equal(
+    matchesRuleCondition(
+      'invoice',
+      { totalAmount: 50000 },
+      { amountMin: 50000, amountMax: 50000 },
+    ),
+    true,
+  );
+  assert.equal(
+    matchesRuleCondition(
+      'invoice',
+      { totalAmount: 49999 },
+      { amountMin: 50000, amountMax: 50000 },
+    ),
+    false,
+  );
+  assert.equal(
+    matchesRuleCondition(
+      'invoice',
+      { totalAmount: 50001 },
+      { amountMin: 50000, amountMax: 50000 },
+    ),
+    false,
+  );
+});
+
 test('normalizeRuleStepsWithPolicy: stages format returns steps and stagePolicy', () => {
   const result = normalizeRuleStepsWithPolicy({
     stages: [

--- a/packages/backend/test/dueDateRule.test.js
+++ b/packages/backend/test/dueDateRule.test.js
@@ -92,3 +92,9 @@ test('computeDueDate: leap year February end is handled correctly', () => {
   assert.equal(result.getHours(), 23);
   assert.equal(result.getMinutes(), 59);
 });
+
+test('computeDueDate: null/undefined rule returns null', () => {
+  const runAt = new Date(2026, 0, 15, 12, 0, 0);
+  assert.equal(computeDueDate(runAt, null), null);
+  assert.equal(computeDueDate(runAt, undefined), null);
+});


### PR DESCRIPTION
## 背景
境界値テストを追加して、ルール評価の回帰検知を強化します。

## 変更内容
- `packages/backend/test/dueDateRule.test.js`
  - `computeDueDate` に `rule=null/undefined` を渡した場合に `null` を返すことを追加
- `packages/backend/test/approvalLogic.test.js`
  - `matchesRuleCondition` の `amountMin/amountMax` 同値境界（=50000）を追加
  - 下限未満（49999）・上限超過（50001）で `false` になることを追加

## 確認
- `npx prettier --check packages/backend/test/dueDateRule.test.js packages/backend/test/approvalLogic.test.js`
- `npm run lint --prefix packages/backend`
- `npm run test --prefix packages/backend -- test/dueDateRule.test.js test/approvalLogic.test.js`
