### PR TITLE
refactor(vendor-docs): unify child component types with shared module

### DIFF
--- a/packages/frontend/src/sections/vendor-documents/PurchaseOrderSendLogsDialog.tsx
+++ b/packages/frontend/src/sections/vendor-documents/PurchaseOrderSendLogsDialog.tsx
@@ -9,15 +9,7 @@ import {
   erpStatusDictionary,
 } from '../../ui';
 import type { DataTableRow } from '../../ui';
-
-export type PurchaseOrderSendLog = {
-  id: string;
-  channel: string;
-  status: string;
-  createdAt: string;
-  error?: string | null;
-  pdfUrl?: string | null;
-};
+import type { DocumentSendLog } from './vendorDocumentsShared';
 
 type PurchaseOrderSendLogsDialogProps = {
   open: boolean;
@@ -27,7 +19,7 @@ type PurchaseOrderSendLogsDialogProps = {
   missingNumberLabel: string;
   message: string;
   loading: boolean;
-  logs: PurchaseOrderSendLog[];
+  logs: DocumentSendLog[];
   onClose: () => void;
   onOpenPdf: (purchaseOrderId: string, pdfUrl: string) => void;
 };

--- a/packages/frontend/src/sections/vendor-documents/VendorDocumentsPurchaseOrdersSection.tsx
+++ b/packages/frontend/src/sections/vendor-documents/VendorDocumentsPurchaseOrdersSection.tsx
@@ -1,28 +1,11 @@
 import React from 'react';
 import { Button, CrudList, FilterBar, Input, Select, Toast } from '../../ui';
-
-type ProjectOption = {
-  id: string;
-  code: string;
-  name: string;
-};
-
-type VendorOption = {
-  id: string;
-  code: string;
-  name: string;
-};
-
-type PurchaseOrderForm = {
-  projectId: string;
-  vendorId: string;
-  issueDate: string;
-  dueDate: string;
-  currency: string;
-  totalAmount: number;
-};
-
-type MessageState = { text: string; type: 'success' | 'error' } | null;
+import type {
+  MessageState,
+  ProjectOption,
+  PurchaseOrderForm,
+  VendorOption,
+} from './vendorDocumentsShared';
 
 type VendorDocumentsPurchaseOrdersSectionProps = {
   active: boolean;

--- a/packages/frontend/src/sections/vendor-documents/VendorDocumentsVendorInvoicesSection.tsx
+++ b/packages/frontend/src/sections/vendor-documents/VendorDocumentsVendorInvoicesSection.tsx
@@ -1,43 +1,19 @@
 import React from 'react';
 import { Button, CrudList, FilterBar, Input, Select, Toast } from '../../ui';
-
-type ProjectOption = {
-  id: string;
-  code: string;
-  name: string;
-};
-
-type VendorOption = {
-  id: string;
-  code: string;
-  name: string;
-};
-
-type PurchaseOrderOption = {
-  id: string;
-  poNo?: string | null;
-};
-
-type VendorInvoiceForm = {
-  projectId: string;
-  vendorId: string;
-  purchaseOrderId?: string;
-  vendorInvoiceNo: string;
-  receivedDate: string;
-  dueDate: string;
-  currency: string;
-  totalAmount: number;
-  documentUrl: string;
-};
-
-type MessageState = { text: string; type: 'success' | 'error' } | null;
+import type {
+  MessageState,
+  ProjectOption,
+  PurchaseOrder,
+  VendorInvoiceForm,
+  VendorOption,
+} from './vendorDocumentsShared';
 
 type VendorDocumentsVendorInvoicesSectionProps = {
   active: boolean;
   invoiceForm: VendorInvoiceForm;
   projects: ProjectOption[];
   vendors: VendorOption[];
-  availablePurchaseOrders: PurchaseOrderOption[];
+  availablePurchaseOrders: PurchaseOrder[];
   missingNumberLabel: string;
   isInvoiceSaving: boolean;
   onChangeInvoiceForm: (next: VendorInvoiceForm) => void;

--- a/packages/frontend/src/sections/vendor-documents/VendorDocumentsVendorQuotesSection.tsx
+++ b/packages/frontend/src/sections/vendor-documents/VendorDocumentsVendorQuotesSection.tsx
@@ -1,29 +1,11 @@
 import React from 'react';
 import { Button, CrudList, FilterBar, Input, Select, Toast } from '../../ui';
-
-type ProjectOption = {
-  id: string;
-  code: string;
-  name: string;
-};
-
-type VendorOption = {
-  id: string;
-  code: string;
-  name: string;
-};
-
-type VendorQuoteForm = {
-  projectId: string;
-  vendorId: string;
-  quoteNo: string;
-  issueDate: string;
-  currency: string;
-  totalAmount: number;
-  documentUrl: string;
-};
-
-type MessageState = { text: string; type: 'success' | 'error' } | null;
+import type {
+  MessageState,
+  ProjectOption,
+  VendorOption,
+  VendorQuoteForm,
+} from './vendorDocumentsShared';
 
 type VendorDocumentsVendorQuotesSectionProps = {
   active: boolean;

--- a/packages/frontend/src/sections/vendor-documents/VendorInvoiceAllocationDialog.tsx
+++ b/packages/frontend/src/sections/vendor-documents/VendorInvoiceAllocationDialog.tsx
@@ -1,43 +1,12 @@
 import React from 'react';
 import { Button, Dialog, StatusBadge, erpStatusDictionary } from '../../ui';
-
-type VendorInvoice = {
-  id: string;
-  vendorInvoiceNo?: string | null;
-  projectId: string;
-  vendorId: string;
-  purchaseOrderId?: string | null;
-  currency: string;
-  totalAmount: number | string;
-  status: string;
-  documentUrl?: string | null;
-};
-
-type ProjectOption = {
-  id: string;
-  code: string;
-  name: string;
-};
-
-type VendorInvoiceAllocation = {
-  projectId: string;
-  amount: number | string;
-  taxRate?: number | string | null;
-  taxAmount?: number | string | null;
-  purchaseOrderLineId?: string | null;
-};
-
-type PurchaseOrderLine = {
-  id: string;
-  description: string;
-  quantity: number | string;
-  unitPrice: number | string;
-};
-
-type PurchaseOrderDetail = {
-  id: string;
-  lines?: PurchaseOrderLine[];
-};
+import type {
+  MessageState,
+  ProjectOption,
+  PurchaseOrderDetail,
+  VendorInvoice,
+  VendorInvoiceAllocation,
+} from './vendorDocumentsShared';
 
 type InvoiceAllocationDialogState = {
   invoice: VendorInvoice;
@@ -56,8 +25,6 @@ type AllocationTaxRateSummaryEntry = {
   amount: number;
   tax: number;
 };
-
-type MessageState = { text: string; type: 'success' | 'error' } | null;
 
 type VendorInvoiceAllocationDialogProps = {
   open: boolean;

--- a/packages/frontend/src/sections/vendor-documents/VendorInvoiceLineDialog.tsx
+++ b/packages/frontend/src/sections/vendor-documents/VendorInvoiceLineDialog.tsx
@@ -1,46 +1,12 @@
 import React from 'react';
 import { Button, Dialog, StatusBadge, erpStatusDictionary } from '../../ui';
-
-type VendorInvoice = {
-  id: string;
-  vendorInvoiceNo?: string | null;
-  projectId: string;
-  vendorId: string;
-  purchaseOrderId?: string | null;
-  currency: string;
-  totalAmount: number | string;
-  status: string;
-  documentUrl?: string | null;
-};
-
-type VendorInvoiceLine = {
-  id?: string;
-  tempId?: string;
-  lineNo?: number | string;
-  description: string;
-  quantity: number | string;
-  unitPrice: number | string;
-  amount?: number | string | null;
-  taxRate?: number | string | null;
-  taxAmount?: number | string | null;
-  purchaseOrderLineId?: string | null;
-};
-
-type VendorInvoicePoLineUsage = {
-  existingQuantity: number;
-};
-
-type PurchaseOrderLine = {
-  id: string;
-  description: string;
-  quantity: number | string;
-  unitPrice: number | string;
-};
-
-type PurchaseOrderDetail = {
-  id: string;
-  lines?: PurchaseOrderLine[];
-};
+import type {
+  MessageState,
+  PurchaseOrderDetail,
+  VendorInvoice,
+  VendorInvoiceLine,
+  VendorInvoicePoLineUsage,
+} from './vendorDocumentsShared';
 
 type InvoiceLineDialogState = {
   invoice: VendorInvoice;
@@ -53,8 +19,6 @@ type InvoiceLineTotals = {
   invoiceTotal: number | null;
   diff: number | null;
 };
-
-type MessageState = { text: string; type: 'success' | 'error' } | null;
 
 type VendorInvoiceLineDialogProps = {
   open: boolean;

--- a/packages/frontend/src/sections/vendor-documents/VendorInvoicePoLinkDialog.tsx
+++ b/packages/frontend/src/sections/vendor-documents/VendorInvoicePoLinkDialog.tsx
@@ -1,33 +1,11 @@
 import React from 'react';
 import { Button, Dialog, StatusBadge, erpStatusDictionary } from '../../ui';
-
-type VendorInvoice = {
-  id: string;
-  vendorInvoiceNo?: string | null;
-  projectId: string;
-  vendorId: string;
-  currency: string;
-  totalAmount: number | string;
-  status: string;
-};
-
-type PurchaseOrder = {
-  id: string;
-  poNo?: string | null;
-  currency: string;
-  totalAmount: number | string;
-};
-
-type PurchaseOrderLine = {
-  id: string;
-  description: string;
-  quantity: number | string;
-  unitPrice: number | string;
-};
-
-type PurchaseOrderDetail = PurchaseOrder & { lines?: PurchaseOrderLine[] };
-
-type MessageState = { text: string; type: 'success' | 'error' } | null;
+import type {
+  MessageState,
+  PurchaseOrder,
+  PurchaseOrderDetail,
+  VendorInvoice,
+} from './vendorDocumentsShared';
 
 type InvoicePoLinkDialogState = {
   invoice: VendorInvoice;


### PR DESCRIPTION
## 概要
- `vendorDocumentsShared.ts` に合わせて、vendor-documents配下の子コンポーネントの重複型定義を共通型 import に置換
- 仕様・表示・挙動は不変（型定義の統一のみ）

## 変更対象
- `PurchaseOrderSendLogsDialog.tsx`
- `VendorDocumentsPurchaseOrdersSection.tsx`
- `VendorDocumentsVendorQuotesSection.tsx`
- `VendorDocumentsVendorInvoicesSection.tsx`
- `VendorInvoiceAllocationDialog.tsx`
- `VendorInvoiceLineDialog.tsx`
- `VendorInvoicePoLinkDialog.tsx`

## 確認
- `npm run typecheck --prefix packages/frontend`
- `npm run lint --prefix packages/frontend`
- `npm run build --prefix packages/frontend`

## 補足
- このPRは #1099 に続く段階的分割（stacked PR）です。

Refs #1086
