### PR TITLE
test: numbering serviceの単体カバレッジを追加

### DIFF
--- a/packages/backend/src/services/numbering.ts
+++ b/packages/backend/src/services/numbering.ts
@@ -16,6 +16,15 @@ type NextNumberOptions = {
   client?: NumberingClient;
   maxRetries?: number;
 };
+const DEFAULT_MAX_RETRIES = 3;
+const MAX_MAX_RETRIES = 10;
+
+function normalizeMaxRetries(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 1) {
+    return DEFAULT_MAX_RETRIES;
+  }
+  return Math.min(Math.floor(value), MAX_MAX_RETRIES);
+}
 
 function isRetryableError(err: unknown): err is RetryableError {
   return !!err && typeof err === 'object' && 'code' in err;
@@ -32,10 +41,7 @@ export async function nextNumber(
   if (!prefix) throw new Error(`Unsupported kind: ${kind}`);
 
   const client = options.client ?? prisma;
-  const maxRetries =
-    typeof options.maxRetries === 'number' && options.maxRetries >= 1
-      ? Math.floor(options.maxRetries)
-      : 3;
+  const maxRetries = normalizeMaxRetries(options.maxRetries);
   let lastError: unknown;
   for (let attempt = 0; attempt < maxRetries; attempt += 1) {
     try {


### PR DESCRIPTION
## 背景
`nextNumber`（採番）の動作は重要ですが、これまで単体テストがありませんでした。特にリトライ・overflow・フォーマット境界の回帰を検知しづらい状態でした。

## 変更内容
- `packages/backend/src/services/numbering.ts`
  - テスト容易化のため `nextNumber` にオプションを追加（後方互換）
    - `client`（`$transaction` DI）
    - `maxRetries`（既定3）
- `packages/backend/test/numbering.test.js`（新規）
  - 採番フォーマット（prefix / yyyy-mm / serial 4桁ゼロ埋め）
  - unsupported kind の拒否
  - serial overflow (`>=10000`) の拒否
  - `P2034` のリトライ成功
  - 非リトライエラーで即失敗
  - `maxRetries` 指定時の試行回数上限

## 確認
- `npx prettier --check packages/backend/src/services/numbering.ts packages/backend/test/numbering.test.js`
- `npm run lint --prefix packages/backend`
- `npm run test --prefix packages/backend -- test/numbering.test.js`
