### PR TITLE
test: replace xpath in select helper with parent locator

### DIFF
--- a/packages/frontend/e2e/frontend-mobile-smoke.spec.ts
+++ b/packages/frontend/e2e/frontend-mobile-smoke.spec.ts
@@ -114,8 +114,9 @@ async function selectByValue(select: Locator, value: string) {
 async function findSelectByOptionText(scope: Locator, optionText: string) {
   const options = scope.locator('option', { hasText: optionText });
   await expect(options).toHaveCount(1, { timeout: actionTimeout });
-  const select = options.locator('xpath=ancestor::select[1]');
+  const select = options.locator('..');
   await expect(select).toHaveCount(1, { timeout: actionTimeout });
+  await expect(select).toHaveJSProperty('tagName', 'SELECT');
   return select;
 }
 

--- a/packages/frontend/e2e/frontend-smoke-vendor-docs-create.spec.ts
+++ b/packages/frontend/e2e/frontend-smoke-vendor-docs-create.spec.ts
@@ -123,8 +123,9 @@ async function selectByValue(select: Locator, value: string) {
 async function findSelectByOptionText(scope: Locator, optionText: string) {
   const options = scope.locator('option', { hasText: optionText });
   await expect(options).toHaveCount(1, { timeout: actionTimeout });
-  const select = options.locator('xpath=ancestor::select[1]');
+  const select = options.locator('..');
   await expect(select).toHaveCount(1, { timeout: actionTimeout });
+  await expect(select).toHaveJSProperty('tagName', 'SELECT');
   return select;
 }
 


### PR DESCRIPTION
## 概要
- vendor/mobile E2E の `findSelectByOptionText` ヘルパーから XPath 依存を除去

## 変更内容
- `option` の親要素取得を `xpath=ancestor::select[1]` から `..` へ変更
- 親要素が `SELECT` であることを `toHaveJSProperty('tagName', 'SELECT')` で検証

## 確認
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run e2e --prefix packages/frontend -- --list e2e/frontend-smoke-vendor-docs-create.spec.ts e2e/frontend-mobile-smoke.spec.ts`
