### PR TITLE
test: reduce e2e selector index dependence in core/offline flows

### DIFF
--- a/packages/frontend/e2e/frontend-offline.spec.ts
+++ b/packages/frontend/e2e/frontend-offline.spec.ts
@@ -74,9 +74,12 @@ test('frontend offline queue @extended', async ({ page, context }) => {
     has: page.locator('strong', { hasText: '現在のユーザー' }),
   });
   await currentSection.scrollIntoViewIfNeeded();
-  await currentSection.getByRole('button', { name: '再読込' }).click();
+  const offlineQueueSection = currentSection
+    .locator('strong', { hasText: 'オフライン送信キュー' })
+    .locator('..');
+  await offlineQueueSection.getByRole('button', { name: '再読込' }).click();
 
-  const statusLine = currentSection.getByText(/件数:/);
+  const statusLine = offlineQueueSection.getByText(/件数:/);
   await expect
     .poll(
       async () => {
@@ -89,6 +92,8 @@ test('frontend offline queue @extended', async ({ page, context }) => {
     .toBeGreaterThan(0);
 
   await context.setOffline(false);
-  await expect(currentSection.getByText('送信待ちを処理しました')).toBeVisible();
-  await captureSection(currentSection, '15-offline-queue-retry.png');
+  await expect(
+    offlineQueueSection.getByText('送信待ちを処理しました'),
+  ).toBeVisible();
+  await captureSection(offlineQueueSection, '15-offline-queue-retry.png');
 });

--- a/packages/frontend/e2e/frontend-pwa.spec.ts
+++ b/packages/frontend/e2e/frontend-pwa.spec.ts
@@ -191,13 +191,14 @@ test('pwa offline duplicate time entries @pwa @extended', async ({
     has: page.locator('strong', { hasText: '現在のユーザー' }),
   });
   await currentSection.scrollIntoViewIfNeeded();
-  await currentSection.getByRole('button', { name: '再読込' }).click();
+  const offlineQueueSection = currentSection
+    .locator('strong', { hasText: 'オフライン送信キュー' })
+    .locator('..');
+  await offlineQueueSection.getByRole('button', { name: '再読込' }).click();
   await expect
     .poll(
       async () => {
-        const statusText = await currentSection
-          .getByText(/件数:/)
-          .textContent();
+        const statusText = await offlineQueueSection.getByText(/件数:/).textContent();
         const match = statusText?.match(/件数:\s*(\d+)/);
         return match ? Number(match[1]) : 0;
       },
@@ -207,16 +208,14 @@ test('pwa offline duplicate time entries @pwa @extended', async ({
 
   await context.setOffline(false);
 
-  const resendButton = currentSection.getByRole('button', { name: '再送' });
+  const resendButton = offlineQueueSection.getByRole('button', { name: '再送' });
   if (await resendButton.isEnabled().catch(() => false)) {
     await resendButton.click();
   }
   await expect
     .poll(
       async () => {
-        const statusText = await currentSection
-          .getByText(/件数:/)
-          .textContent();
+        const statusText = await offlineQueueSection.getByText(/件数:/).textContent();
         const match = statusText?.match(/件数:\s*(\d+)/);
         return match ? Number(match[1]) : 0;
       },


### PR DESCRIPTION
## 概要
- `frontend-offline.spec.ts` の再読込ボタン操作から `.first()` を除去
- `frontend-pwa.spec.ts` の再読込ボタン操作から `.first()` を除去

## 目的
- E2Eの index 依存セレクタを減らし、UI変化時の flaky 要因を低減する

## 確認
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run e2e --prefix packages/frontend -- --list e2e/frontend-offline.spec.ts e2e/frontend-pwa.spec.ts`

Refs #1001