### PR TITLE
fix: vendor invoice allocation の負値補正を防止

### DIFF
--- a/packages/backend/src/services/vendorInvoiceAllocations.ts
+++ b/packages/backend/src/services/vendorInvoiceAllocations.ts
@@ -52,24 +52,28 @@ export function normalizeVendorInvoiceAllocations(
     if (Math.abs(diff) > 0.00001) {
       const lastIndex = normalized.length - 1;
       const last = normalized[lastIndex];
-      normalized[lastIndex] = {
-        ...last,
-        taxAmount: (last.taxAmount ?? 0) + diff,
-      };
-      adjusted = true;
-      const recalculated = normalized.reduce(
-        (acc, item) => {
-          acc.amountTotal += item.amount;
-          acc.taxTotal += item.taxAmount ?? 0;
-          acc.grossTotal += item.amount + (item.taxAmount ?? 0);
-          return acc;
-        },
-        { amountTotal: 0, taxTotal: 0, grossTotal: 0 },
-      );
-      totals.amountTotal = recalculated.amountTotal;
-      totals.taxTotal = recalculated.taxTotal;
-      totals.grossTotal = recalculated.grossTotal;
-      diff = invoiceTotal - totals.grossTotal;
+      const nextTaxAmount = (last.taxAmount ?? 0) + diff;
+      const nextGrossAmount = last.amount + nextTaxAmount;
+      if (nextTaxAmount >= -0.00001 && nextGrossAmount >= -0.00001) {
+        normalized[lastIndex] = {
+          ...last,
+          taxAmount: nextTaxAmount,
+        };
+        adjusted = true;
+        const recalculated = normalized.reduce(
+          (acc, item) => {
+            acc.amountTotal += item.amount;
+            acc.taxTotal += item.taxAmount ?? 0;
+            acc.grossTotal += item.amount + (item.taxAmount ?? 0);
+            return acc;
+          },
+          { amountTotal: 0, taxTotal: 0, grossTotal: 0 },
+        );
+        totals.amountTotal = recalculated.amountTotal;
+        totals.taxTotal = recalculated.taxTotal;
+        totals.grossTotal = recalculated.grossTotal;
+        diff = invoiceTotal - totals.grossTotal;
+      }
     }
   }
 

--- a/packages/backend/test/vendorInvoiceAllocations.test.js
+++ b/packages/backend/test/vendorInvoiceAllocations.test.js
@@ -38,3 +38,14 @@ test('normalizeVendorInvoiceAllocations: keeps diff when autoAdjust disabled', (
   assert.equal(result.totals.grossTotal, 1650);
   assert.equal(result.totals.diff, -49);
 });
+
+test('normalizeVendorInvoiceAllocations: keeps diff when autoAdjust would make tax negative', () => {
+  const result = normalizeVendorInvoiceAllocations(
+    [{ amount: 100, taxRate: null, taxAmount: 0 }],
+    50,
+    { autoAdjust: true },
+  );
+  assert.equal(result.items[0].taxAmount, 0);
+  assert.equal(result.totals.grossTotal, 100);
+  assert.equal(result.totals.diff, -50);
+});


### PR DESCRIPTION
## 背景
`normalizeVendorInvoiceAllocations` の自動差分補正は、差分が大きくマイナスの場合に最終行の `taxAmount` を負値へ補正し得る実装でした。

`vendorInvoiceLines` 側は同種ケースで「負値になる補正を行わず diff を残す」ガードがあるため、挙動を揃えます。

## 変更内容
1. `packages/backend/src/services/vendorInvoiceAllocations.ts`
   - 自動補正時に `nextTaxAmount` / `nextGrossAmount` が負値になる場合は補正しないように変更
   - 補正可能な場合のみ `adjusted=true` と再集計を行う
2. `packages/backend/test/vendorInvoiceAllocations.test.js`
   - `autoAdjust` により税額が負値になるケースで、補正せず diff を保持するテストを追加

## 確認
- `npm run format:check --prefix packages/backend`
- `npm run lint --prefix packages/backend`
- `npm run typecheck --prefix packages/backend`
- `npm run test --prefix packages/backend -- test/vendorInvoiceAllocations.test.js test/vendorInvoiceLines.test.js`
- `E2E_CAPTURE=0 E2E_GREP='backend-vendor-invoice-linking|vendor invoice allocations|vendor invoice lines' ./scripts/e2e-frontend.sh`
