### PR TITLE
feat(expense): QAチェックリスト完了を一次承認の必須条件に追加

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4120,6 +4120,76 @@
         }
       }
     },
+    "/expenses/{id}/qa-checklist": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      },
+      "put": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "minProperties": 1,
+                "properties": {
+                  "amountVerified": {
+                    "type": "boolean"
+                  },
+                  "budgetChecked": {
+                    "type": "boolean"
+                  },
+                  "journalPrepared": {
+                    "type": "boolean"
+                  },
+                  "notes": {
+                    "maxLength": 2000,
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "projectLinked": {
+                    "type": "boolean"
+                  },
+                  "receiptVerified": {
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
     "/expenses/{id}/reassign": {
       "post": {
         "parameters": [

--- a/docs/requirements/expense-settlement.md
+++ b/docs/requirements/expense-settlement.md
@@ -1,38 +1,47 @@
 # 経費精算の精算書/支払フロー（MVP確定）
 
 ## 背景
+
 旧システムでは「申請→承認→精算（支払）」の二段階運用があり、申請後の精算処理が重要な業務フローでした。ERP4 では申請/承認に加え、MVPとして明細単位の支払状態は実装済みですが、精算書（バンドル）単位や支払方法等は後続の整理対象です。
 
 ## 現状（ERP4）
+
 - Expense は明細単位で `draft/pending_*/approved/rejected` を持つ
 - Expense の内訳として `ExpenseLine`（明細）、`ExpenseAttachment`（証憑メタ）、`ExpenseComment`（コメント）を保持できる
 - 申請承認フローは approval_rules に準拠
 - 支払状態（MVP）は実装済み（`settlementStatus=unpaid/paid` + `paidAt/paidBy`、支払済み/取消 API、通知/監査ログ）
 
 ## 差分/課題
+
 - 支払（精算）操作は admin/mgmt 向け API として実装済みだが、業務UI（一覧/詳細での支払操作）は後続
 - 支払方法/税率/支払先など、実務に必要な属性が不足
 - 複数明細を束ねる単位（精算書/バンドル）の要否が未決定
 
 ## MVP方針（確定）
+
 - 明細単位の精算で開始する（精算書は後続検討）
 - 旧システムの「Submitter=支払対象」を踏襲し、支払先は原則 `userId` とする
 - 外部支払先は既存の支払先名（外部会社名）で保持し、支払対象とは分離する
 - 精算状態は Expense に保持する（MVP: `settlementStatus=unpaid/paid` + `paidAt/paidBy`）
 
 ## 後続拡張（候補）
+
 ### A. 明細単位の精算（MVP）
+
 - Expense に `settlementStatus` / `paidAt` / `paidBy` を追加
 - 精算操作は単票ごとに実施
 - 実装負荷は低いが、件数が多い場合の運用負荷が残る
 
 ### B. 精算書（バンドル）単位
+
 - ExpenseSettlement（精算書）を新設し、複数Expenseを紐付け
 - 精算書で支払方法/支払日/担当を管理
 - 実務運用に近いが設計/実装コストが増える
 
 ## 追加で整理すべき論点（MVPで確定させる項目）
+
 ### 属性（MVP確定/候補）
+
 - 支払先（支払対象）: `userId` を基本とする（従業員）
 - 精算状態: `settlementStatus`（MVP: `unpaid` / `paid`）
 - 支払日: `paidAt`（MVP）
@@ -43,19 +52,23 @@
 - 備考: `notes`（後続。現状 `Expense` に未実装）
 
 ### 状態遷移（MVP確定）
+
 - 申請承認（既存）: `draft` → `pending_qa` → `pending_exec` → `approved` / `rejected`
   - 経理一次チェックを先行させるため、`approval_rules(flowType=expense)` の先頭ステージに `exec` は設定不可（`exec` を使う場合は先に non-exec ステージが必要）
   - `POST /expenses/:id/submit` 実行時、`ExpenseAttachment` が1件以上、または `receiptUrl` が設定されていることを必須とする
+  - `pending_qa` ステージの承認実行前に QA チェックリスト（`amountVerified/receiptVerified/journalPrepared/projectLinked/budgetChecked`）の全項目完了を必須とする
 - 精算（追加）: `settlementStatus=unpaid` → `paid`
   - `status=approved` のみ `paid` へ遷移可能
   - `paid` の取消（`paid` → `unpaid`）は admin/mgmt のみ（理由必須、監査ログ対象）
 
 ### UI導線（MVP確定）
+
 - 申請者: ダッシュボード通知（`kind=expense_mark_paid`）で支払完了を確認できる（Expense一覧/詳細での表示は後続）
 - admin/mgmt: `POST /expenses/:id/mark-paid` / `unmark-paid` で支払済み/取消（理由/監査）を実施する（UIは後続）
 - 検索/集計: 「未精算のみ」「支払日レンジ」「案件」での絞り込み UI は後続（MVPは最小）
 
 ### 権限/監査/通知（MVP確定）
+
 - 精算操作（支払済み/取消）は admin/mgmt のみ
 - `status=pending_*`（承認中）/`status=approved`（承認後）は、申請者による主要項目変更を禁止（現行ポリシー維持）
 - 監査ログ:
@@ -70,11 +83,13 @@
 - 通知: 支払完了は申請者へアプリ内通知（`kind=expense_mark_paid`）。メールは運用次第（通知体系は `docs/requirements/notifications.md` に準拠）
 
 ## 後続検討
+
 - 属性要件（支払方法/税率/備考 等）の拡充
 - UI導線（精算操作、検索、証憑の扱い）の整理
 - 精算書（バンドル）への拡張要否
 
 ## 関連
+
 - `docs/requirements/domain-api-draft.md`
 - `docs/requirements/approval-alerts.md`
 - `docs/requirements/reassignment-policy.md`

--- a/docs/requirements/frontend-api-wire.md
+++ b/docs/requirements/frontend-api-wire.md
@@ -1,14 +1,17 @@
 # フロント→バック API ワイヤ（PoC）
 
 ## auth
+
 - GET `/me`
   - headers: `x-user-id`, `x-roles`, `x-org-id`, `x-project-ids`
   - res: `{ user: { userId, roles, orgId, ownerOrgId, ownerProjects } }`
 
 ## dashboard
+
 - GET `/alerts` → ダッシュボード表示
 
 ## projects
+
 - GET `/projects/:projectId/members`
 - GET `/projects/:projectId/member-candidates?q=<keyword>`
 - POST `/projects/:projectId/members` { userId, role? }
@@ -21,6 +24,7 @@
 - POST `/jobs/recurring-projects/run`
 
 ## reports
+
 - GET `/reports/delivery-due?from=YYYY-MM-DD&to=YYYY-MM-DD&projectId?&format=csv|pdf?&layout=default?`
 - GET `/reports/project-effort/:projectId?from=YYYY-MM-DD&to=YYYY-MM-DD&format=csv|pdf?&layout=default?`
 - GET `/reports/project-profit/:projectId?from=YYYY-MM-DD&to=YYYY-MM-DD&format=csv|pdf?&layout=default?`
@@ -30,6 +34,7 @@
 - GET `/reports/overtime/:userId?from=YYYY-MM-DD&to=YYYY-MM-DD&format=csv|pdf?&layout=default?`
 
 ## report subscriptions
+
 - GET `/report-subscriptions`
 - POST `/report-subscriptions`
 - PATCH `/report-subscriptions/:id`
@@ -41,6 +46,7 @@
 - `format=pdf` 指定時は `{ format, templateId, url }` を返す（`url=/pdf-files/:filename`）
 
 ## daily report / wellbeing
+
 - POST `/daily-reports` { content, reportDate, linkedProjectIds?, status }
 - POST `/wellbeing-entries` { entryDate, status, notes?, helpRequested?, notGoodTags?, visibilityGroupId }
 - (人事向け) GET `/wellbeing-entries` → HRのみ
@@ -48,49 +54,58 @@
   - 備考: `minUsers` のデフォルトは `5`、`groupBy` のデフォルトは `group`
 
 ## time entries
+
 - GET `/time-entries?projectId?&userId?`
 - POST `/time-entries` { projectId, userId, workDate, minutes, taskId?, workType?, location?, notes? }
 - PATCH `/time-entries/:id`
 - POST `/time-entries/:id/submit`
 
 ## invoices / estimates
+
 - GET `/projects/:projectId/estimates` (list)
 - POST `/projects/:projectId/estimates` { lines, totalAmount, currency, validUntil?, notes }
 - POST `/estimates/:id/submit`
 - POST `/estimates/:id/send?templateId?&templateSettingId?`
-- GET  `/estimates/:id/send-logs`
+- GET `/estimates/:id/send-logs`
 - GET `/projects/:projectId/invoices` (list)
 - POST `/projects/:projectId/invoices` { estimateId?, milestoneId?, lines, issueDate?, dueDate?, currency, totalAmount }
 - POST `/invoices/:id/submit`
 - POST `/invoices/:id/send?templateId?&templateSettingId?`
-- GET  `/invoices/:id/send-logs`
-- GET  `/alerts` (承認遅延/予算超過の表示用)
+- GET `/invoices/:id/send-logs`
+- GET `/alerts` (承認遅延/予算超過の表示用)
 
 ## purchase orders / vendor docs
+
 - POST `/projects/:projectId/purchase-orders` { vendorId, lines, totals... }
 - POST `/purchase-orders/:id/submit`
 - POST `/purchase-orders/:id/send?templateId?&templateSettingId?`
-- GET  `/purchase-orders/:id/send-logs`
+- GET `/purchase-orders/:id/send-logs`
 - POST `/vendor-quotes` { projectId, vendorId, quote_no?, ... }
 - POST `/vendor-invoices` { projectId, vendorId, vendor_invoice_no?, ... }
 - POST `/vendor-invoices/:id/submit`（承認フロー起動、後方互換: `/approve` も残す）
 
 ## project chat
+
 - GET `/projects/:projectId/chat-messages?limit=&before=&tag=`
 - POST `/projects/:projectId/chat-messages` { body, tags? }
 - POST `/chat-messages/:id/reactions` { emoji }
 
 ## expenses
+
 - GET `/expenses?projectId?&userId?`
 - POST `/expenses` { projectId, userId, category, amount, currency?, incurredOn, isShared?, receiptUrl? }
+- GET `/expenses/:id/qa-checklist`
+- PUT `/expenses/:id/qa-checklist` { amountVerified?, receiptVerified?, journalPrepared?, projectLinked?, budgetChecked?, notes? }
 - POST `/expenses/:id/submit`
 
 ## leave
+
 - GET `/leave-requests?userId?`
 - POST `/leave-requests` { userId, leaveType, startDate, endDate, hours?, notes }
 - POST `/leave-requests/:id/submit`
 
 ## settings (admin/mgmt)
+
 - GET/POST/PATCH `/alert-settings`, `/alert-settings/:id/enable|disable`
 - GET/POST/PATCH `/approval-rules`
 - GET `/pdf-templates?kind=`
@@ -104,6 +119,7 @@
 - POST `/jobs/approval-escalations/run` (承認期限エスカレーション)
 
 ## role/permission policy (PoC)
+
 - headers: `x-roles` = admin, mgmt, user, hr を想定
 - HRのみ: `/wellbeing-entries` GET
 - admin/mgmt: alert/approval設定

--- a/packages/backend/prisma/migrations/20260220213000_add_expense_qa_checklist/migration.sql
+++ b/packages/backend/prisma/migrations/20260220213000_add_expense_qa_checklist/migration.sql
@@ -1,0 +1,31 @@
+CREATE TABLE "ExpenseQaChecklist" (
+  "id" TEXT NOT NULL,
+  "expenseId" TEXT NOT NULL,
+  "amountVerified" BOOLEAN NOT NULL DEFAULT false,
+  "receiptVerified" BOOLEAN NOT NULL DEFAULT false,
+  "journalPrepared" BOOLEAN NOT NULL DEFAULT false,
+  "projectLinked" BOOLEAN NOT NULL DEFAULT false,
+  "budgetChecked" BOOLEAN NOT NULL DEFAULT false,
+  "notes" TEXT,
+  "completedAt" TIMESTAMP(3),
+  "completedBy" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "createdBy" TEXT,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  "updatedBy" TEXT,
+
+  CONSTRAINT "ExpenseQaChecklist_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ExpenseQaChecklist_expenseId_key"
+  ON "ExpenseQaChecklist"("expenseId");
+
+CREATE INDEX "ExpenseQaChecklist_completedAt_idx"
+  ON "ExpenseQaChecklist"("completedAt");
+
+ALTER TABLE "ExpenseQaChecklist"
+  ADD CONSTRAINT "ExpenseQaChecklist_expenseId_fkey"
+  FOREIGN KEY ("expenseId")
+  REFERENCES "Expense"("id")
+  ON DELETE RESTRICT
+  ON UPDATE CASCADE;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -1049,10 +1049,31 @@ model Expense {
   attachments   ExpenseAttachment[]
   comments      ExpenseComment[]
   stateTransitions ExpenseStateTransitionLog[]
+  qaChecklist   ExpenseQaChecklist?
 
   @@index([projectId, deletedAt])
   @@index([userId, incurredOn])
   @@index([status])
+}
+
+model ExpenseQaChecklist {
+  id                String   @id @default(uuid())
+  expense           Expense  @relation(fields: [expenseId], references: [id], onDelete: Restrict)
+  expenseId         String   @unique
+  amountVerified    Boolean  @default(false)
+  receiptVerified   Boolean  @default(false)
+  journalPrepared   Boolean  @default(false)
+  projectLinked     Boolean  @default(false)
+  budgetChecked     Boolean  @default(false)
+  notes             String?
+  completedAt       DateTime?
+  completedBy       String?
+  createdAt         DateTime @default(now())
+  createdBy         String?
+  updatedAt         DateTime @updatedAt
+  updatedBy         String?
+
+  @@index([completedAt])
 }
 
 model ExpenseLine {

--- a/packages/backend/src/routes/approvalRules.ts
+++ b/packages/backend/src/routes/approvalRules.ts
@@ -1,5 +1,8 @@
 import { FastifyInstance } from 'fastify';
-import { act } from '../services/approval.js';
+import {
+  act,
+  ExpenseQaChecklistIncompleteError,
+} from '../services/approval.js';
 import { requireRole } from '../services/rbac.js';
 import { prisma } from '../services/db.js';
 import {
@@ -673,6 +676,14 @@ export async function registerApprovalRuleRoutes(app: FastifyInstance) {
         }
         return result;
       } catch (err: any) {
+        if (err instanceof ExpenseQaChecklistIncompleteError) {
+          return reply.code(409).send({
+            error: {
+              code: 'EXPENSE_QA_CHECKLIST_REQUIRED',
+              message: 'expense QA checklist must be completed before approval',
+            },
+          });
+        }
         return reply.code(400).send({
           error: 'approval_action_failed',
           message: err?.message || 'failed',

--- a/packages/backend/src/routes/validators.ts
+++ b/packages/backend/src/routes/validators.ts
@@ -327,6 +327,22 @@ export const expenseCommentCreateSchema = {
   ),
 };
 
+export const expenseQaChecklistPatchSchema = {
+  body: Type.Object(
+    {
+      amountVerified: Type.Optional(Type.Boolean()),
+      receiptVerified: Type.Optional(Type.Boolean()),
+      journalPrepared: Type.Optional(Type.Boolean()),
+      projectLinked: Type.Optional(Type.Boolean()),
+      budgetChecked: Type.Optional(Type.Boolean()),
+      notes: Type.Optional(
+        Type.Union([Type.String({ maxLength: 2000 }), Type.Null()]),
+      ),
+    },
+    { additionalProperties: false, minProperties: 1 },
+  ),
+};
+
 export const estimateSchema = {
   body: Type.Object({
     lines: Type.Optional(Type.Array(Type.Any())),

--- a/packages/backend/src/services/expenseQaChecklist.ts
+++ b/packages/backend/src/services/expenseQaChecklist.ts
@@ -1,0 +1,35 @@
+export type ExpenseQaChecklistLike = {
+  amountVerified: boolean;
+  receiptVerified: boolean;
+  journalPrepared: boolean;
+  projectLinked: boolean;
+  budgetChecked: boolean;
+};
+
+export const EXPENSE_QA_CHECKLIST_FIELDS: Array<keyof ExpenseQaChecklistLike> =
+  [
+    'amountVerified',
+    'receiptVerified',
+    'journalPrepared',
+    'projectLinked',
+    'budgetChecked',
+  ];
+
+export function isExpenseQaChecklistComplete(
+  checklist: ExpenseQaChecklistLike | null | undefined,
+): boolean {
+  if (!checklist) return false;
+  return EXPENSE_QA_CHECKLIST_FIELDS.every((field) => checklist[field]);
+}
+
+export function normalizeExpenseQaChecklist(
+  checklist: Partial<ExpenseQaChecklistLike> | null | undefined,
+): ExpenseQaChecklistLike {
+  return {
+    amountVerified: Boolean(checklist?.amountVerified),
+    receiptVerified: Boolean(checklist?.receiptVerified),
+    journalPrepared: Boolean(checklist?.journalPrepared),
+    projectLinked: Boolean(checklist?.projectLinked),
+    budgetChecked: Boolean(checklist?.budgetChecked),
+  };
+}

--- a/packages/backend/test/expenseQaChecklist.test.js
+++ b/packages/backend/test/expenseQaChecklist.test.js
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  isExpenseQaChecklistComplete,
+  normalizeExpenseQaChecklist,
+} from '../dist/services/expenseQaChecklist.js';
+
+test('isExpenseQaChecklistComplete: returns false when checklist is missing', () => {
+  assert.equal(isExpenseQaChecklistComplete(null), false);
+  assert.equal(isExpenseQaChecklistComplete(undefined), false);
+});
+
+test('normalizeExpenseQaChecklist: fills missing fields with false', () => {
+  const normalized = normalizeExpenseQaChecklist({
+    amountVerified: true,
+    journalPrepared: true,
+  });
+  assert.deepEqual(normalized, {
+    amountVerified: true,
+    receiptVerified: false,
+    journalPrepared: true,
+    projectLinked: false,
+    budgetChecked: false,
+  });
+});
+
+test('isExpenseQaChecklistComplete: returns true only when all checks are true', () => {
+  assert.equal(
+    isExpenseQaChecklistComplete({
+      amountVerified: true,
+      receiptVerified: true,
+      journalPrepared: true,
+      projectLinked: true,
+      budgetChecked: true,
+    }),
+    true,
+  );
+  assert.equal(
+    isExpenseQaChecklistComplete({
+      amountVerified: true,
+      receiptVerified: true,
+      journalPrepared: false,
+      projectLinked: true,
+      budgetChecked: true,
+    }),
+    false,
+  );
+});

--- a/packages/backend/test/expenseSchema.test.js
+++ b/packages/backend/test/expenseSchema.test.js
@@ -9,6 +9,7 @@ import {
 } from '../dist/routes/expenses.js';
 import {
   expenseCommentCreateSchema,
+  expenseQaChecklistPatchSchema,
   expenseSchema,
 } from '../dist/routes/validators.js';
 
@@ -113,6 +114,39 @@ test('expenseCommentCreateSchema: rejects empty body', async () => {
       kind: 'review',
       body: '',
     },
+  });
+
+  assert.equal(res.statusCode, 400);
+  await app.close();
+});
+
+test('expenseQaChecklistPatchSchema: accepts partial payload', async () => {
+  const app = await buildValidatorServer(
+    '/validate/expense-qa-checklist',
+    expenseQaChecklistPatchSchema,
+  );
+  const res = await app.inject({
+    method: 'POST',
+    url: '/validate/expense-qa-checklist',
+    payload: {
+      receiptVerified: true,
+      notes: 'e2e checklist',
+    },
+  });
+
+  assert.equal(res.statusCode, 200);
+  await app.close();
+});
+
+test('expenseQaChecklistPatchSchema: rejects empty payload', async () => {
+  const app = await buildValidatorServer(
+    '/validate/expense-qa-checklist',
+    expenseQaChecklistPatchSchema,
+  );
+  const res = await app.inject({
+    method: 'POST',
+    url: '/validate/expense-qa-checklist',
+    payload: {},
   });
 
   assert.equal(res.statusCode, 400);

--- a/packages/frontend/e2e/frontend-dashboard-notification-routing.spec.ts
+++ b/packages/frontend/e2e/frontend-dashboard-notification-routing.spec.ts
@@ -220,6 +220,26 @@ async function approveUntilApproved(
       roles: ['mgmt'],
       groupIds: actorGroupIds,
     });
+    if (flowType === 'expense' && instance.status === 'pending_qa') {
+      const checklistRes = await page.request.put(
+        `${apiBase}/expenses/${encodeURIComponent(targetId)}/qa-checklist`,
+        {
+          headers: actorHeaders,
+          data: {
+            amountVerified: true,
+            receiptVerified: true,
+            journalPrepared: true,
+            projectLinked: true,
+            budgetChecked: true,
+          },
+        },
+      );
+      if (!checklistRes.ok()) {
+        throw new Error(
+          `[e2e] expense checklist failed: ${checklistRes.status()} ${await checklistRes.text()} (target=${targetId})`,
+        );
+      }
+    }
     const actRes = await page.request.post(
       `${apiBase}/approval-instances/${encodeURIComponent(instance.id)}/act`,
       {


### PR DESCRIPTION
## 概要
- 経費一次チェック用の `ExpenseQaChecklist` モデルを追加し、API（取得/更新）を実装
- `approval-instances/:id/act` で expense の `pending_qa` 承認時にチェックリスト完了を必須化
- エラーレスポンス `EXPENSE_QA_CHECKLIST_REQUIRED` を追加
- 関連E2E・unit test・OpenAPI・要件ドキュメントを更新

## 変更内容
- DB: `ExpenseQaChecklist` テーブル追加（migration + Prisma schema）
- API:
  - `GET /expenses/:id/qa-checklist`
  - `PUT /expenses/:id/qa-checklist`
- Approval guard:
  - expense の `pending_qa` で approve 実行時、5項目未完了なら 409 でブロック
- Tests:
  - backend unit: `expenseQaChecklist` ヘルパー
  - backend schema: QAチェックリストPATCH schema
  - e2e:
    - `backend-approval-flow` に未完了時ブロック→完了後承認を追加
    - 既存の approval ヘルパー/manual checklist を QAチェックリスト前提に更新

## 検証
- `npm run lint --prefix packages/backend`
- `npm run lint --prefix packages/frontend`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public npm run test --prefix packages/backend`
- `npm run typecheck --prefix packages/frontend`
- `E2E_SCOPE=core E2E_GREP="approval flow: expense requires qa stage before exec stage" E2E_CAPTURE=0 ./scripts/e2e-frontend.sh`
- `E2E_SCOPE=core E2E_GREP="dashboard notification cards route to chat/leave/expense targets" E2E_CAPTURE=0 ./scripts/e2e-frontend.sh`
- `E2E_SCOPE=extended E2E_GREP="backend manual checklist: members/vendors/time/expenses/wellbeing" E2E_CAPTURE=0 ./scripts/e2e-frontend.sh`
- `node scripts/export-openapi.mjs --out tmp/openapi.json` + `docs/api/openapi.json` 同期

## 関連
- refs #1155
