### PR TITLE
refactor: chat routes の入力パーサを共通化

### DIFF
--- a/packages/backend/src/routes/chat.ts
+++ b/packages/backend/src/routes/chat.ts
@@ -39,11 +39,11 @@ import { resolveRoomAudienceUserIds } from '../services/chatMentionRecipients.js
 import { resolveGroupCandidatesBySelector } from '../services/groupCandidates.js';
 import {
   normalizeStringArray,
-  parseDateParam,
   parseLimit,
   parseLimitNumber,
   parseNonNegativeInt,
 } from './chat/shared/inputParsers.js';
+import { parseDateParam } from '../utils/date.js';
 
 function parseMaxBytes(raw: string | undefined, fallback: number) {
   if (!raw) return fallback;

--- a/packages/backend/src/routes/chat/shared/inputParsers.ts
+++ b/packages/backend/src/routes/chat/shared/inputParsers.ts
@@ -1,10 +1,3 @@
-export function parseDateParam(value?: string) {
-  if (!value) return null;
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return null;
-  return parsed;
-}
-
 export function parseLimit(value?: string, fallback = 50) {
   if (!value) return fallback;
   const parsed = Number(value);

--- a/packages/backend/src/routes/chatBreakGlass.ts
+++ b/packages/backend/src/routes/chatBreakGlass.ts
@@ -8,7 +8,8 @@ import {
   chatBreakGlassRejectSchema,
   chatBreakGlassRequestSchema,
 } from './validators.js';
-import { parseDateParam, parseLimit } from './chat/shared/inputParsers.js';
+import { parseLimit } from './chat/shared/inputParsers.js';
+import { parseDateParam } from '../utils/date.js';
 
 function resolveEffectiveApproverRole(roles: string[]) {
   if (roles.includes('exec')) return 'exec';

--- a/packages/backend/src/routes/chatRooms.ts
+++ b/packages/backend/src/routes/chatRooms.ts
@@ -42,11 +42,11 @@ import {
 } from './validators.js';
 import {
   normalizeStringArray,
-  parseDateParam,
   parseLimit,
   parseLimitNumber,
   parseNonNegativeInt,
 } from './chat/shared/inputParsers.js';
+import { parseDateParam } from '../utils/date.js';
 
 export async function registerChatRoomRoutes(app: FastifyInstance) {
   const chatRoles = ['admin', 'mgmt', 'user', 'hr', 'exec', 'external_chat'];


### PR DESCRIPTION
## 概要
#1001 Lane D の backend chat routes 共通化の1段目として、重複していた入力パーサ/正規化処理を shared helper に切り出しました（挙動不変）。

## 変更内容
- 追加: `packages/backend/src/routes/chat/shared/inputParsers.ts`
  - `parseDateParam`
  - `parseLimit`
  - `parseLimitNumber`
  - `parseNonNegativeInt`
  - `normalizeStringArray`
- 置換:
  - `packages/backend/src/routes/chat.ts`
  - `packages/backend/src/routes/chatRooms.ts`
  - `packages/backend/src/routes/chatBreakGlass.ts`
  - 上記の重複実装を削除し shared helper を import

## 影響範囲
- ルートの request/response 契約は不変
- 監査ログ・権限制御ロジックは未変更

## 検証
- `npm run lint --prefix packages/backend` ✅
- `npm run typecheck --prefix packages/backend` ✅
