### PR TITLE
test: requireProjectAccessのルートE2Eを追加

### DIFF
--- a/packages/frontend/e2e/backend-project-access-guard.spec.ts
+++ b/packages/frontend/e2e/backend-project-access-guard.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
 
 const runId = () =>
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 900 + 100)}`;
+  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
 
 const buildHeaders = (input: {
   userId: string;
@@ -96,4 +96,10 @@ test('project access guard: route/query projectId is enforced @core', async ({
     { headers: memberHeaders },
   );
   await ensureOk(timeEntriesAllowedRes);
+
+  const timeEntriesMgmtBypassRes = await request.get(
+    `${apiBase}/time-entries?projectId=${encodeURIComponent(projectId)}`,
+    { headers: mgmtHeaders },
+  );
+  await ensureOk(timeEntriesMgmtBypassRes);
 });


### PR DESCRIPTION
## 背景
`requireProjectAccess` の単体テストは拡充済みですが、ルート実行時（path/query の projectId 解決）での E2E 検証が不足していました。

## 変更内容
- `packages/frontend/e2e/backend-project-access-guard.spec.ts` を新規追加
  - `GET /projects/:projectId/chat-messages`（path param）
  - `GET /time-entries?projectId=...`（query param）
- 検証ケース
  - 権限なしユーザー（`roles=user`, `projectIds=[]`）は `403` + `error.code=forbidden_project`
  - 対象案件メンバー（`projectIds` に対象IDを含む）は通過
  - `mgmt` は `projectIds` 未設定でもバイパス通過

## 確認
- `npx prettier --check packages/frontend/e2e/backend-project-access-guard.spec.ts`
- `npm run lint --prefix packages/frontend`
- `E2E_SCOPE=core E2E_CAPTURE=0 E2E_GREP='project access guard: route/query projectId is enforced @core' ./scripts/e2e-frontend.sh`
