### PR TITLE
test(security): add IDOR API boundary fixture and smoke suite

### DIFF
--- a/docs/test-results/2026-02-18-idor-smoke.md
+++ b/docs/test-results/2026-02-18-idor-smoke.md
@@ -1,0 +1,21 @@
+# IDOR smoke test result (2026-02-18)
+
+- Scope: ISSUE #1130 (major API boundary checks)
+- Spec: `packages/frontend/e2e/backend-idor-api-boundary.spec.ts`
+- Fixture: 2 users (`userA`, `userB`) + 2 projects (`projA`, `projB`)
+- Expected: cross-project access is denied (403 or 404)
+
+## Covered endpoints
+
+1. `GET /projects/:projectId/invoices`
+2. `GET /projects/:projectId/estimates`
+3. `GET /projects/:projectId/chat-messages`
+4. `GET /projects/:projectId/tasks`
+5. `GET /ref-candidates?projectId=...`
+6. `PATCH /projects/:projectId/tasks/:taskId`
+7. `POST /projects/:projectId/chat-messages`
+
+## Result
+
+- All listed cross-project read/write requests are expected to be denied.
+- Regression is continuously checked by Playwright E2E in CI.

--- a/packages/frontend/e2e/backend-idor-api-boundary.spec.ts
+++ b/packages/frontend/e2e/backend-idor-api-boundary.spec.ts
@@ -1,0 +1,251 @@
+import { randomUUID } from 'node:crypto';
+import { APIRequestContext, APIResponse, expect, test } from '@playwright/test';
+
+const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
+
+type ActorHeaderInput = {
+  userId: string;
+  roles: string[];
+  projectIds?: string[];
+  groupIds?: string[];
+};
+
+type IdorFixture = {
+  projectA: string;
+  projectB: string;
+  userAId: string;
+  userBId: string;
+  userAHeaders: Record<string, string>;
+  userBHeaders: Record<string, string>;
+};
+
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
+
+const buildHeaders = (input: ActorHeaderInput) => ({
+  'x-user-id': input.userId,
+  'x-roles': input.roles.join(','),
+  'x-project-ids': (input.projectIds ?? []).join(','),
+  'x-group-ids': (input.groupIds ?? []).join(','),
+});
+
+const adminHeaders = buildHeaders({
+  userId: 'demo-user',
+  roles: ['admin', 'mgmt'],
+  groupIds: ['mgmt'],
+});
+
+async function parseJsonOrText(res: APIResponse) {
+  try {
+    return await res.json();
+  } catch {
+    return { raw: await res.text() };
+  }
+}
+
+function extractErrorCode(payload: unknown) {
+  if (!payload || typeof payload !== 'object') return '';
+  const error = (payload as { error?: unknown }).error;
+  if (typeof error === 'string') return error;
+  if (error && typeof error === 'object') {
+    const code = (error as { code?: unknown }).code;
+    if (typeof code === 'string') return code;
+  }
+  return '';
+}
+
+async function ensureOk(res: APIResponse, label: string) {
+  if (res.ok()) return;
+  const body = await res.text();
+  throw new Error(`[e2e] ${label} failed: ${res.status()} ${body}`);
+}
+
+async function expectDenied(res: APIResponse, label: string) {
+  const status = res.status();
+  if (status !== 403 && status !== 404) {
+    const body = await res.text();
+    throw new Error(
+      `[e2e] ${label} should be denied (403/404) but got ${status}: ${body}`,
+    );
+  }
+  const payload = await parseJsonOrText(res);
+  const code = extractErrorCode(payload);
+  if (status === 403) {
+    expect(
+      ['forbidden', 'forbidden_project', 'FORBIDDEN', 'FORBIDDEN_PROJECT'].includes(
+        code,
+      ),
+    ).toBeTruthy();
+  }
+}
+
+async function createProject(
+  request: APIRequestContext,
+  suffix: string,
+  label: 'A' | 'B',
+) {
+  const res = await request.post(`${apiBase}/projects`, {
+    data: {
+      code: `E2E-IDOR-${label}-${suffix}`.slice(0, 32),
+      name: `E2E IDOR ${label} ${suffix}`,
+      status: 'active',
+    },
+    headers: adminHeaders,
+  });
+  await ensureOk(res, `create project ${label}`);
+  const payload = (await res.json()) as { id?: string };
+  expect(payload.id).toBeTruthy();
+  return payload.id as string;
+}
+
+async function addProjectMember(
+  request: APIRequestContext,
+  projectId: string,
+  userId: string,
+) {
+  const res = await request.post(
+    `${apiBase}/projects/${encodeURIComponent(projectId)}/members`,
+    {
+      data: { userId, role: 'member' },
+      headers: adminHeaders,
+    },
+  );
+  await ensureOk(res, `add member ${userId}`);
+}
+
+async function createFixture(request: APIRequestContext): Promise<IdorFixture> {
+  const suffix = runId();
+  const projectA = await createProject(request, suffix, 'A');
+  const projectB = await createProject(request, suffix, 'B');
+  const userAId = `e2e-idor-a-${suffix}@example.com`;
+  const userBId = `e2e-idor-b-${suffix}@example.com`;
+  await addProjectMember(request, projectA, userAId);
+  await addProjectMember(request, projectB, userBId);
+  return {
+    projectA,
+    projectB,
+    userAId,
+    userBId,
+    userAHeaders: buildHeaders({
+      userId: userAId,
+      roles: ['user'],
+      projectIds: [projectA],
+    }),
+    userBHeaders: buildHeaders({
+      userId: userBId,
+      roles: ['user'],
+      projectIds: [projectB],
+    }),
+  };
+}
+
+async function createProjectTask(
+  request: APIRequestContext,
+  projectId: string,
+  headers: Record<string, string>,
+) {
+  const suffix = runId();
+  const res = await request.post(
+    `${apiBase}/projects/${encodeURIComponent(projectId)}/tasks`,
+    {
+      data: { name: `IDOR Task ${suffix}` },
+      headers,
+    },
+  );
+  await ensureOk(res, 'create project task');
+  const payload = (await res.json()) as { id?: string };
+  expect(payload.id).toBeTruthy();
+  return payload.id as string;
+}
+
+test('idor api boundary fixture rejects cross-project invoice access @core', async ({
+  request,
+}) => {
+  const fixture = await createFixture(request);
+
+  const ownRes = await request.get(
+    `${apiBase}/projects/${encodeURIComponent(fixture.projectA)}/invoices`,
+    { headers: fixture.userAHeaders },
+  );
+  await ensureOk(ownRes, 'own project invoices');
+
+  const deniedRes = await request.get(
+    `${apiBase}/projects/${encodeURIComponent(fixture.projectA)}/invoices`,
+    { headers: fixture.userBHeaders },
+  );
+  await expectDenied(deniedRes, 'cross project invoices');
+});
+
+test('idor smoke: selected endpoints reject cross-project read/write access @core', async ({
+  request,
+}) => {
+  const fixture = await createFixture(request);
+  const taskId = await createProjectTask(
+    request,
+    fixture.projectA,
+    fixture.userAHeaders,
+  );
+
+  const projectA = encodeURIComponent(fixture.projectA);
+  const deniedChecks = [
+    {
+      label: 'invoices list',
+      request: () =>
+        request.get(`${apiBase}/projects/${projectA}/invoices`, {
+          headers: fixture.userBHeaders,
+        }),
+    },
+    {
+      label: 'estimates list',
+      request: () =>
+        request.get(`${apiBase}/projects/${projectA}/estimates`, {
+          headers: fixture.userBHeaders,
+        }),
+    },
+    {
+      label: 'chat messages list',
+      request: () =>
+        request.get(`${apiBase}/projects/${projectA}/chat-messages?limit=1`, {
+          headers: fixture.userBHeaders,
+        }),
+    },
+    {
+      label: 'project task list',
+      request: () =>
+        request.get(`${apiBase}/projects/${projectA}/tasks`, {
+          headers: fixture.userBHeaders,
+        }),
+    },
+    {
+      label: 'ref candidates',
+      request: () =>
+        request.get(
+          `${apiBase}/ref-candidates?projectId=${projectA}&q=ID&types=invoice`,
+          { headers: fixture.userBHeaders },
+        ),
+    },
+    {
+      label: 'project task patch',
+      request: () =>
+        request.patch(
+          `${apiBase}/projects/${projectA}/tasks/${encodeURIComponent(taskId)}`,
+          {
+            data: { name: `patched-${runId()}` },
+            headers: fixture.userBHeaders,
+          },
+        ),
+    },
+    {
+      label: 'chat message post',
+      request: () =>
+        request.post(`${apiBase}/projects/${projectA}/chat-messages`, {
+          data: { body: `idor-cross-post-${runId()}` },
+          headers: fixture.userBHeaders,
+        }),
+    },
+  ];
+
+  for (const denied of deniedChecks) {
+    const res = await denied.request();
+    await expectDenied(res, denied.label);
+  }
+});


### PR DESCRIPTION
## 対応Issue
- Closes #1129
- Closes #1130

## 変更内容
### 1) IDOR/RBAC API境界テスト基盤（#1129）
- 追加: `packages/frontend/e2e/backend-idor-api-boundary.spec.ts`
- 2主体 + 2プロジェクト fixture を実装
  - userA は projA のみ所属
  - userB は projB のみ所属
- ヘッダ生成/失敗判定/403・404判定の共通ヘルパを整備
- 最小サンプルとして `GET /projects/:projectId/invoices` の cross-project 拒否を自動検証

### 2) IDOR重点点検（#1130）
- 同 spec 内で主要エンドポイントの cross-project read/write 拒否を追加
  1. `GET /projects/:projectId/invoices`
  2. `GET /projects/:projectId/estimates`
  3. `GET /projects/:projectId/chat-messages`
  4. `GET /projects/:projectId/tasks`
  5. `GET /ref-candidates?projectId=...`
  6. `PATCH /projects/:projectId/tasks/:taskId`
  7. `POST /projects/:projectId/chat-messages`
- 全ケースで 403/404 を期待し、拒否されることを確認

### 3) テスト結果記録
- 追加: `docs/test-results/2026-02-18-idor-smoke.md`
  - 対象エンドポイントと期待結果を記録

## 実行コマンド
- `E2E_CAPTURE=0 E2E_SKIP_PLAYWRIGHT_INSTALL=1 E2E_GREP='idor api boundary|idor smoke' ./scripts/e2e-frontend.sh`
- `npm run build --prefix packages/frontend`
