### PR TITLE
refactor(chat): extract missing-user-id guard helper

### DIFF
--- a/packages/backend/src/routes/chat.ts
+++ b/packages/backend/src/routes/chat.ts
@@ -611,7 +611,7 @@ export async function registerChatRoutes(app: FastifyInstance) {
     async (req, reply) => {
       const { projectId } = req.params as { projectId: string };
       const userId = requireUserId(reply, req.user?.userId);
-      if (!userId) return;
+      if (typeof userId !== 'string') return userId;
       const state = await prisma.chatReadState.findUnique({
         where: { roomId_userId: { roomId: projectId, userId } },
         select: { lastReadAt: true },
@@ -641,7 +641,7 @@ export async function registerChatRoutes(app: FastifyInstance) {
     async (req, reply) => {
       const { projectId } = req.params as { projectId: string };
       const userId = requireUserId(reply, req.user?.userId);
-      if (!userId) return;
+      if (typeof userId !== 'string') return userId;
       if (!(await ensureProjectRoom(projectId, userId))) {
         return reply.status(404).send({
           error: { code: 'NOT_FOUND', message: 'Project not found' },
@@ -1078,7 +1078,7 @@ export async function registerChatRoutes(app: FastifyInstance) {
       }
 
       const userId = requireUserId(reply, req.user?.userId);
-      if (!userId) return;
+      if (typeof userId !== 'string') return userId;
 
       const roles = req.user?.roles || [];
       const projectIds = req.user?.projectIds || [];
@@ -1186,7 +1186,7 @@ export async function registerChatRoutes(app: FastifyInstance) {
       }
 
       const userId = requireUserId(reply, req.user?.userId);
-      if (!userId) return;
+      if (typeof userId !== 'string') return userId;
 
       const roles = req.user?.roles || [];
       const projectIds = req.user?.projectIds || [];
@@ -1249,7 +1249,7 @@ export async function registerChatRoutes(app: FastifyInstance) {
       }
 
       const userId = requireUserId(reply, req.user?.userId);
-      if (!userId) return;
+      if (typeof userId !== 'string') return userId;
 
       const roles = req.user?.roles || [];
       const projectIds = req.user?.projectIds || [];
@@ -1353,7 +1353,7 @@ export async function registerChatRoutes(app: FastifyInstance) {
       }
 
       const userId = requireUserId(reply, req.user?.userId);
-      if (!userId) return;
+      if (typeof userId !== 'string') return userId;
 
       const roles = req.user?.roles || [];
       const projectIds = req.user?.projectIds || [];
@@ -1448,7 +1448,7 @@ export async function registerChatRoutes(app: FastifyInstance) {
         });
       }
       const userId = requireUserId(reply, req.user?.userId);
-      if (!userId) return;
+      if (typeof userId !== 'string') return userId;
 
       const roles = req.user?.roles || [];
       const projectIds = req.user?.projectIds || [];
@@ -1550,7 +1550,7 @@ export async function registerChatRoutes(app: FastifyInstance) {
         });
       }
       const userId = requireUserId(reply, req.user?.userId);
-      if (!userId) return;
+      if (typeof userId !== 'string') return userId;
 
       const roles = req.user?.roles || [];
       const projectIds = req.user?.projectIds || [];
@@ -1749,7 +1749,7 @@ export async function registerChatRoutes(app: FastifyInstance) {
           .send({ error: { code: 'NOT_FOUND', message: 'Not found' } });
       }
       const userId = requireUserId(reply, req.user?.userId);
-      if (!userId) return;
+      if (typeof userId !== 'string') return userId;
       const roles = req.user?.roles || [];
       const projectIds = req.user?.projectIds || [];
       const groupIds = Array.isArray(req.user?.groupIds)

--- a/packages/backend/src/routes/chat/shared/requireUserId.ts
+++ b/packages/backend/src/routes/chat/shared/requireUserId.ts
@@ -1,16 +1,11 @@
-type ReplyLike = {
-  status: (statusCode: number) => {
-    send: (payload: unknown) => unknown;
-  };
-};
+import type { FastifyReply } from 'fastify';
 
 export function requireUserId(
-  reply: ReplyLike,
+  reply: FastifyReply,
   userId: string | null | undefined,
 ) {
   if (userId) return userId;
-  reply.status(400).send({
+  return reply.status(400).send({
     error: { code: 'MISSING_USER_ID', message: 'user id is required' },
   });
-  return null;
 }


### PR DESCRIPTION
## 概要
- chat routes 内で重複していた `MISSING_USER_ID` ガードを `requireUserId` helper に共通化
- 9箇所の同一レスポンスを helper 呼び出しへ置換（HTTP 400 / error.code / message は不変）

## 変更ファイル
- 追加: `packages/backend/src/routes/chat/shared/requireUserId.ts`
- 変更: `packages/backend/src/routes/chat.ts`

## 仕様影響
- なし（APIエラー形式・文言は不変）

## 確認
- `npm run typecheck --prefix packages/backend`
- `npm run lint --prefix packages/backend`
- `npm run build --prefix packages/backend`

Refs #1088
