### PR TITLE
test: dashboard通知カード遷移E2Eを追加 (#1003)

### DIFF
--- a/packages/frontend/e2e/frontend-dashboard-notification-routing.spec.ts
+++ b/packages/frontend/e2e/frontend-dashboard-notification-routing.spec.ts
@@ -104,6 +104,18 @@ async function listUnreadNotifications(
   return Array.isArray(payload?.items) ? payload.items : [];
 }
 
+async function markNotificationRead(
+  page: Page,
+  headers: Record<string, string>,
+  notificationId: string,
+) {
+  const res = await page.request.post(
+    `${apiBase}/notifications/${encodeURIComponent(notificationId)}/read`,
+    { headers, data: {} },
+  );
+  await ensureOk(res);
+}
+
 async function findCompanyRoomId(page: Page, headers: Record<string, string>) {
   const roomRes = await page.request.get(`${apiBase}/chat-rooms`, { headers });
   await ensureOk(roomRes);
@@ -444,6 +456,7 @@ test('dashboard notification cards route to chat/leave/expense targets @core', a
   await expect(
     page.locator('main').getByRole('heading', { name: '休暇', level: 2, exact: true }),
   ).toBeVisible({ timeout: actionTimeout });
+  await markNotificationRead(page, targetHeaders, leaveNotification.id);
 
   await openHome(page);
   const dashboardSectionAfterHome = page
@@ -463,6 +476,7 @@ test('dashboard notification cards route to chat/leave/expense targets @core', a
       .locator('main')
       .getByRole('heading', { name: '経費入力', level: 2, exact: true }),
   ).toBeVisible({ timeout: actionTimeout });
+  await markNotificationRead(page, targetHeaders, expenseNotification.id);
 
   // chat_ack_required notification (active user account is required)
   await prepare(page, chatTargetState);
@@ -522,4 +536,5 @@ test('dashboard notification cards route to chat/leave/expense targets @core', a
   await expect(page.locator('main').getByText(ackBody)).toBeVisible({
     timeout: actionTimeout,
   });
+  await markNotificationRead(page, chatTargetHeaders, ackNotification.id);
 });


### PR DESCRIPTION
## 概要
- Dashboard の通知カードから chat/leave/expense への遷移を検証する E2E を追加
- deep link の open イベント (`erp4_open_entity` / `erp4_open_chat_message`) を記録し、kind/id の一致を検証
- leave_upcoming / expense_mark_paid / chat_ack_required を API でシードして UI 遷移を確認

## 変更ファイル
- `packages/frontend/e2e/frontend-dashboard-notification-routing.spec.ts`

## 検証
- `npx --prefix packages/frontend playwright test --config packages/frontend/playwright.config.ts packages/frontend/e2e/frontend-dashboard-notification-routing.spec.ts --list`
- `E2E_SCOPE=full E2E_CAPTURE=0 E2E_GREP="dashboard notification cards route to chat/leave/expense targets" ./scripts/e2e-frontend.sh`

## 関連
- Closes #1003
