### PR TITLE
test(e2e): mobile period lock の index 依存セレクタを除去

### DIFF
--- a/packages/frontend/e2e/frontend-mobile-smoke.spec.ts
+++ b/packages/frontend/e2e/frontend-mobile-smoke.spec.ts
@@ -517,18 +517,17 @@ test.describe('mobile smoke 375x667 @core', () => {
     await expect(periodCreatePeriodInput).toBeVisible({
       timeout: actionTimeout,
     });
-    const periodCreatePanel = periodCreatePeriodInput.locator('..').locator('..');
+    const periodCreateProjectSelect = periodLockSection
+      .getByRole('combobox', { name: 'project' })
+      .filter({ hasText: '案件を選択' });
+    await expect(periodCreateProjectSelect).toHaveCount(1, {
+      timeout: actionTimeout,
+    });
     await periodCreatePeriodInput.fill(mobileLockPeriod);
-    await periodCreatePanel
-      .getByLabel('scope', { exact: true })
-      .selectOption({ value: 'project' });
-    await selectByValue(
-      periodCreatePanel.getByLabel('project', { exact: true }),
-      defaultProjectId,
-    );
-    await periodCreatePanel.getByLabel('reason', { exact: true }).fill(
-      mobileLockReason,
-    );
+    await selectByValue(periodCreateProjectSelect, defaultProjectId);
+    await periodLockSection
+      .getByLabel('reason', { exact: true })
+      .fill(mobileLockReason);
     await periodLockSection.getByRole('button', { name: '締め登録' }).click();
     await periodLockSection
       .getByLabel('period', { exact: true })


### PR DESCRIPTION
## 概要
- #1085 の継続対応です。
- `frontend-mobile-smoke.spec.ts` の期間締めシナリオで残っていた `locator.first()` 依存を除去しました。

## 変更点
- `packages/frontend/e2e/frontend-mobile-smoke.spec.ts`
  - 期間締め登録フォームの操作対象を `period (YYYY-MM)` 入力の親パネルにスコープ
  - `scope` / `project` / `reason` の入力をパネル内ロケータに統一
  - `first()` 依存を排除

## 仕様影響
- なし（E2Eテストコードのみ）

## 確認
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `E2E_CAPTURE=0 E2E_GREP='invoices / vendor-documents / admin-jobs / audit-logs / period-locks operate on mobile viewport' ./scripts/e2e-frontend.sh`
- `rg -n "\\.first\\(|\\.nth\\(" packages/frontend/e2e --glob '*.spec.ts' --glob '*.ts'` が 0 件
