### PR TITLE
security(headers): document and test CORS/CSP baseline

### DIFF
--- a/docs/ops/configuration.md
+++ b/docs/ops/configuration.md
@@ -19,6 +19,15 @@ backend は起動時に環境変数の検証を行い、不正/不足があれ�
 - `PORT`（任意、指定時は `1-65535`、未指定時は `3001`）
 - `ALLOWED_ORIGINS`（任意、指定時は `http(s)` URL のカンマ区切り。未設定/空の場合は Fastify の CORS 設定で `origin: false` となり、全オリジン拒否）
 
+セキュリティヘッダ/CORS（固定ポリシー）:
+
+- CORS
+  - `ALLOWED_ORIGINS` 設定時: 指定オリジンのみ許可
+  - `ALLOWED_ORIGINS` 未設定/空: 全オリジン拒否（`Access-Control-Allow-Origin` を返さない）
+- CSP（`@fastify/helmet`）
+  - 既定: `default-src 'self'`, `script-src 'self'`, `style-src 'self'`, `img-src 'self'`, `connect-src 'self'`, `font-src 'self'`, `object-src 'none'`, `frame-ancestors 'self'`, `base-uri 'self'`
+  - 埋め込み要件などで `frame-ancestors` を変更する場合は、コード変更 + セキュリティレビューを必須とする
+
 認証:
 
 - `AUTH_MODE=header|jwt|hybrid`（未設定時は `header`）

--- a/docs/ops/deploy-start.md
+++ b/docs/ops/deploy-start.md
@@ -39,5 +39,4 @@
 
 ### 注意
 - TLS は reverse proxy 側で終端する前提（アプリ単体でのTLS終端は扱わない）
-- `ALLOWED_ORIGINS` を本番の配信元に合わせる
-
+- `ALLOWED_ORIGINS` を本番の配信元に合わせる（未設定/空の場合は CORS 全拒否）

--- a/packages/backend/test/securityHeaders.test.js
+++ b/packages/backend/test/securityHeaders.test.js
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const MIN_DATABASE_URL = 'postgresql://user:pass@localhost:5432/postgres';
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const BACKEND_DIR = resolve(TEST_DIR, '..');
+
+const BASE_ENV = {
+  DATABASE_URL: MIN_DATABASE_URL,
+};
+
+function runHealthRequest(overrides = {}, headers = {}) {
+  const script = `
+    import { buildServer } from './dist/server.js';
+    const server = await buildServer({ logger: false });
+    try {
+      const headers = process.env.TEST_HEADERS
+        ? JSON.parse(process.env.TEST_HEADERS)
+        : {};
+      const res = await server.inject({ method: 'GET', url: '/healthz', headers });
+      process.stdout.write(JSON.stringify({
+        statusCode: res.statusCode,
+        headers: {
+          accessControlAllowOrigin: res.headers['access-control-allow-origin'] ?? null,
+          contentSecurityPolicy: res.headers['content-security-policy'] ?? null,
+        },
+      }));
+    } finally {
+      await server.close();
+    }
+  `;
+  const result = spawnSync(process.execPath, ['-e', script], {
+    cwd: BACKEND_DIR,
+    env: {
+      ...BASE_ENV,
+      ...overrides,
+      TEST_HEADERS: JSON.stringify(headers),
+    },
+    encoding: 'utf8',
+  });
+  return result;
+}
+
+function parseResult(result, label) {
+  assert.equal(result.status, 0, `${label}: ${result.stderr}`);
+  return JSON.parse(result.stdout);
+}
+
+test('cors denies when ALLOWED_ORIGINS is empty', () => {
+  const result = runHealthRequest(
+    { ALLOWED_ORIGINS: '' },
+    { origin: 'http://blocked.example' },
+  );
+  const payload = parseResult(result, 'cors-empty');
+  assert.equal(payload.statusCode, 200);
+  assert.equal(payload.headers.accessControlAllowOrigin, null);
+});
+
+test('cors allows configured origin', () => {
+  const result = runHealthRequest(
+    {
+      ALLOWED_ORIGINS:
+        'http://allowed.example,http://localhost:5173,http://127.0.0.1:5173',
+    },
+    { origin: 'http://allowed.example' },
+  );
+  const payload = parseResult(result, 'cors-allowed');
+  assert.equal(payload.statusCode, 200);
+  assert.equal(
+    payload.headers.accessControlAllowOrigin,
+    'http://allowed.example',
+  );
+});
+
+test('cors rejects origin not in allowlist', () => {
+  const result = runHealthRequest(
+    { ALLOWED_ORIGINS: 'http://allowed.example' },
+    { origin: 'http://blocked.example' },
+  );
+  const payload = parseResult(result, 'cors-blocked');
+  assert.equal(payload.statusCode, 200);
+  assert.equal(payload.headers.accessControlAllowOrigin, null);
+});
+
+test('csp header is attached with baseline directives', () => {
+  const result = runHealthRequest();
+  const payload = parseResult(result, 'csp');
+  assert.equal(payload.statusCode, 200);
+  const csp = String(payload.headers.contentSecurityPolicy || '');
+  assert.match(csp, /default-src 'self'/);
+  assert.match(csp, /connect-src 'self'/);
+  assert.match(csp, /frame-ancestors 'self'/);
+});


### PR DESCRIPTION
## 対応概要
- CORS/CSP の現行ポリシーを docs に明文化
  - `ALLOWED_ORIGINS` 未設定/空時は全オリジン拒否
  - Helmet の CSP 既定ディレクティブを明記
- CORS/CSP の回帰防止テストを追加
  - `ALLOWED_ORIGINS` 空で拒否
  - 許可オリジンのみ許可
  - allowlist 外オリジン拒否
  - CSP ヘッダに基準ディレクティブが含まれること

## 変更ファイル
- `packages/backend/test/securityHeaders.test.js`
- `docs/ops/configuration.md`
- `docs/ops/deploy-start.md`

## テスト
- `npm run test --prefix packages/backend`
- `npm run lint --prefix packages/backend`
- `npm run format:check --prefix packages/backend`

Closes #1137
