### PR TITLE
security(audit): define required events and fill log coverage gaps

### DIFF
--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -5,6 +5,7 @@
 
 ## 参照
 - セキュリティベースライン: `docs/security/security-baseline.md`
+- 監査ログ必須イベント: `docs/security/audit-required-events.md`
 - サプライチェーン対策: `docs/security/supply-chain.md`
 - 品質目標: `docs/quality/quality-goals.md`
 

--- a/docs/security/audit-required-events.md
+++ b/docs/security/audit-required-events.md
@@ -1,0 +1,38 @@
+# 監査ログ必須イベント定義（Security Hardening v1）
+
+## 目的
+
+- 重要操作の監査証跡を「どのイベント名で、どの最小項目を持って残すか」に統一する
+- 実装差分レビュー時に、ログ抜けを機械的に確認できる状態にする
+
+## 監査ログの最小項目
+
+`audit_logs`（`packages/backend/prisma/schema.prisma`）のうち、運用で必須とする項目は以下。
+
+- `action`（必須）: 操作種別。`domain_operation_result` 形式で命名（例: `project_member_added`）。
+- `createdAt`（必須）: 記録時刻（UTC）。
+- `userId`（推奨）: 実行主体。バッチ等は `system` または `null` を許容。
+- `actorRole`（推奨）: 主要ロール（絞り込み用途）。
+- `requestId`（推奨）: APIリクエストとの相関ID。
+- `targetTable` / `targetId`（推奨）: 対象リソース識別子。
+- `reasonCode` / `reasonText`（条件付き必須）: 例外運用・override・取消系では必須。
+- `metadata`（推奨）: before/after、判定理由、件数などの補足情報。
+
+## 必須イベント一覧（v1）
+
+| 分類                    | 必須イベント（action）                                                                                                                                      | 実装箇所（代表）                                |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| 権限・所属変更          | `project_member_added` / `project_member_removed` / `project_member_role_updated`                                                                           | `packages/backend/src/routes/projects.ts`       |
+| 権限・所属変更          | `group_created` / `group_updated` / `group_deleted` / `group_member_added` / `group_member_removed`                                                         | `packages/backend/src/routes/groups.ts`         |
+| 監査閲覧（break-glass） | `chat_break_glass_requested` / `chat_break_glass_approved` / `chat_break_glass_rejected` / `chat_break_glass_accessed`                                      | `packages/backend/src/routes/chatBreakGlass.ts` |
+| 外部送信（設定/実行）   | `chat_room_updated`（`allowExternalIntegrations` 変更を含む）                                                                                               | `packages/backend/src/routes/chatRooms.ts`      |
+| 外部送信（実行可否）    | `chat_external_llm_requested` / `chat_external_llm_succeeded` / `chat_external_llm_failed` / `chat_external_llm_blocked` / `chat_external_llm_rate_limited` | `packages/backend/src/routes/chatRooms.ts`      |
+| 添付操作                | `chat_attachment_uploaded` / `chat_attachment_downloaded` / `chat_attachment_blocked` / `chat_attachment_scan_failed`                                       | `packages/backend/src/routes/chat.ts`           |
+| 監査ログ閲覧            | `audit_log_exported`（JSON/CSVの検索・出力）                                                                                                                | `packages/backend/src/routes/auditLogs.ts`      |
+| 重要状態変更            | `project_status_updated`                                                                                                                                    | `packages/backend/src/routes/projects.ts`       |
+
+## 運用ルール
+
+- 追加APIで権限判定・外部送信・状態遷移を実装する場合、上表に該当する `action` の追加/再利用を必須にする。
+- `reasonText` は個人情報や機密値を含めない（必要情報は `metadata` に構造化して保持）。
+- 監査ログの回帰防止として、最低1本の自動テスト（integration/e2e）で `action` 記録を検証する。

--- a/docs/security/security-baseline.md
+++ b/docs/security/security-baseline.md
@@ -37,6 +37,8 @@ PoC→運用フェーズに向けて、最低限のセキュリティ基準（�
   - 設定: `RATE_LIMIT_MAX`（既定 600）/ `RATE_LIMIT_WINDOW`（既定 `1 minute`）
 - 可観測性
   - request-id（`x-request-id`）付与と統一エラー応答（`docs/ops/observability.md`）
+- 監査ログ
+  - 必須イベント一覧と最小項目を定義（`docs/security/audit-required-events.md`）
 - キャッシュ制御
   - backend API は `Cache-Control: no-store` / `Pragma: no-cache` を既定付与
   - Service Worker は静的アセット（`/assets/*` とコアファイル）のみキャッシュし、`/api*`・`/health*`・`/ready*` はキャッシュしない

--- a/packages/backend/src/routes/projects.ts
+++ b/packages/backend/src/routes/projects.ts
@@ -408,6 +408,18 @@ export async function registerProjectRoutes(app: FastifyInstance) {
         });
       }
       if (statusChanged) {
+        await logAudit({
+          action: 'project_status_updated',
+          targetTable: 'projects',
+          targetId: projectId,
+          reasonText: reasonText || undefined,
+          metadata: {
+            fromStatus: current.status,
+            toStatus: project.status,
+            ownerUserId: project.ownerUserId,
+          } as Prisma.InputJsonValue,
+          ...auditContextFromRequest(req),
+        });
         try {
           await createProjectStatusChangedNotifications({
             projectId,

--- a/packages/frontend/e2e/backend-audit-required-events.spec.ts
+++ b/packages/frontend/e2e/backend-audit-required-events.spec.ts
@@ -1,0 +1,120 @@
+import { randomUUID } from 'node:crypto';
+import { expect, test, type APIRequestContext } from '@playwright/test';
+
+const apiBase = process.env.E2E_API_BASE || 'http://localhost:3002';
+
+const runId = () => `${Date.now().toString().slice(-6)}-${randomUUID()}`;
+
+const buildHeaders = (input: {
+  userId: string;
+  roles: string[];
+  projectIds?: string[];
+  groupIds?: string[];
+}) => ({
+  'x-user-id': input.userId,
+  'x-roles': input.roles.join(','),
+  'x-project-ids': (input.projectIds ?? []).join(','),
+  'x-group-ids': (input.groupIds ?? []).join(','),
+});
+
+const adminHeaders = buildHeaders({
+  userId: 'demo-user',
+  roles: ['admin', 'mgmt', 'exec'],
+  groupIds: ['mgmt', 'exec'],
+});
+
+async function ensureOk(
+  res: { ok(): boolean; status(): number; text(): Promise<string> },
+  label: string,
+) {
+  if (res.ok()) return;
+  const body = await res.text();
+  throw new Error(`[e2e] ${label} failed: ${res.status()} ${body}`);
+}
+
+async function waitAuditAction(
+  request: APIRequestContext,
+  action: string,
+  targetTable: string,
+  targetId: string,
+) {
+  await expect
+    .poll(
+      async () => {
+        const params = new URLSearchParams({
+          action,
+          targetTable,
+          targetId,
+          format: 'json',
+          mask: '0',
+          limit: '20',
+        });
+        const res = await request.get(`${apiBase}/audit-logs?${params}`, {
+          headers: adminHeaders,
+        });
+        if (!res.ok()) return false;
+        const payload = await res.json();
+        return (payload?.items ?? []).some(
+          (item: any) => item?.action === action,
+        );
+      },
+      { timeout: 5000 },
+    )
+    .toBe(true);
+}
+
+test('audit required events: project status change is recorded @core @audit-required', async ({
+  request,
+}) => {
+  const suffix = runId();
+  const createRes = await request.post(`${apiBase}/projects`, {
+    headers: adminHeaders,
+    data: {
+      code: `E2E-AUD-${suffix}`.slice(0, 32),
+      name: `E2E Audit ${suffix}`,
+      status: 'active',
+    },
+  });
+  await ensureOk(createRes, 'create project');
+  const created = await createRes.json();
+  const projectId = String(created?.id || '');
+  expect(projectId).toBeTruthy();
+
+  const patchRes = await request.patch(
+    `${apiBase}/projects/${encodeURIComponent(projectId)}`,
+    {
+      headers: adminHeaders,
+      data: { status: 'closed' },
+    },
+  );
+  await ensureOk(patchRes, 'patch project status');
+  const patched = await patchRes.json();
+  expect(String(patched?.status || '')).toBe('closed');
+
+  await waitAuditAction(
+    request,
+    'project_status_updated',
+    'projects',
+    projectId,
+  );
+
+  const params = new URLSearchParams({
+    action: 'project_status_updated',
+    targetTable: 'projects',
+    targetId: projectId,
+    format: 'json',
+    mask: '0',
+    limit: '20',
+  });
+  const auditRes = await request.get(`${apiBase}/audit-logs?${params}`, {
+    headers: adminHeaders,
+  });
+  await ensureOk(auditRes, 'fetch audit logs');
+  const payload = await auditRes.json();
+  const event = (payload?.items ?? []).find(
+    (item: any) => item?.action === 'project_status_updated',
+  );
+  expect(event).toBeTruthy();
+  expect(event?.metadata?.fromStatus).toBe('active');
+  expect(event?.metadata?.toStatus).toBe('closed');
+});


### PR DESCRIPTION
## 対応概要
- 監査ログの必須イベント/最小項目を `docs/security/audit-required-events.md` として新規定義
- `projects` 更新で状態変更時の監査ログ `project_status_updated` を追加
- Chat外部LLM要約の拒否/レート制限時に監査ログを追加（`chat_external_llm_blocked` / `chat_external_llm_rate_limited`）
- 監査ログ回帰検知のため、E2Eを追加（`project_status_updated` 記録確認）

## 変更ファイル
- `docs/security/audit-required-events.md`
- `docs/security/README.md`
- `docs/security/security-baseline.md`
- `packages/backend/src/routes/projects.ts`
- `packages/backend/src/routes/chatRooms.ts`
- `packages/frontend/e2e/backend-audit-required-events.spec.ts`

## テスト
- `npm run test --prefix packages/backend`
- `npm run lint --prefix packages/backend`
- `npm run lint --prefix packages/frontend`
- `npm run format:check --prefix packages/backend`
- `npm run format:check --prefix packages/frontend`
- `npm run typecheck --prefix packages/backend`
- `npm run typecheck --prefix packages/frontend`
- `E2E_SCOPE=core E2E_GREP='@audit-required' E2E_CAPTURE=0 ./scripts/e2e-frontend.sh`

Closes #1133
