### PR TITLE
docs(security): record low vulnerability triage for #1089

### DIFF
--- a/docs/test-results/2026-02-17-audit-low-triage-r2.md
+++ b/docs/test-results/2026-02-17-audit-low-triage-r2.md
@@ -8,6 +8,7 @@
 ## 結果サマリ
 - backend: low=0 / moderate=7 / high=0 / critical=0
 - frontend: low=0 / moderate=0 / high=0 / critical=0
+- 本記録の判定対象は low（Dependabot alert #10）のみ。moderate は別トリアージで扱う。
 - Dependabot alert: 1件 open（low）
   - Alert: `#10` / `GHSA-w7fw-mjwx-w883` / `CVE-2026-2391`
   - package: `qs`（transitive, runtime）


### PR DESCRIPTION
## 概要
- `docs/test-results/2026-02-17-audit-low-triage-r2.md` を追加
- npm audit (low含む) と Dependabot alert #10 (`GHSA-w7fw-mjwx-w883`) の評価結果を記録
- 今回判断（暫定許容）と再確認条件を明文化

## 背景
- Issue #1089（low脆弱性1件のトリアージ）対応

## 判定
- 現在の lockfile は `qs@6.15.0`（patched range 6.14.2+）
- alert は transitive dependency (`googleapis-common -> qs:^6.7.0`) に対する検出
- ERP4コードで `qs.parse(..., { comma: true })` の利用なし
- 上記により **許容（暫定）** とし、再確認条件を設定

## 実行確認
- `npm audit --prefix packages/backend --audit-level=low --json`
- `npm audit --prefix packages/frontend --audit-level=low --json`
- `gh api repos/itdojp/ITDO_ERP4/dependabot/alerts/10`

Closes #1089
