### PR TITLE
test: stabilize vendor-docs/mobile e2e selectors

### DIFF
--- a/packages/frontend/e2e/frontend-mobile-smoke.spec.ts
+++ b/packages/frontend/e2e/frontend-mobile-smoke.spec.ts
@@ -112,9 +112,9 @@ async function selectByValue(select: Locator, value: string) {
 }
 
 async function findSelectByOptionText(scope: Locator, optionText: string) {
-  const select = scope.locator('select', {
-    has: scope.locator('option', { hasText: optionText }),
-  });
+  const options = scope.locator('option', { hasText: optionText });
+  await expect(options).toHaveCount(1, { timeout: actionTimeout });
+  const select = options.locator('xpath=ancestor::select[1]');
   await expect(select).toHaveCount(1, { timeout: actionTimeout });
   return select;
 }

--- a/packages/frontend/e2e/frontend-smoke-vendor-docs-create.spec.ts
+++ b/packages/frontend/e2e/frontend-smoke-vendor-docs-create.spec.ts
@@ -121,9 +121,9 @@ async function selectByValue(select: Locator, value: string) {
 }
 
 async function findSelectByOptionText(scope: Locator, optionText: string) {
-  const select = scope.locator('select', {
-    has: scope.locator('option', { hasText: optionText }),
-  });
+  const options = scope.locator('option', { hasText: optionText });
+  await expect(options).toHaveCount(1, { timeout: actionTimeout });
+  const select = options.locator('xpath=ancestor::select[1]');
   await expect(select).toHaveCount(1, { timeout: actionTimeout });
   return select;
 }


### PR DESCRIPTION
## 概要
- `frontend-smoke-vendor-docs-create.spec.ts` の index依存 (`.first()`/`.nth()`) を、option文言スコープ・単一件確認に置換
- `frontend-mobile-smoke.spec.ts` の row/select 特定を単一件確認ベースへ変更
- ダイアログ内 select も option文言ベースで特定し、同名要素追加時のstrict mode失敗を回避

## 変更詳細
- helper `findSelectByOptionText` を追加し、`案件を選択`/`業者を選択`/`紐づけなし` を手掛かりに select を一意特定
- 一覧行の取得を `.first()` から `toHaveCount(1)` + locator へ変更
- 配賦明細の金額入力を `td:nth-child(2)` で明示化

## 確認
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run e2e --prefix packages/frontend -- --list e2e/frontend-smoke-vendor-docs-create.spec.ts e2e/frontend-mobile-smoke.spec.ts`