### PR TITLE
test: tighten reports/settings e2e locator scoping

### DIFF
--- a/packages/frontend/e2e/frontend-smoke-reports-masters-settings.spec.ts
+++ b/packages/frontend/e2e/frontend-smoke-reports-masters-settings.spec.ts
@@ -316,8 +316,8 @@ test('frontend smoke reports masters settings @extended', async ({ page }) => {
 
   const chatRoomSettingsBlock = settingsSection
     .locator('strong', { hasText: 'チャットルーム設定' })
-    .first()
     .locator('..');
+  await expect(chatRoomSettingsBlock).toHaveCount(1, { timeout: actionTimeout });
   await captureSection(chatRoomSettingsBlock, '11-chat-room-settings.png');
 
   const scimBlock = settingsSection
@@ -353,18 +353,27 @@ test('frontend smoke reports masters settings @extended', async ({ page }) => {
   await expect(
     settingsSection.getByText('承認ルールを作成しました'),
   ).toBeVisible();
-  await approvalBlock
-    .getByRole('button', { name: '履歴を見る' })
-    .first()
-    .click();
-  await expect(
-    approvalBlock.locator('.itdo-audit-timeline').first(),
-  ).toBeVisible({
+  const approvalHistoryButtons = approvalBlock.getByRole('button', {
+    name: '履歴を見る',
+  });
+  await expect(approvalHistoryButtons).toHaveCount(1, {
     timeout: actionTimeout,
   });
-  await expect(
-    approvalBlock.getByRole('region', { name: 'Diff output' }).first(),
-  ).toBeVisible({
+  await approvalHistoryButtons.click();
+  const approvalAuditTimelines = approvalBlock.locator('.itdo-audit-timeline');
+  await expect(approvalAuditTimelines).toHaveCount(1, {
+    timeout: actionTimeout,
+  });
+  await expect(approvalAuditTimelines).toBeVisible({
+    timeout: actionTimeout,
+  });
+  const approvalDiffRegions = approvalBlock.getByRole('region', {
+    name: 'Diff output',
+  });
+  await expect(approvalDiffRegions).toHaveCount(1, {
+    timeout: actionTimeout,
+  });
+  await expect(approvalDiffRegions).toBeVisible({
     timeout: actionTimeout,
   });
   await captureSection(approvalBlock, '11-approval-rules.png');
@@ -374,14 +383,19 @@ test('frontend smoke reports masters settings @extended', async ({ page }) => {
     .locator('..');
   const actionPolicyKey = `submit.e2e.${id}`;
   await actionPolicyBlock.getByLabel('subjects (JSON)').fill('{');
-  await actionPolicyBlock.getByRole('button', { name: '作成' }).first().click();
-  const settingsMessage = settingsSection.locator(':scope > p').first();
-  await expect(settingsMessage).toHaveText('subjects のJSONが不正です', {
+  const actionPolicyCreateButtons = actionPolicyBlock.getByRole('button', {
+    name: '作成',
+  });
+  await expect(actionPolicyCreateButtons).toHaveCount(1, {
+    timeout: actionTimeout,
+  });
+  await actionPolicyCreateButtons.click();
+  await expect(settingsSection.getByText('subjects のJSONが不正です')).toBeVisible({
     timeout: actionTimeout,
   });
   await actionPolicyBlock.getByLabel('subjects (JSON)').fill('{}');
   await actionPolicyBlock.getByLabel('actionKey').fill(actionPolicyKey);
-  await actionPolicyBlock.getByRole('button', { name: '作成' }).first().click();
+  await actionPolicyCreateButtons.click();
   await expect(
     settingsSection.getByText('ActionPolicy を作成しました'),
   ).toBeVisible({ timeout: actionTimeout });


### PR DESCRIPTION
## 概要
- `frontend-smoke-reports-masters-settings.spec.ts` の `.first()` 依存を縮退し、設定画面ブロック内で一意に特定する locator へ変更

## 変更詳細
- チャットルーム設定ブロックを `toHaveCount(1)` で単一件確認
- 承認ルールの「履歴を見る」/監査タイムライン/Diff表示を件数確認後に操作
- ActionPolicy の「作成」ボタンをブロックスコープで単一件確認して再利用
- エラーメッセージ確認を `:scope > p` + `.first()` から文言ベース可視確認へ変更

## 確認
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run e2e --prefix packages/frontend -- --list e2e/frontend-smoke-reports-masters-settings.spec.ts`
