### PR TITLE
test: remove remaining Math.random usage from e2e specs

### DIFF
--- a/packages/frontend/e2e/frontend-smoke-core.spec.ts
+++ b/packages/frontend/e2e/frontend-smoke-core.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import fs from 'fs';
 import path from 'path';
 import { expect, test, type Locator, type Page } from '@playwright/test';
@@ -140,7 +141,7 @@ async function selectByValue(select: Locator, value: string) {
 
 const runId = () =>
   process.env.E2E_RUN_ID ||
-  `${Date.now().toString().slice(-6)}-${Math.floor(Math.random() * 90 + 10)}`;
+  `${Date.now().toString().slice(-6)}-${randomUUID()}`;
 
 const pad2 = (value: number) => String(value).padStart(2, '0');
 


### PR DESCRIPTION
## 概要
- `packages/frontend/e2e/frontend-smoke-core.spec.ts` の `runId` 生成を `randomUUID()` に置換
- `packages/frontend/e2e/frontend-pwa.spec.ts` の `runId` 生成を `randomUUID()` に置換
- pushモック内の `Math.random()` フォールバックを除去
  - `randomBytes` フォールバックは決定的バイト列に変更
  - `makeId` フォールバックは単調増加シーケンスに変更

## 目的
- E2Eスペック内の `Math.random` を解消し、CodeQLノイズを抑制
- 挙動不変（識別子生成/モックデータ生成の方式のみ変更）

## 確認
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run e2e --prefix packages/frontend -- --list e2e/frontend-smoke-core.spec.ts e2e/frontend-pwa.spec.ts`
