### PR TITLE
test: stabilize workflow-evidence e2e selectors

### DIFF
--- a/packages/frontend/e2e/frontend-smoke-workflow-evidence.spec.ts
+++ b/packages/frontend/e2e/frontend-smoke-workflow-evidence.spec.ts
@@ -189,13 +189,15 @@ test('frontend smoke workflow evidence chat references @extended', async ({
   await expect(evidencePickerDrawer.getByText(evidenceMessage)).toBeVisible({
     timeout: actionTimeout,
   });
-  await evidencePickerDrawer
-    .getByRole('button', { name: '追加' })
-    .first()
-    .click();
-  await evidencePickerDrawer
+  const evidenceCandidateCard = evidencePickerDrawer.locator('.itdo-card', {
+    hasText: evidenceMessage,
+  });
+  await expect(evidenceCandidateCard).toHaveCount(1, {
+    timeout: actionTimeout,
+  });
+  await evidenceCandidateCard.getByRole('button', { name: '追加' }).click();
+  await evidenceCandidateCard
     .getByRole('button', { name: 'メモへ挿入' })
-    .first()
     .click();
   await evidencePickerDrawer.getByRole('button', { name: '閉じる' }).click();
   await expect(evidencePickerDrawer).toBeHidden({ timeout: actionTimeout });
@@ -303,9 +305,9 @@ test('frontend smoke workflow evidence chat references @extended', async ({
   await expect(
     evidenceApprovalItem.getByRole('link', { name: evidenceUrl }),
   ).toBeVisible({ timeout: actionTimeout });
-  const previewButton = evidenceApprovalItem
-    .getByRole('button', { name: 'プレビュー' })
-    .first();
+  const previewButton = evidenceApprovalItem.getByRole('button', {
+    name: 'プレビュー',
+  });
   await previewButton.click();
   await expect(evidenceApprovalItem.getByText(evidenceMessage)).toBeVisible({
     timeout: actionTimeout,


### PR DESCRIPTION
## 概要
- `frontend-smoke-workflow-evidence.spec.ts` のセレクタを安定化
  - エビデンス候補操作 (`追加` / `メモへ挿入`) を候補カード単位へスコープ
  - 承認一覧の `プレビュー` ボタン操作から不要な `.first()` を除去

## 目的
- 候補件数増加時・同名ボタン共存時の誤クリックリスクを減らす

## 確認
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run e2e --prefix packages/frontend -- --list e2e/frontend-smoke-workflow-evidence.spec.ts`

Refs #1001
