### PR TITLE
chore: eslint10 readiness の #914 ステータス同期を追加

### DIFF
--- a/.github/workflows/eslint10-readiness-watch.yml
+++ b/.github/workflows/eslint10-readiness-watch.yml
@@ -63,6 +63,41 @@ jobs:
             echo "\`make eslint10-readiness-check\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Sync issue #914 status comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          READY: ${{ steps.check.outputs.ready }}
+          PLUGIN_PEER: ${{ steps.check.outputs.plugin_peer }}
+          PARSER_PEER: ${{ steps.check.outputs.parser_peer }}
+          REACT_PLUGIN_PEER: ${{ steps.check.outputs.react_plugin_peer }}
+          REACT_HOOKS_PLUGIN_PEER: ${{ steps.check.outputs.react_hooks_plugin_peer }}
+        run: |
+          marker="<!-- eslint10-readiness-status -->"
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          now="$(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+          body="$(cat <<EOF
+          eslint@10 readiness 週次監視（自動更新）
+
+          - 実行時刻: ${now}
+          - ready: \`${READY}\`
+          - @typescript-eslint/eslint-plugin peer: \`${PLUGIN_PEER}\`
+          - @typescript-eslint/parser peer: \`${PARSER_PEER}\`
+          - eslint-plugin-react peer: \`${REACT_PLUGIN_PEER}\`
+          - eslint-plugin-react-hooks peer: \`${REACT_HOOKS_PLUGIN_PEER}\`
+
+          workflow run: ${run_url}
+          ${marker}
+          EOF
+          )"
+
+          existing_id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/914/comments" --paginate --jq '.[] | select(.user.login=="github-actions[bot]") | select(.body | contains("<!-- eslint10-readiness-status -->")) | .id' | tail -n1)"
+
+          if [[ -n "${existing_id}" ]]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" -f body="${body}" >/dev/null
+          else
+            gh issue comment 914 --body "${body}" >/dev/null
+          fi
+
       - name: Notify issue #914 when ready
         if: steps.check.outputs.ready == 'true'
         env:


### PR DESCRIPTION
## 概要
- `.github/workflows/eslint10-readiness-watch.yml` に Issue #914 の状態サマリ同期ステップを追加
  - `github-actions[bot]` コメントを1件に集約し、毎週の readiness 結果を上書き更新
  - 記録内容: `ready`, 各 plugin/parser の peer 範囲、workflow run URL
- 既存の `ready=true` 通知ロジックは維持

## 背景
- #914 は定期確認コメントが増えやすく、最新状態の参照性が低下していたため。
- #1153 と同様に「定点ステータスを1コメントに同期」する運用へ寄せる。

## テスト
- workflow 変更のため静的変更のみ（ローカル実行なし）

Refs #914
