### PR TITLE
refactor(chat): chatRooms の access 判定重複を共通化

### DIFF
--- a/packages/backend/src/routes/chatRooms.ts
+++ b/packages/backend/src/routes/chatRooms.ts
@@ -1991,6 +1991,7 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
         roomId,
         userId,
         accessContext,
+        accessLevel: 'post',
       });
       if (!access) return;
 


### PR DESCRIPTION
## 概要
- #1088 の継続対応です（仕様不変）。
- `chatRooms.ts` で重複していた room access 判定ブロックを共通化しました。

## 変更点
- `packages/backend/src/routes/chatRooms.ts`
  - `readRoomAccessContext` を追加（`roles/projectIds/groupIds/groupAccountIds` 取得を統一）
  - `ensureRoomAccessWithReasonError` を追加（`ensureChatRoomContentAccess` + 403/404 応答を統一）
  - 12箇所の重複ブロックを helper 呼び出しへ置換
  - `mention-candidates` の group 候補解決は `accessContext` を利用するように変更

## 仕様影響
- なし（レスポンス形状・HTTPステータスは既存維持）

## 確認
- `npm run lint --prefix packages/backend`
- `npm run format:check --prefix packages/backend`
- `npm run typecheck --prefix packages/backend`
- `npm run build --prefix packages/backend`
- `npm run test:ci --prefix packages/backend`
