### PR TITLE
refactor(vendor-docs): extract invoice saved-view bar component

### DIFF
--- a/packages/frontend/src/sections/VendorDocuments.tsx
+++ b/packages/frontend/src/sections/VendorDocuments.tsx
@@ -17,7 +17,6 @@ import {
   Dialog,
   FilterBar,
   Input,
-  SavedViewBar,
   Select,
   StatusBadge,
   Tabs,
@@ -35,6 +34,7 @@ import { VendorDocumentsVendorQuotesSection } from './vendor-documents/VendorDoc
 import { VendorDocumentsVendorInvoicesSection } from './vendor-documents/VendorDocumentsVendorInvoicesSection';
 import { VendorInvoiceLineDialog } from './vendor-documents/VendorInvoiceLineDialog';
 import { VendorInvoicePoLinkDialog } from './vendor-documents/VendorInvoicePoLinkDialog';
+import { VendorInvoiceSavedViewBar } from './vendor-documents/VendorInvoiceSavedViewBar';
 import {
   defaultPurchaseOrderForm,
   defaultVendorInvoiceForm,
@@ -1928,64 +1928,14 @@ export const VendorDocuments: React.FC = () => {
             invoiceResult={invoiceResult}
             onDismissInvoiceResult={() => setInvoiceResult(null)}
             invoiceSavedViewBar={
-              <SavedViewBar
-                views={invoiceSavedViews.views}
-                activeViewId={invoiceSavedViews.activeViewId}
-                onSelectView={(viewId) => {
-                  invoiceSavedViews.selectView(viewId);
-                  const selected = invoiceSavedViews.views.find(
-                    (view) => view.id === viewId,
-                  );
-                  if (!selected) return;
-                  setInvoiceSearch(selected.payload.search);
-                  setInvoiceStatusFilter(
-                    normalizeInvoiceStatusFilter(
-                      selected.payload.status,
-                      invoiceStatusOptions,
-                    ),
-                  );
-                }}
-                onSaveAs={(name) => {
-                  const normalizedStatus = normalizeInvoiceStatusFilter(
-                    invoiceStatusFilter,
-                    invoiceStatusOptions,
-                  );
-                  invoiceSavedViews.createView(name, {
-                    search: invoiceSearch,
-                    status: normalizedStatus,
-                  });
-                }}
-                onUpdateView={(viewId) => {
-                  const normalizedStatus = normalizeInvoiceStatusFilter(
-                    invoiceStatusFilter,
-                    invoiceStatusOptions,
-                  );
-                  invoiceSavedViews.updateView(viewId, {
-                    payload: {
-                      search: invoiceSearch,
-                      status: normalizedStatus,
-                    },
-                  });
-                }}
-                onDuplicateView={(viewId) => {
-                  invoiceSavedViews.duplicateView(viewId);
-                }}
-                onShareView={(viewId) => {
-                  invoiceSavedViews.toggleShared(viewId, true);
-                }}
-                onDeleteView={(viewId) => {
-                  invoiceSavedViews.deleteView(viewId);
-                }}
-                labels={{
-                  title: '仕入請求フィルタ保存',
-                  saveAsPlaceholder: 'ビュー名',
-                  saveAsButton: '保存',
-                  update: '更新',
-                  duplicate: '複製',
-                  share: '共有',
-                  delete: '削除',
-                  active: '現在のビュー',
-                }}
+              <VendorInvoiceSavedViewBar
+                savedViews={invoiceSavedViews}
+                invoiceSearch={invoiceSearch}
+                invoiceStatusFilter={invoiceStatusFilter}
+                invoiceStatusOptions={invoiceStatusOptions}
+                onChangeInvoiceSearch={setInvoiceSearch}
+                onChangeInvoiceStatusFilter={setInvoiceStatusFilter}
+                normalizeInvoiceStatusFilter={normalizeInvoiceStatusFilter}
               />
             }
             onReloadVendorInvoices={() => {

--- a/packages/frontend/src/sections/vendor-documents/VendorInvoiceSavedViewBar.tsx
+++ b/packages/frontend/src/sections/vendor-documents/VendorInvoiceSavedViewBar.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { SavedViewBar } from '../../ui';
+import type { UseSavedViewsResult } from '../../ui';
+import type { InvoiceSavedFilterPayload } from './vendorDocumentsShared';
+
+type VendorInvoiceSavedViewBarProps = {
+  savedViews: UseSavedViewsResult<InvoiceSavedFilterPayload>;
+  invoiceSearch: string;
+  invoiceStatusFilter: string;
+  invoiceStatusOptions: string[];
+  onChangeInvoiceSearch: (value: string) => void;
+  onChangeInvoiceStatusFilter: (value: string) => void;
+  normalizeInvoiceStatusFilter: (value: string, options: string[]) => string;
+};
+
+export const VendorInvoiceSavedViewBar: React.FC<
+  VendorInvoiceSavedViewBarProps
+> = ({
+  savedViews,
+  invoiceSearch,
+  invoiceStatusFilter,
+  invoiceStatusOptions,
+  onChangeInvoiceSearch,
+  onChangeInvoiceStatusFilter,
+  normalizeInvoiceStatusFilter,
+}) => (
+  <SavedViewBar
+    views={savedViews.views}
+    activeViewId={savedViews.activeViewId}
+    onSelectView={(viewId) => {
+      savedViews.selectView(viewId);
+      const selected = savedViews.views.find((view) => view.id === viewId);
+      if (!selected) return;
+      onChangeInvoiceSearch(selected.payload.search);
+      onChangeInvoiceStatusFilter(
+        normalizeInvoiceStatusFilter(
+          selected.payload.status,
+          invoiceStatusOptions,
+        ),
+      );
+    }}
+    onSaveAs={(name) => {
+      const normalizedStatus = normalizeInvoiceStatusFilter(
+        invoiceStatusFilter,
+        invoiceStatusOptions,
+      );
+      savedViews.createView(name, {
+        search: invoiceSearch,
+        status: normalizedStatus,
+      });
+    }}
+    onUpdateView={(viewId) => {
+      const normalizedStatus = normalizeInvoiceStatusFilter(
+        invoiceStatusFilter,
+        invoiceStatusOptions,
+      );
+      savedViews.updateView(viewId, {
+        payload: {
+          search: invoiceSearch,
+          status: normalizedStatus,
+        },
+      });
+    }}
+    onDuplicateView={(viewId) => {
+      savedViews.duplicateView(viewId);
+    }}
+    onShareView={(viewId) => {
+      savedViews.toggleShared(viewId, true);
+    }}
+    onDeleteView={(viewId) => {
+      savedViews.deleteView(viewId);
+    }}
+    labels={{
+      title: '仕入請求フィルタ保存',
+      saveAsPlaceholder: 'ビュー名',
+      saveAsButton: '保存',
+      update: '更新',
+      duplicate: '複製',
+      share: '共有',
+      delete: '削除',
+      active: '現在のビュー',
+    }}
+  />
+);


### PR DESCRIPTION
## 概要
- `VendorDocuments.tsx` 内の仕入請求 SavedViewBar 構築ロジックを `VendorInvoiceSavedViewBar` に分離
- 画面側は状態管理/イベント配線に責務を限定（仕様不変）

## 変更ファイル
- 追加: `packages/frontend/src/sections/vendor-documents/VendorInvoiceSavedViewBar.tsx`
- 変更: `packages/frontend/src/sections/VendorDocuments.tsx`

## 仕様影響
- なし（UI/文言/挙動は不変）

## 確認
- `npm run typecheck --prefix packages/frontend`
- `npm run lint --prefix packages/frontend`
- `npm run build --prefix packages/frontend`

Refs #1086
