### PR TITLE
ci(security): add scheduled OWASP ZAP DAST workflow

### DIFF
--- a/.github/workflows/dast-zap.yml
+++ b/.github/workflows/dast-zap.yml
@@ -1,0 +1,106 @@
+name: DAST (OWASP ZAP)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  zap-baseline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20.19.0
+
+      - run: npm ci --prefix packages/backend
+      - run: npx --prefix packages/backend prisma generate --config packages/backend/prisma.config.ts
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres?schema=public
+      - run: npx --prefix packages/backend prisma db push --config packages/backend/prisma.config.ts
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres?schema=public
+      - run: npm run build --prefix packages/backend
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres?schema=public
+
+      - name: Start backend
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres?schema=public
+          PORT: "3002"
+          ALLOWED_ORIGINS: http://localhost:5173,http://127.0.0.1:5173
+        run: |
+          mkdir -p tmp
+          node packages/backend/dist/index.js > tmp/dast-backend.log 2>&1 &
+          echo $! > tmp/dast-backend.pid
+
+      - name: Wait backend health
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS "http://localhost:3002/healthz" >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "backend not ready" >&2
+          tail -n 200 tmp/dast-backend.log >&2 || true
+          exit 1
+
+      - name: Run ZAP baseline (non-blocking)
+        continue-on-error: true
+        run: |
+          mkdir -p tmp/zap-report
+          docker run --rm --network=host \
+            -v "$PWD/tmp/zap-report:/zap/wrk/:rw" \
+            ghcr.io/zaproxy/zaproxy:stable \
+            zap-baseline.py \
+              -t "http://127.0.0.1:3002/healthz" \
+              -J "zap-report.json" \
+              -r "zap-report.html" \
+              -w "zap-report.md" \
+              -m 1 \
+              -I
+
+      - name: Upload ZAP report artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: zap-report-${{ github.run_id }}
+          path: tmp/zap-report/*
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Upload DAST backend logs
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: dast-backend-log-${{ github.run_id }}
+          path: tmp/dast-backend.log
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Stop backend
+        if: always()
+        run: |
+          if [ -f tmp/dast-backend.pid ]; then
+            kill "$(cat tmp/dast-backend.pid)" >/dev/null 2>&1 || true
+          fi

--- a/docs/ops/security.md
+++ b/docs/ops/security.md
@@ -13,3 +13,18 @@
 - APIレスポンスは `Cache-Control: no-store` / `Pragma: no-cache` を前提とする
 - Service Worker のキャッシュ対象は静的アセットのみ（`/assets/*` とコアファイル）
 - Push 通知の遷移URLは same-origin 相対パスのみ許可し、外部URLは開かない
+
+## DAST（OWASP ZAP）運用
+- 定常実行: GitHub Actions `DAST (OWASP ZAP)`（`/.github/workflows/dast-zap.yml`）
+  - `schedule`: 毎週月曜 06:00 UTC
+  - `workflow_dispatch`: 手動実行可能
+- スキャン方式:
+  - backend を CI 上で起動し、`http://127.0.0.1:3002/healthz` を ZAP baseline で検査
+  - 初期運用は non-blocking（`Run ZAP baseline` ステップは `continue-on-error: true`）
+- 成果物:
+  - `zap-report-<run_id>`（`zap-report.html` / `zap-report.json` / `zap-report.md`）
+  - `dast-backend-log-<run_id>`（backend 起動ログ）
+- 指摘対応:
+  1. Medium/High の新規検知は Security ラベル付き Issue を起票
+  2. 該当 run の artifact URL と再現条件を Issue に記載
+  3. 誤検知の場合は理由と抑止方針（rule ignore など）を Issue に記録


### PR DESCRIPTION
## 対応概要
- OWASP ZAP の定常 DAST workflow を追加（schedule + workflow_dispatch）
- backend 起動後に ZAP baseline を実行し、結果を artifact 化
- 初期運用は non-blocking（ZAP ステップは `continue-on-error: true`）
- 運用Runbookに DAST 実行/成果物/Issue化手順を追記

## 変更ファイル
- `.github/workflows/dast-zap.yml`
- `docs/ops/security.md`

## 補足
- schedule: 毎週月曜 06:00 UTC
- scan target: `http://127.0.0.1:3002/healthz`

Closes #1134
