### PR TITLE
chore: align dependabot with eslint10 hold policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,13 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "eslint"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@eslint/js"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "npm"
     directory: "/packages/frontend"
@@ -35,6 +42,13 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "eslint"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@eslint/js"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## 概要
- `.github/dependabot.yml` に `eslint` / `@eslint/js` の major update ignore を backend/frontend 双方へ明示追加
- #914 の方針（eslint@10 readinessがtrueになるまで major 更新を止める）との設定乖離を解消

## 背景
#914 では「eslint@10 再開条件を満たすまで major PR を停止」が運用方針ですが、現状の dependabot 設定から明示 ignore が抜けており、将来の再発余地がありました。

## 変更内容
- `/.github/dependabot.yml`
  - `/packages/backend` と `/packages/frontend` の update 設定に以下を追加
    - `eslint`: `version-update:semver-major`
    - `@eslint/js`: `version-update:semver-major`

## 確認
- `python` で YAML 構文読み込み確認（`yaml.safe_load`）
- `make eslint10-readiness-check` 実行（現時点 `ready: false` 継続）

## 影響
- eslint 関連 major update PR の自動起票を明示的に抑止
- minor/patch update の挙動には影響なし
