### PR TITLE
test: replace Math.random runId with randomUUID in e2e

### DIFF
--- a/packages/frontend/e2e/backend-delivery-due.spec.ts
+++ b/packages/frontend/e2e/backend-delivery-due.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 
 const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
@@ -8,8 +9,7 @@ const authHeaders = {
   'x-group-ids': 'mgmt,hr-group',
 };
 
-const runId = () =>
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
   if (res.ok()) return;

--- a/packages/frontend/e2e/backend-leave-time-conflict.spec.ts
+++ b/packages/frontend/e2e/backend-leave-time-conflict.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 
 const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
@@ -8,8 +9,7 @@ const authHeaders = {
   'x-group-ids': 'mgmt,hr-group',
 };
 
-const runId = () =>
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
   if (res.ok()) return;
@@ -24,7 +24,9 @@ function toDateInput(value: Date) {
   return `${year}-${month}-${day}`;
 }
 
-test('leave submit blocks when time entries exist @core', async ({ request }) => {
+test('leave submit blocks when time entries exist @core', async ({
+  request,
+}) => {
   const suffix = runId();
   const today = new Date();
   const tomorrow = new Date(today);
@@ -100,4 +102,3 @@ test('leave submit blocks when time entries exist @core', async ({ request }) =>
   const submitted = await submitOkRes.json();
   expect(submitted.status).toBe('pending_manager');
 });
-

--- a/packages/frontend/e2e/backend-milestone-sync.spec.ts
+++ b/packages/frontend/e2e/backend-milestone-sync.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 
 const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
@@ -8,8 +9,7 @@ const authHeaders = {
   'x-group-ids': 'mgmt,hr-group',
 };
 
-const runId = () =>
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 const toNumber = (value: unknown) => {
   if (typeof value === 'number') return value;

--- a/packages/frontend/e2e/backend-project-access-guard.spec.ts
+++ b/packages/frontend/e2e/backend-project-access-guard.spec.ts
@@ -1,9 +1,9 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 
 const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
 
-const runId = () =>
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 const buildHeaders = (input: {
   userId: string;

--- a/packages/frontend/e2e/backend-project-baselines.spec.ts
+++ b/packages/frontend/e2e/backend-project-baselines.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 
 const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
@@ -10,8 +11,7 @@ const authHeaders = {
 
 const demoProjectId = '00000000-0000-0000-0000-000000000001';
 
-const runId = () =>
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
   if (res.ok()) return;
@@ -100,4 +100,3 @@ test('project baseline can snapshot tasks @extended', async ({ request }) => {
   expect(String(snapB.planStart)).toContain('2026-01-11');
   expect(String(snapB.planEnd)).toContain('2026-01-20');
 });
-

--- a/packages/frontend/e2e/backend-project-burndown.spec.ts
+++ b/packages/frontend/e2e/backend-project-burndown.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 
 const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
@@ -8,8 +9,7 @@ const authHeaders = {
   'x-group-ids': 'mgmt,hr-group',
 };
 
-const runId = () =>
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
   if (res.ok()) return;

--- a/packages/frontend/e2e/backend-project-effort-variance.spec.ts
+++ b/packages/frontend/e2e/backend-project-effort-variance.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 
 const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
@@ -8,8 +9,7 @@ const authHeaders = {
   'x-group-ids': 'mgmt,hr-group',
 };
 
-const runId = () =>
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
   if (res.ok()) return;

--- a/packages/frontend/e2e/backend-project-evm.spec.ts
+++ b/packages/frontend/e2e/backend-project-evm.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 
 const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
@@ -10,8 +11,7 @@ const authHeaders = {
 
 const vendorId = '00000000-0000-0000-0000-000000000010';
 
-const runId = () =>
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
   if (res.ok()) return;

--- a/packages/frontend/e2e/backend-project-parent.spec.ts
+++ b/packages/frontend/e2e/backend-project-parent.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 
 const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
@@ -8,8 +9,7 @@ const authHeaders = {
   'x-group-ids': 'mgmt,hr-group',
 };
 
-const runId = () =>
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
   if (res.ok()) return;
@@ -85,4 +85,3 @@ test('project parent can be updated with reason @extended', async ({
   expect(circularRes.ok()).toBeFalsy();
   expect(circularRes.status()).toBe(400);
 });
-

--- a/packages/frontend/e2e/backend-project-period.spec.ts
+++ b/packages/frontend/e2e/backend-project-period.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 
 const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
@@ -8,8 +9,7 @@ const authHeaders = {
   'x-group-ids': 'mgmt,hr-group',
 };
 
-const runId = () =>
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
   if (res.ok()) return;

--- a/packages/frontend/e2e/backend-rate-card-profit.spec.ts
+++ b/packages/frontend/e2e/backend-rate-card-profit.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 
 const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
@@ -8,8 +9,7 @@ const authHeaders = {
   'x-group-ids': 'mgmt,hr-group',
 };
 
-const runId = () =>
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
   if (res.ok()) return;
@@ -68,4 +68,3 @@ test('rate card affects profit report @core', async ({ request }) => {
   const profit = await profitRes.json();
   expect(Number(profit?.costBreakdown?.laborCost ?? 0)).toBeGreaterThan(0);
 });
-

--- a/packages/frontend/e2e/backend-recurring-template.spec.ts
+++ b/packages/frontend/e2e/backend-recurring-template.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 
 const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
@@ -8,8 +9,7 @@ const authHeaders = {
   'x-group-ids': 'mgmt,hr-group',
 };
 
-const runId = () =>
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
   if (res.ok()) return;
@@ -17,7 +17,9 @@ async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
   throw new Error(`[e2e] api failed: ${res.status()} ${body}`);
 }
 
-test('recurring template generates draft invoice @core', async ({ request }) => {
+test('recurring template generates draft invoice @core', async ({
+  request,
+}) => {
   const suffix = runId();
   const projectRes = await request.post(`${apiBase}/projects`, {
     data: {

--- a/packages/frontend/e2e/backend-task-dependencies.spec.ts
+++ b/packages/frontend/e2e/backend-task-dependencies.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 
 const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
@@ -10,8 +11,7 @@ const authHeaders = {
 
 const demoProjectId = '00000000-0000-0000-0000-000000000001';
 
-const runId = () =>
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
   if (res.ok()) return;

--- a/packages/frontend/e2e/backend-task-parent.spec.ts
+++ b/packages/frontend/e2e/backend-task-parent.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 
 const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
@@ -10,8 +11,7 @@ const authHeaders = {
 
 const demoProjectId = '00000000-0000-0000-0000-000000000001';
 
-const runId = () =>
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
   if (res.ok()) return;
@@ -19,7 +19,9 @@ async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
   throw new Error(`[e2e] api failed: ${res.status()} ${body}`);
 }
 
-test('task parent can be updated and cleared @extended', async ({ request }) => {
+test('task parent can be updated and cleared @extended', async ({
+  request,
+}) => {
   const suffix = runId();
 
   const parentRes = await request.post(

--- a/packages/frontend/e2e/backend-task-period.spec.ts
+++ b/packages/frontend/e2e/backend-task-period.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 
 const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
@@ -10,8 +11,7 @@ const authHeaders = {
 
 const demoProjectId = '00000000-0000-0000-0000-000000000001';
 
-const runId = () =>
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
   if (res.ok()) return;

--- a/packages/frontend/e2e/backend-task-progress.spec.ts
+++ b/packages/frontend/e2e/backend-task-progress.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 
 const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
@@ -10,8 +11,7 @@ const authHeaders = {
 
 const demoProjectId = '00000000-0000-0000-0000-000000000001';
 
-const runId = () =>
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
   if (res.ok()) return;

--- a/packages/frontend/e2e/backend-time-invoice.spec.ts
+++ b/packages/frontend/e2e/backend-time-invoice.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 
 const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
@@ -8,8 +9,7 @@ const authHeaders = {
   'x-group-ids': 'mgmt,hr-group',
 };
 
-const runId = () =>
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 const toNumber = (value: unknown) => {
   if (typeof value === 'number') return value;
@@ -38,10 +38,13 @@ test('time entries to invoice draft @core', async ({ request }) => {
   await ensureOk(projectRes);
   const project = await projectRes.json();
 
-  const taskRes = await request.post(`${apiBase}/projects/${project.id}/tasks`, {
-    data: { name: `Task ${suffix}` },
-    headers: authHeaders,
-  });
+  const taskRes = await request.post(
+    `${apiBase}/projects/${project.id}/tasks`,
+    {
+      data: { name: `Task ${suffix}` },
+      headers: authHeaders,
+    },
+  );
   await ensureOk(taskRes);
   const task = await taskRes.json();
 
@@ -113,8 +116,9 @@ test('time entries to invoice draft @core', async ({ request }) => {
   await ensureOk(timeListRes);
   const timeList = await timeListRes.json();
   const timeItems = Array.isArray(timeList.items) ? timeList.items : [];
-  expect(timeItems.filter((item: any) => item.billedInvoiceId === invoice.id))
-    .toHaveLength(3);
+  expect(
+    timeItems.filter((item: any) => item.billedInvoiceId === invoice.id),
+  ).toHaveLength(3);
 
   const patchRes = await request.patch(`${apiBase}/time-entries/${entry1.id}`, {
     data: { minutes: 90 },

--- a/packages/frontend/e2e/frontend-smoke-admin-ops.spec.ts
+++ b/packages/frontend/e2e/frontend-smoke-admin-ops.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import fs from 'fs';
 import path from 'path';
 import { expect, test, type Locator, type Page } from '@playwright/test';
@@ -92,7 +93,7 @@ async function navigateToSection(page: Page, label: string, heading?: string) {
 
 const runId = () =>
   process.env.E2E_RUN_ID ||
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+  `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 const pad2 = (value: number) => String(value).padStart(2, '0');
 

--- a/packages/frontend/e2e/frontend-smoke-vendor-docs-create.spec.ts
+++ b/packages/frontend/e2e/frontend-smoke-vendor-docs-create.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import fs from 'fs';
 import path from 'path';
 import { expect, test, type Locator, type Page } from '@playwright/test';
@@ -28,7 +29,7 @@ const authState = {
 
 const runId = () =>
   process.env.E2E_RUN_ID ||
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+  `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 function ensureEvidenceDir() {
   if (!captureEnabled) return;

--- a/packages/frontend/e2e/frontend-task-time-entry.spec.ts
+++ b/packages/frontend/e2e/frontend-task-time-entry.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test, type Locator, type Page } from '@playwright/test';
 
 const baseUrl = process.env.E2E_BASE_URL || 'http://localhost:5173';
@@ -28,7 +29,7 @@ const authHeaders = {
 
 const runId = () =>
   process.env.E2E_RUN_ID ||
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+  `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
   if (res.ok()) return;


### PR DESCRIPTION
## 概要
- `packages/frontend/e2e` の runId 生成で使っていた `Math.random()` を `randomUUID()` に置換
- 対象は runId 生成のみ（挙動は同等、識別子の一意性をより安定化）
- `frontend-pwa.spec.ts` の `crypto` フォールバック用途の `Math.random()` は意図的に現状維持

## 変更範囲
- 20 spec ファイル（backend系E2E + frontend一部E2E）
- 各ファイルに `import { randomUUID } from 'node:crypto';` を追加し、runId生成式を更新

## 目的
- CodeQL レビューで継続的に指摘される `Math.random` ノイズの削減
- E2E識別子の衝突リスク低減

## 確認
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run e2e --prefix packages/frontend -- --list e2e/backend-time-invoice.spec.ts e2e/backend-project-evm.spec.ts e2e/frontend-task-time-entry.spec.ts`
