### PR TITLE
refactor(chat): move @all rate-limit logic into shared module

### DIFF
--- a/packages/backend/src/routes/chat.ts
+++ b/packages/backend/src/routes/chat.ts
@@ -107,7 +107,7 @@ export async function registerChatRoutes(app: FastifyInstance) {
     userId: string;
   }) {
     const rateLimit = await enforceAllMentionRateLimit({
-      projectId: options.projectId,
+      roomId: options.projectId,
       userId: options.userId,
       now: new Date(),
     });

--- a/packages/backend/src/routes/chat/shared/allMentionRateLimit.ts
+++ b/packages/backend/src/routes/chat/shared/allMentionRateLimit.ts
@@ -17,7 +17,7 @@ export type AllMentionRateLimit =
     };
 
 export async function enforceAllMentionRateLimit(options: {
-  projectId: string;
+  roomId: string;
   userId: string;
   now: Date;
 }): Promise<AllMentionRateLimit> {
@@ -36,7 +36,7 @@ export async function enforceAllMentionRateLimit(options: {
     minIntervalSeconds > 0
       ? prisma.chatMessage.findFirst({
           where: {
-            roomId: options.projectId,
+            roomId: options.roomId,
             userId: options.userId,
             mentionsAll: true,
             deletedAt: null,
@@ -48,7 +48,7 @@ export async function enforceAllMentionRateLimit(options: {
     maxPer24h > 0
       ? prisma.chatMessage.count({
           where: {
-            roomId: options.projectId,
+            roomId: options.roomId,
             userId: options.userId,
             mentionsAll: true,
             deletedAt: null,


### PR DESCRIPTION
## 概要
- `chat.ts` 内の @all 投稿レート制御ロジックを `chat/shared/allMentionRateLimit.ts` に切り出し
  - `enforceAllMentionRateLimit`
  - `buildAllMentionBlockedMetadata`
  - `AllMentionRateLimit` type
- `chat.ts` は routes と監査送信に責務を絞る（挙動・レスポンス仕様は不変）

## 背景
- #1088 の段階的共通化（1PR 1テーマ）

## 影響
- API入出力、エラーコード、監査イベント名は変更なし

## 確認
- `npm run typecheck --prefix packages/backend`
- `npm run lint --prefix packages/backend`
- `npm run build --prefix packages/backend`

Refs #1088
