### PR TITLE
test: stabilize approval-flow e2e selectors

### DIFF
--- a/packages/frontend/e2e/frontend-smoke-approval-ack-link.spec.ts
+++ b/packages/frontend/e2e/frontend-smoke-approval-ack-link.spec.ts
@@ -198,15 +198,17 @@ test('frontend smoke approval ack link lifecycle @extended', async ({
     .locator('h2', { hasText: '承認一覧' })
     .locator('..');
   await approvalsSection.scrollIntoViewIfNeeded();
+  const flowTypeSelect = approvalsSection.locator('select', {
+    has: approvalsSection.locator('option', { hasText: '見積' }),
+  });
   await selectByLabelOrFirst(
-    approvalsSection.locator('select').first(),
+    flowTypeSelect,
     '見積',
   );
   await approvalsSection.getByRole('button', { name: '再読込' }).click();
 
-  const approvalItem = approvalsSection
-    .locator('li', { hasText: estimateId })
-    .first();
+  const approvalItem = approvalsSection.locator('li', { hasText: estimateId });
+  await expect(approvalItem).toHaveCount(1, { timeout: actionTimeout });
   await expect(approvalItem).toBeVisible({ timeout: actionTimeout });
 
   const ackInput = approvalItem.getByPlaceholder(
@@ -221,7 +223,7 @@ test('frontend smoke approval ack link lifecycle @extended', async ({
   });
 
   page.once('dialog', (dialog) => dialog.accept().catch(() => undefined));
-  await approvalItem.getByRole('button', { name: '削除' }).first().click();
+  await approvalItem.getByRole('button', { name: '削除' }).click();
   await expect(
     approvalItem.getByText('登録済みリンクはありません'),
   ).toBeVisible({

--- a/packages/frontend/e2e/frontend-smoke-approvals-ack-guard.spec.ts
+++ b/packages/frontend/e2e/frontend-smoke-approvals-ack-guard.spec.ts
@@ -245,15 +245,17 @@ test('frontend smoke approvals ack guard requires override reason @extended', as
     .locator('h2', { hasText: '承認一覧' })
     .locator('..');
   await approvalsSection.scrollIntoViewIfNeeded();
+  const flowTypeSelect = approvalsSection.locator('select', {
+    has: approvalsSection.locator('option', { hasText: '見積' }),
+  });
   await selectByLabelOrFirst(
-    approvalsSection.locator('select').first(),
+    flowTypeSelect,
     '見積',
   );
   await approvalsSection.getByRole('button', { name: '再読込' }).click();
 
-  const approvalItem = approvalsSection
-    .locator('li', { hasText: estimateId })
-    .first();
+  const approvalItem = approvalsSection.locator('li', { hasText: estimateId });
+  await expect(approvalItem).toHaveCount(1, { timeout: actionTimeout });
   await expect(approvalItem).toBeVisible({ timeout: actionTimeout });
   const reasonInput = approvalItem.getByPlaceholder('却下理由 (任意)');
 

--- a/packages/frontend/e2e/frontend-smoke-vendor-approvals.spec.ts
+++ b/packages/frontend/e2e/frontend-smoke-vendor-approvals.spec.ts
@@ -208,9 +208,8 @@ test('frontend smoke vendor approvals @extended', async ({ page }) => {
     .locator('h3', { hasText: '発注書' })
     .locator('..');
   await poBlock.getByRole('button', { name: /再取得|再読込/ }).click();
-  const poRow = poBlock
-    .locator('tbody tr', { hasText: fixture.purchaseOrderNo })
-    .first();
+  const poRow = poBlock.locator('tbody tr', { hasText: fixture.purchaseOrderNo });
+  await expect(poRow).toHaveCount(1, { timeout: actionTimeout });
   await expect(poRow).toBeVisible({ timeout: actionTimeout });
   const poSubmitButton = poRow.getByRole('button', { name: '承認依頼' });
   await expect(poSubmitButton).toBeVisible({ timeout: actionTimeout });
@@ -232,14 +231,18 @@ test('frontend smoke vendor approvals @extended', async ({ page }) => {
     .locator('h2', { hasText: '承認一覧' })
     .locator('..');
   await approvalsSection.scrollIntoViewIfNeeded();
+  const flowTypeSelect = approvalsSection.locator('select', {
+    has: approvalsSection.locator('option', { hasText: '発注' }),
+  });
   await selectByLabelOrFirst(
-    approvalsSection.locator('select').first(),
+    flowTypeSelect,
     '発注',
   );
   await approvalsSection.getByRole('button', { name: '再読込' }).click();
-  const approvalItem = approvalsSection
-    .locator('li', { hasText: `purchase_orders:${fixture.purchaseOrderId}` })
-    .first();
+  const approvalItem = approvalsSection.locator('li', {
+    hasText: `purchase_orders:${fixture.purchaseOrderId}`,
+  });
+  await expect(approvalItem).toHaveCount(1, { timeout: actionTimeout });
   await expect(approvalItem).toBeVisible({ timeout: actionTimeout });
   const approveButton = approvalItem.getByRole('button', { name: '承認' });
   await expect(approveButton).toBeVisible({ timeout: actionTimeout });

--- a/packages/frontend/e2e/frontend-smoke-workflow-evidence.spec.ts
+++ b/packages/frontend/e2e/frontend-smoke-workflow-evidence.spec.ts
@@ -165,9 +165,10 @@ test('frontend smoke workflow evidence chat references @extended', async ({
   await expenseSection.getByRole('button', { name: '追加' }).click();
   await expect(expenseSection.getByText('経費を保存しました')).toBeVisible();
 
-  const createdExpenseItem = expenseSection
-    .locator('li', { hasText: expenseAmountPattern })
-    .first();
+  const createdExpenseItem = expenseSection.locator('li', {
+    hasText: expenseAmountPattern,
+  });
+  await expect(createdExpenseItem).toHaveCount(1, { timeout: actionTimeout });
   await expect(createdExpenseItem).toBeVisible({ timeout: actionTimeout });
   const expenseAnnotationButton = createdExpenseItem.getByRole('button', {
     name: /注釈（経費）:/,
@@ -202,14 +203,16 @@ test('frontend smoke workflow evidence chat references @extended', async ({
   await evidencePickerDrawer.getByRole('button', { name: '閉じる' }).click();
   await expect(evidencePickerDrawer).toBeHidden({ timeout: actionTimeout });
 
-  await expect(
-    expenseAnnotationDrawer.getByRole('link', { name: /Chat（/ }).first(),
-  ).toBeVisible({ timeout: actionTimeout });
-  await expect(
-    expenseAnnotationDrawer
-      .locator('.badge', { hasText: 'chat_message' })
-      .first(),
-  ).toBeVisible({ timeout: actionTimeout });
+  const chatReferenceLink = expenseAnnotationDrawer.getByRole('link', {
+    name: /Chat（/,
+  });
+  await expect(chatReferenceLink).toHaveCount(1, { timeout: actionTimeout });
+  await expect(chatReferenceLink).toBeVisible({ timeout: actionTimeout });
+  const chatRefBadge = expenseAnnotationDrawer.locator('.badge', {
+    hasText: 'chat_message',
+  });
+  await expect(chatRefBadge).toHaveCount(1, { timeout: actionTimeout });
+  await expect(chatRefBadge).toBeVisible({ timeout: actionTimeout });
   await expect(
     expenseAnnotationDrawer.getByLabel('メモ（Markdown）'),
   ).toHaveValue(new RegExp(messageId), { timeout: actionTimeout });
@@ -278,15 +281,19 @@ test('frontend smoke workflow evidence chat references @extended', async ({
     .locator('h2', { hasText: '承認一覧' })
     .locator('..');
   await approvalsSection.scrollIntoViewIfNeeded();
+  const flowTypeSelect = approvalsSection.locator('select', {
+    has: approvalsSection.locator('option', { hasText: '見積' }),
+  });
   await selectByLabelOrFirst(
-    approvalsSection.locator('select').first(),
+    flowTypeSelect,
     '見積',
   );
   await approvalsSection.getByRole('button', { name: '再読込' }).click();
 
-  const evidenceApprovalItem = approvalsSection
-    .locator('li', { hasText: estimateId })
-    .first();
+  const evidenceApprovalItem = approvalsSection.locator('li', {
+    hasText: estimateId,
+  });
+  await expect(evidenceApprovalItem).toHaveCount(1, { timeout: actionTimeout });
   await expect(evidenceApprovalItem).toBeVisible({ timeout: actionTimeout });
   await evidenceApprovalItem.getByRole('button', { name: '表示' }).click();
   await expect(evidenceApprovalItem.getByText('状態: 生成済み')).toBeVisible({


### PR DESCRIPTION
## 概要
- 承認関連E2Eのセレクタ安定化（index依存削減）
  - `frontend-smoke-approval-ack-link.spec.ts`
  - `frontend-smoke-approvals-ack-guard.spec.ts`
  - `frontend-smoke-vendor-approvals.spec.ts`
  - `frontend-smoke-workflow-evidence.spec.ts`

### 主な変更
- 承認一覧のフロー種別選択を `select.first()` から「対象 option を持つ select」へ変更
- 対象行の特定を `.first()` 依存から `toHaveCount(1)` + 該当ロケータへ変更
- workflow evidence の参照リンク/バッジ確認を `.first()` 依存から単一件前提の確認へ変更

## 目的
- 同名要素が増えた際の strict mode 失敗・誤クリックを抑制する

## 確認
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run e2e --prefix packages/frontend -- --list e2e/frontend-smoke-approval-ack-link.spec.ts e2e/frontend-smoke-approvals-ack-guard.spec.ts e2e/frontend-smoke-vendor-approvals.spec.ts e2e/frontend-smoke-workflow-evidence.spec.ts`

Refs #1001
