### PR TITLE
refactor(chat): extract ack-required target check helper

### DIFF
--- a/packages/backend/src/routes/chat/shared/ackRequiredTarget.ts
+++ b/packages/backend/src/routes/chat/shared/ackRequiredTarget.ts
@@ -1,0 +1,14 @@
+import { normalizeStringArray } from './inputParsers.js';
+
+export function resolveAckRequiredTarget(
+  requiredUserIdsRaw: unknown,
+  userId: string,
+) {
+  const requiredUserIds = normalizeStringArray(requiredUserIdsRaw, {
+    dedupe: true,
+  });
+  return {
+    isRequired: requiredUserIds.includes(userId),
+    requiredUserCount: requiredUserIds.length,
+  };
+}


### PR DESCRIPTION
## 概要
- `chat.ts` の ack required 対象者判定（requiredUserIds の正規化 + include 判定）を shared helper に切り出し
- 重複していた2箇所（ack/revoke）を `resolveAckRequiredTarget` 利用に統一

## 変更ファイル
- 追加: `packages/backend/src/routes/chat/shared/ackRequiredTarget.ts`
- 変更: `packages/backend/src/routes/chat.ts`

## 仕様影響
- なし（レスポンス/エラー条件/監査値は不変）

## 確認
- `npm run typecheck --prefix packages/backend`
- `npm run lint --prefix packages/backend`
- `npm run build --prefix packages/backend`

Refs #1088
