### PR TITLE
test: add vendor-invoice purchaseOrderLineId guard e2e

### DIFF
--- a/docs/manual/manual-test-checklist.md
+++ b/docs/manual/manual-test-checklist.md
@@ -45,11 +45,11 @@
 - [ ] /vendor-quotes 作成と /vendor-invoices 作成 → /vendor-invoices/:id/submit → /vendor-invoices/:id/approve のハッピーパスが通る
 - [x] POST /vendor-invoices/:id/link-po で PO を紐づけできる（案件/業者一致、監査ログ）
 - [x] POST /vendor-invoices/:id/unlink-po で PO 紐づけを解除できる（監査ログ）
-- [ ] GET /vendor-invoices/:id/lines で `poLineUsage`（他VI利用数量/入力数量/残数量）が取得できる
+- [x] GET /vendor-invoices/:id/lines で `poLineUsage`（他VI利用数量/入力数量/残数量）が取得できる
 - [x] PUT /vendor-invoices/:id/lines で部分請求数量を更新できる（同一PO明細の未請求残が負値になる更新は 400）
 - [ ] PUT /vendor-invoices/:id/allocations で配賦明細を更新できる（合計=請求合計、autoAdjust による端数調整）
 - [ ] allocations を空配列で送ると配賦明細をクリアできる（監査ログ）
-- [ ] purchaseOrderLineId 指定時、VI が PO 未紐づけの場合は 400、別 PO の line は 400、存在しない line は 404
+- [x] purchaseOrderLineId 指定時、VI が PO 未紐づけの場合は 400、別 PO の line は 400、存在しない line は 404
 
 ### その他
 

--- a/docs/test-results/2026-02-17-test-gap-triage-r2.md
+++ b/docs/test-results/2026-02-17-test-gap-triage-r2.md
@@ -3,17 +3,18 @@
 Issue: #1001
 
 ## 対象
-- `docs/manual/manual-test-checklist.md`（未チェック 80 項目）
+
+- `docs/manual/manual-test-checklist.md`（未チェック 72 項目）
 - 高優先ドメイン: 承認/通知/仕入請求(PO↔VI)/権限
 
 ## 先行判定（高優先のみ）
 
-| ドメイン | チェック項目（代表） | 既存自動テスト根拠 | 判定 | 次アクション |
-| --- | --- | --- | --- | --- |
-| 承認(Workflow) | 承認一覧で承認実行、ack guard時の理由必須、リンク作成/削除 | `packages/frontend/e2e/frontend-smoke-approval-ack-link.spec.ts`, `packages/frontend/e2e/frontend-smoke-approvals-ack-guard.spec.ts`, `packages/frontend/e2e/backend-action-policy-ack-guard.spec.ts` | 自動E2E済み | 失敗時の分岐（schema validation含む）の code基準維持を継続 |
-| 通知 | 通知抑止、current-user通知設定、digest/realtime | `packages/frontend/e2e/backend-notification-suppression.spec.ts`, `packages/frontend/e2e/frontend-smoke-current-user-notification-settings.spec.ts`, `packages/frontend/e2e/frontend-dashboard-notification-routing.spec.ts` | 自動E2E済み | 高優先ギャップ解消済み |
-| 仕入請求(PO↔VI) | link/unlink、submit後理由必須、配賦/明細整合 | `packages/frontend/e2e/backend-vendor-invoice-linking.spec.ts`, `packages/frontend/e2e/frontend-smoke-vendor-docs-create.spec.ts`, `packages/frontend/e2e/frontend-smoke-vendor-approvals.spec.ts` | 自動E2E済み | 高優先ギャップ解消済み |
-| 権限境界 | project access、non-admin制限、override監査 | `packages/frontend/e2e/backend-project-access-guard.spec.ts`, `packages/frontend/e2e/backend-vendor-invoice-linking.spec.ts`, `packages/frontend/e2e/backend-action-policy-ack-guard.spec.ts`, `packages/frontend/e2e/frontend-smoke-invoice-send-mark-paid.spec.ts` | 自動E2E済み | 高優先ギャップ解消済み |
+| ドメイン        | チェック項目（代表）                                       | 既存自動テスト根拠                                                                                                                                                                                                                                                   | 判定        | 次アクション                                               |
+| --------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------------- |
+| 承認(Workflow)  | 承認一覧で承認実行、ack guard時の理由必須、リンク作成/削除 | `packages/frontend/e2e/frontend-smoke-approval-ack-link.spec.ts`, `packages/frontend/e2e/frontend-smoke-approvals-ack-guard.spec.ts`, `packages/frontend/e2e/backend-action-policy-ack-guard.spec.ts`                                                                | 自動E2E済み | 失敗時の分岐（schema validation含む）の code基準維持を継続 |
+| 通知            | 通知抑止、current-user通知設定、digest/realtime            | `packages/frontend/e2e/backend-notification-suppression.spec.ts`, `packages/frontend/e2e/frontend-smoke-current-user-notification-settings.spec.ts`, `packages/frontend/e2e/frontend-dashboard-notification-routing.spec.ts`                                         | 自動E2E済み | 高優先ギャップ解消済み                                     |
+| 仕入請求(PO↔VI) | link/unlink、submit後理由必須、配賦/明細整合               | `packages/frontend/e2e/backend-vendor-invoice-linking.spec.ts`, `packages/frontend/e2e/frontend-smoke-vendor-docs-create.spec.ts`, `packages/frontend/e2e/frontend-smoke-vendor-approvals.spec.ts`                                                                   | 自動E2E済み | 高優先ギャップ解消済み                                     |
+| 権限境界        | project access、non-admin制限、override監査                | `packages/frontend/e2e/backend-project-access-guard.spec.ts`, `packages/frontend/e2e/backend-vendor-invoice-linking.spec.ts`, `packages/frontend/e2e/backend-action-policy-ack-guard.spec.ts`, `packages/frontend/e2e/frontend-smoke-invoice-send-mark-paid.spec.ts` | 自動E2E済み | 高優先ギャップ解消済み                                     |
 
 ## 優先ギャップの対応状況（2026-02-17 更新）
 
@@ -24,7 +25,9 @@ Issue: #1001
    - 対応:
      - `packages/frontend/e2e/backend-vendor-invoice-linking.spec.ts`
      - `PO_LINE_QUANTITY_EXCEEDED`（単一行/分割行）と `quantity <= 0` の境界をカバー
-   - PR: #1054, #1057（main 反映済み）
+     - `GET /vendor-invoices/:id/lines` の `poLineUsage` をカバー
+     - `purchaseOrderLineId` の異常系（PO未紐づけ=400 / 別PO line=400 / 不存在line=404）をカバー
+   - PR: #1054, #1057, #1059（main 反映済み）
 3. モバイル回帰（375x667）
    - 対応: `packages/frontend/e2e/frontend-mobile-smoke.spec.ts`
    - 範囲: Invoices / VendorDocuments / AdminJobs / AuditLogs / PeriodLocks
@@ -36,5 +39,6 @@ Issue: #1001
 - 次段は `docs/manual/manual-test-checklist.md` の未消化項目から低優先項目を分割する
 
 ## 備考
+
 - 現時点では高優先4ドメインの「機能自体の回帰防止」は成立。
 - 以降は UI 遷移品質と境界条件の取りこぼしを埋める段階。


### PR DESCRIPTION
## 概要
- `backend-vendor-invoice-linking.spec.ts` に `purchaseOrderLineId` 異常系のE2Eを追加
  - VIがPO未紐づけ: `400 INVALID_PURCHASE_ORDER_LINE`
  - 別POのline指定: `400 INVALID_PURCHASE_ORDER_LINE`
  - 存在しないline指定: `404 NOT_FOUND`
- `manual-test-checklist` の PO↔VI 2項目（`poLineUsage` / `purchaseOrderLineId` 異常系）を消し込み
- `test-gap-triage-r2` を最新化（未チェック数72、vendor-invoice lines 境界カバレッジ追記）

## 実行コマンド
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npx prettier --check packages/frontend/e2e/backend-vendor-invoice-linking.spec.ts docs/manual/manual-test-checklist.md docs/test-results/2026-02-17-test-gap-triage-r2.md`
- `npm run e2e --prefix packages/frontend -- --list e2e/backend-vendor-invoice-linking.spec.ts`
- `E2E_CAPTURE=0 E2E_GREP='purchaseOrderLineId must belong to linked purchase order' ./scripts/e2e-frontend.sh`

## 補足
- 並行タスクとして #1001 をクローズ済み、#914 には readiness 定期確認コメントを追記済みです。