### PR TITLE
docs: update checklist and R2 gap triage after #1054-#1057

### DIFF
--- a/docs/manual/manual-test-checklist.md
+++ b/docs/manual/manual-test-checklist.md
@@ -43,10 +43,10 @@
 ### 仕入/発注（PO↔VI、配賦明細）
 
 - [ ] /vendor-quotes 作成と /vendor-invoices 作成 → /vendor-invoices/:id/submit → /vendor-invoices/:id/approve のハッピーパスが通る
-- [ ] POST /vendor-invoices/:id/link-po で PO を紐づけできる（案件/業者一致、監査ログ）
-- [ ] POST /vendor-invoices/:id/unlink-po で PO 紐づけを解除できる（監査ログ）
+- [x] POST /vendor-invoices/:id/link-po で PO を紐づけできる（案件/業者一致、監査ログ）
+- [x] POST /vendor-invoices/:id/unlink-po で PO 紐づけを解除できる（監査ログ）
 - [ ] GET /vendor-invoices/:id/lines で `poLineUsage`（他VI利用数量/入力数量/残数量）が取得できる
-- [ ] PUT /vendor-invoices/:id/lines で部分請求数量を更新できる（同一PO明細の未請求残が負値になる更新は 400）
+- [x] PUT /vendor-invoices/:id/lines で部分請求数量を更新できる（同一PO明細の未請求残が負値になる更新は 400）
 - [ ] PUT /vendor-invoices/:id/allocations で配賦明細を更新できる（合計=請求合計、autoAdjust による端数調整）
 - [ ] allocations を空配列で送ると配賦明細をクリアできる（監査ログ）
 - [ ] purchaseOrderLineId 指定時、VI が PO 未紐づけの場合は 400、別 PO の line は 400、存在しない line は 404
@@ -62,7 +62,7 @@
 ### ダッシュボード/通知
 
 - [ ] ダッシュボード: アラートカードが最新5件表示される（なければプレースホルダ）
-- [ ] ダッシュボード: 通知カードが表示され、クリックで該当画面に遷移できる（chat/休暇/経費）
+- [x] ダッシュボード: 通知カードが表示され、クリックで該当画面に遷移できる（chat/休暇/経費）
 
 ### チャット
 
@@ -117,14 +117,14 @@
 
 - [ ] ActionPolicy: PolicyFormBuilder で作成/更新ができる（必須・JSONバリデーション）
 - [ ] 承認ルール/ActionPolicy: 履歴表示で AuditTimeline と DiffViewer が表示される
-- [ ] 監査ログ: DateRangePicker（from/to）で期間指定検索ができる
+- [x] 監査ログ: DateRangePicker（from/to）で期間指定検索ができる
 - [ ] 監査閲覧: DateTimeRangePicker（targetFrom/targetUntil）で期間指定できる
 - [ ] HR分析: DateRangePicker（開始日/終了日）で集計範囲を変更できる
 
 ### モバイル回帰（design-system適用後）
 
 - [ ] `docs/test-results/mobile-regression-template.md` をコピーし、PR単位の証跡ファイル（`YYYY-MM-DD-mobile-regression-*.md`）を作成する
-- [ ] Invoices: 一覧/フィルタ/行アクションが `375x667` で崩れず操作できる
+- [x] Invoices: 一覧/フィルタ/行アクションが `375x667` で崩れず操作できる
 - [ ] VendorDocuments: PO紐づけ/解除、配賦明細または請求明細入力が `375x667` で操作できる
 - [ ] AuditLogs: 検索フォーム/一覧/CSV出力が `375x667` で操作できる
 - [ ] PeriodLocks: 登録/解除導線が `375x667` で操作できる

--- a/docs/test-results/2026-02-17-test-gap-triage-r2.md
+++ b/docs/test-results/2026-02-17-test-gap-triage-r2.md
@@ -10,28 +10,30 @@ Issue: #1001
 
 | ドメイン | チェック項目（代表） | 既存自動テスト根拠 | 判定 | 次アクション |
 | --- | --- | --- | --- | --- |
-| 承認(Workflow) | 承認一覧で承認実行、ack guard時の理由必須、リンク作成/削除 | `packages/frontend/e2e/frontend-smoke.spec.ts` (`approval ack link lifecycle`, `approvals ack guard requires override reason`), `packages/frontend/e2e/backend-action-policy-ack-guard.spec.ts` | 自動E2E済み | 失敗時メッセージの文言変更耐性（code基準）を追加検討 |
-| 通知 | 通知抑止、current-user通知設定、digest/realtime | `packages/frontend/e2e/backend-notification-suppression.spec.ts`, `packages/frontend/e2e/frontend-smoke.spec.ts` (`current-user notification settings`) | 自動E2E済み | 通知カード遷移（dashboard click-through）を追加 |
-| 仕入請求(PO↔VI) | link/unlink、submit後理由必須、配賦/明細整合 | `packages/frontend/e2e/backend-vendor-invoice-linking.spec.ts`, `packages/frontend/e2e/frontend-smoke.spec.ts` (`vendor docs create`, `vendor approvals`) | 概ね自動E2E済み | `GET/PUT /vendor-invoices/:id/lines` の負値境界を追加 |
-| 権限境界 | project access、non-admin制限、override監査 | `packages/frontend/e2e/backend-project-access-guard.spec.ts`, `packages/frontend/e2e/backend-vendor-invoice-linking.spec.ts`, `packages/frontend/e2e/backend-action-policy-ack-guard.spec.ts` | 自動E2E済み | 非管理ロールのUI非表示/無効化のE2Eを追加 |
+| 承認(Workflow) | 承認一覧で承認実行、ack guard時の理由必須、リンク作成/削除 | `packages/frontend/e2e/frontend-smoke-approval-ack-link.spec.ts`, `packages/frontend/e2e/frontend-smoke-approvals-ack-guard.spec.ts`, `packages/frontend/e2e/backend-action-policy-ack-guard.spec.ts` | 自動E2E済み | 失敗時の分岐（schema validation含む）の code基準維持を継続 |
+| 通知 | 通知抑止、current-user通知設定、digest/realtime | `packages/frontend/e2e/backend-notification-suppression.spec.ts`, `packages/frontend/e2e/frontend-smoke-current-user-notification-settings.spec.ts`, `packages/frontend/e2e/frontend-dashboard-notification-routing.spec.ts` | 自動E2E済み | 高優先ギャップ解消済み |
+| 仕入請求(PO↔VI) | link/unlink、submit後理由必須、配賦/明細整合 | `packages/frontend/e2e/backend-vendor-invoice-linking.spec.ts`, `packages/frontend/e2e/frontend-smoke-vendor-docs-create.spec.ts`, `packages/frontend/e2e/frontend-smoke-vendor-approvals.spec.ts` | 自動E2E済み | 高優先ギャップ解消済み |
+| 権限境界 | project access、non-admin制限、override監査 | `packages/frontend/e2e/backend-project-access-guard.spec.ts`, `packages/frontend/e2e/backend-vendor-invoice-linking.spec.ts`, `packages/frontend/e2e/backend-action-policy-ack-guard.spec.ts`, `packages/frontend/e2e/frontend-smoke-invoice-send-mark-paid.spec.ts` | 自動E2E済み | 高優先ギャップ解消済み |
 
-## 未カバー（優先）
+## 優先ギャップの対応状況（2026-02-17 更新）
 
 1. Dashboard通知カードの遷移検証（chat/休暇/経費）
-   - チェックリスト: 「ダッシュボード: 通知カードが表示され、クリックで該当画面に遷移」
-   - 現状: APIレベルと設定UIは網羅、カード遷移は未自動化
+   - 対応: `packages/frontend/e2e/frontend-dashboard-notification-routing.spec.ts`
+   - 状態: main 反映済み
 2. Vendor invoice lines 境界（部分請求残が負値になる更新は 400）
-   - チェックリスト: `PUT /vendor-invoices/:id/lines` の境界
-   - 現状: link/unlink と submit後制御は網羅、lines負値境界の直接E2Eは不足
+   - 対応:
+     - `packages/frontend/e2e/backend-vendor-invoice-linking.spec.ts`
+     - `PO_LINE_QUANTITY_EXCEEDED`（単一行/分割行）と `quantity <= 0` の境界をカバー
+   - PR: #1054, #1057（main 反映済み）
 3. モバイル回帰（375x667）
-   - チェックリスト: Invoices/VendorDocuments/AuditLogs/PeriodLocks/AdminJobs
-   - 現状: 画面単位のモバイル検証シナリオ未整備
+   - 対応: `packages/frontend/e2e/frontend-mobile-smoke.spec.ts`
+   - 範囲: Invoices / VendorDocuments / AdminJobs / AuditLogs / PeriodLocks
+   - PR: #1056（main 反映済み）
 
 ## 次PR候補（小粒）
 
-- PR-A: dashboard notification card click-through E2E
-- PR-B: vendor-invoice lines negative-remaining boundary E2E
-- PR-C: mobile smoke for Invoices/VendorDocuments/AdminJobs (375x667)
+- 高優先4ドメインの直近ギャップは解消済み
+- 次段は `docs/manual/manual-test-checklist.md` の未消化項目から低優先項目を分割する
 
 ## 備考
 - 現時点では高優先4ドメインの「機能自体の回帰防止」は成立。


### PR DESCRIPTION
## 概要
- #1054〜#1057 のマージ後状態に合わせ、品質向上R2の記録を更新
- 高優先ギャップ（通知カード遷移 / VI lines境界 / モバイル回帰）の対応済み状態を反映
- manual checklist の該当項目を最新状態へ更新

## 変更
- `docs/test-results/2026-02-17-test-gap-triage-r2.md`
  - 旧 `frontend-smoke.spec.ts` 参照を分割後specへ更新
  - 優先ギャップの対応状況を反映
- `docs/manual/manual-test-checklist.md`
  - PO↔VI link/unlink
  - `PUT /vendor-invoices/:id/lines` 境界
  - ダッシュボード通知カード遷移
  - AuditLogs DateRangePicker
  - mobile Invoices項目

## 関連
- #1001
