### PR TITLE
test: ActionPolicy JSON入力不正時のE2Eを追加

### DIFF
--- a/packages/frontend/e2e/frontend-smoke.spec.ts
+++ b/packages/frontend/e2e/frontend-smoke.spec.ts
@@ -1191,12 +1191,11 @@ test('frontend smoke reports masters settings @extended', async ({ page }) => {
   const actionPolicyKey = `submit.e2e.${id}`;
   await actionPolicyBlock.getByLabel('subjects (JSON)').fill('{');
   await actionPolicyBlock.getByRole('button', { name: '作成' }).first().click();
-  await expect(
-    settingsSection.getByText('subjects のJSONが不正です'),
-  ).toBeVisible({
+  const settingsMessage = settingsSection.locator(':scope > p').first();
+  await expect(settingsMessage).toHaveText('subjects のJSONが不正です', {
     timeout: actionTimeout,
   });
-  await actionPolicyBlock.getByLabel('subjects (JSON)').fill('');
+  await actionPolicyBlock.getByLabel('subjects (JSON)').fill('{}');
   await actionPolicyBlock.getByLabel('actionKey').fill(actionPolicyKey);
   await actionPolicyBlock.getByRole('button', { name: '作成' }).first().click();
   await expect(


### PR DESCRIPTION
## 背景
管理設定の ActionPolicy 作成フローでは JSON 文字列の入力不正時に保存を止める実装がありますが、E2E で未検証でした。

## 変更内容
- `packages/frontend/e2e/frontend-smoke.spec.ts`
  - `frontend smoke reports masters settings @extended` に以下を追加
    - `subjects (JSON)` に不正値 `{` を入力して `作成`
    - `subjects のJSONが不正です` メッセージ表示を確認
    - 入力を復旧して通常作成に進み、既存の成功フローを継続

## 確認
- `npx prettier --check packages/frontend/e2e/frontend-smoke.spec.ts`
- `npm run lint --prefix packages/frontend`
- `E2E_SCOPE=extended E2E_CAPTURE=0 E2E_GREP='frontend smoke reports masters settings @extended' ./scripts/e2e-frontend.sh`
