### PR TITLE
test: pending_qa後の配賦/請求明細更新で理由必須をE2E追加

### DIFF
--- a/packages/frontend/e2e/frontend-smoke-vendor-docs-create.spec.ts
+++ b/packages/frontend/e2e/frontend-smoke-vendor-docs-create.spec.ts
@@ -421,6 +421,76 @@ test('frontend smoke vendor docs create @extended', async ({ page }) => {
     )
     .toBe(false);
 
+  // (5) pending_qa では配賦明細/請求明細の更新にも変更理由が必須
+  await createdInvoiceItem.scrollIntoViewIfNeeded();
+  await createdInvoiceItem.getByRole('button', { name: '配賦明細' }).click();
+  const allocationReasonRequiredDialog = page.getByRole('dialog');
+  await expect(
+    allocationReasonRequiredDialog.getByText('仕入請求: 配賦明細'),
+  ).toBeVisible({
+    timeout: actionTimeout,
+  });
+  await expect(
+    allocationReasonRequiredDialog.getByText('配賦明細を読み込み中...'),
+  ).toHaveCount(0, { timeout: actionTimeout });
+  await allocationReasonRequiredDialog
+    .getByRole('button', { name: '更新' })
+    .click();
+  await expect(
+    allocationReasonRequiredDialog.getByText('変更理由を入力してください'),
+  ).toBeVisible({ timeout: actionTimeout });
+  await allocationReasonRequiredDialog
+    .getByPlaceholder('変更理由（必須）')
+    .fill('e2e: pending_qa での配賦明細更新');
+  await allocationReasonRequiredDialog
+    .getByRole('button', { name: '更新' })
+    .click();
+  await expect(
+    allocationReasonRequiredDialog.getByText('配賦明細を更新しました'),
+  ).toBeVisible({
+    timeout: actionTimeout,
+  });
+  await allocationReasonRequiredDialog
+    .getByRole('button', { name: '閉じる' })
+    .click();
+  await expect(allocationReasonRequiredDialog).toBeHidden({
+    timeout: actionTimeout,
+  });
+
+  await createdInvoiceItem.scrollIntoViewIfNeeded();
+  await createdInvoiceItem.getByRole('button', { name: '請求明細' }).click();
+  const lineReasonRequiredDialog = page.getByRole('dialog');
+  await expect(
+    lineReasonRequiredDialog.getByText('仕入請求: 請求明細'),
+  ).toBeVisible({
+    timeout: actionTimeout,
+  });
+  await expect(
+    lineReasonRequiredDialog.getByText('請求明細を読み込み中...'),
+  ).toHaveCount(0, { timeout: actionTimeout });
+  await lineReasonRequiredDialog
+    .getByRole('button', { name: '請求明細を入力' })
+    .click();
+  await lineReasonRequiredDialog.getByRole('button', { name: '更新' }).click();
+  await expect(
+    lineReasonRequiredDialog.getByText('変更理由を入力してください'),
+  ).toBeVisible({ timeout: actionTimeout });
+  await lineReasonRequiredDialog
+    .getByPlaceholder('変更理由（必須）')
+    .fill('e2e: pending_qa での請求明細更新');
+  await lineReasonRequiredDialog.getByRole('button', { name: '更新' }).click();
+  await expect(
+    lineReasonRequiredDialog.getByText('請求明細を更新しました'),
+  ).toBeVisible({
+    timeout: actionTimeout,
+  });
+  await lineReasonRequiredDialog
+    .getByRole('button', { name: '閉じる' })
+    .click();
+  await expect(lineReasonRequiredDialog).toBeHidden({
+    timeout: actionTimeout,
+  });
+
   await createdInvoiceItem.getByRole('button', { name: '注釈' }).click();
   const annotationDialog = page.getByRole('dialog');
   await expect(


### PR DESCRIPTION
## 背景
PO/VI運用で、`pending_qa` 以降の更新時に「理由必須」が仕様ですが、
PO紐づけ以外（配賦明細・請求明細）の回帰確認が不足していました。

## 変更内容
1. `backend-vendor-invoice-linking.spec.ts` に以下APIシナリオを追加
   - `PUT /vendor-invoices/:id/allocations` は post-submit で `reasonText` 必須
   - `PUT /vendor-invoices/:id/lines` は post-submit で `reasonText` 必須
2. `frontend-smoke-vendor-docs-create.spec.ts` を拡張
   - `pending_qa` 状態で配賦明細更新時の理由必須UIを検証
   - `pending_qa` 状態で請求明細更新時の理由必須UIを検証

## 確認
- `E2E_CAPTURE=0 E2E_GREP='frontend smoke vendor docs create|vendor invoice allocations: post-submit update requires reason|vendor invoice lines: post-submit update requires reason' ./scripts/e2e-frontend.sh`
