### PR TITLE
test: add vendor-invoice allocations api e2e coverage

### DIFF
--- a/docs/manual/manual-test-checklist.md
+++ b/docs/manual/manual-test-checklist.md
@@ -47,8 +47,8 @@
 - [x] POST /vendor-invoices/:id/unlink-po で PO 紐づけを解除できる（監査ログ）
 - [x] GET /vendor-invoices/:id/lines で `poLineUsage`（他VI利用数量/入力数量/残数量）が取得できる
 - [x] PUT /vendor-invoices/:id/lines で部分請求数量を更新できる（同一PO明細の未請求残が負値になる更新は 400）
-- [ ] PUT /vendor-invoices/:id/allocations で配賦明細を更新できる（合計=請求合計、autoAdjust による端数調整）
-- [ ] allocations を空配列で送ると配賦明細をクリアできる（監査ログ）
+- [x] PUT /vendor-invoices/:id/allocations で配賦明細を更新できる（合計=請求合計、autoAdjust による端数調整）
+- [x] allocations を空配列で送ると配賦明細をクリアできる（監査ログ）
 - [x] purchaseOrderLineId 指定時、VI が PO 未紐づけの場合は 400、別 PO の line は 400、存在しない line は 404
 
 ### その他

--- a/docs/test-results/2026-02-17-test-gap-triage-r2.md
+++ b/docs/test-results/2026-02-17-test-gap-triage-r2.md
@@ -4,7 +4,7 @@ Issue: #1001
 
 ## 対象
 
-- `docs/manual/manual-test-checklist.md`（未チェック 72 項目）
+- `docs/manual/manual-test-checklist.md`（未チェック 70 項目）
 - 高優先ドメイン: 承認/通知/仕入請求(PO↔VI)/権限
 
 ## 先行判定（高優先のみ）
@@ -27,6 +27,8 @@ Issue: #1001
      - `PO_LINE_QUANTITY_EXCEEDED`（単一行/分割行）と `quantity <= 0` の境界をカバー
      - `GET /vendor-invoices/:id/lines` の `poLineUsage` をカバー
      - `purchaseOrderLineId` の異常系（PO未紐づけ=400 / 別PO line=400 / 不存在line=404）をカバー
+     - `PUT /vendor-invoices/:id/allocations` の `autoAdjust` 境界、`allocations=[]` クリア、監査ログをカバー
+     - allocations の `purchaseOrderLineId` 異常系（PO未紐づけ=400 / 別PO line=400 / 不存在line=404）をカバー
    - PR: #1054, #1057, #1059（main 反映済み）
 3. モバイル回帰（375x667）
    - 対応: `packages/frontend/e2e/frontend-mobile-smoke.spec.ts`


### PR DESCRIPTION
## 概要
- `backend-vendor-invoice-linking.spec.ts` に allocations API の未カバーを追加
  - `autoAdjust=false` の不整合時 `ALLOCATION_MISMATCH`
  - `autoAdjust` 既定有効での補正更新
  - `allocations=[]` クリア + 監査ログ（`vendor_invoice_allocations_update/clear`）
  - allocations の `purchaseOrderLineId` 異常系（未紐づけ400 / 別PO line 400 / 不存在line 404）
- `docs/manual/manual-test-checklist.md` の allocations 2項目を消し込み
- `docs/test-results/2026-02-17-test-gap-triage-r2.md` の未チェック件数とカバレッジ説明を更新

## 実行コマンド
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npx prettier --check packages/frontend/e2e/backend-vendor-invoice-linking.spec.ts docs/manual/manual-test-checklist.md docs/test-results/2026-02-17-test-gap-triage-r2.md`
- `npm run e2e --prefix packages/frontend -- --list e2e/backend-vendor-invoice-linking.spec.ts`
- `E2E_CAPTURE=0 E2E_GREP='vendor invoice allocations:' ./scripts/e2e-frontend.sh`

## 補足
- 未追跡ファイル（`docs/test-results/*-frontend-e2e/` と `=`）は変更していません。