### PR TITLE
fix: Dependabot watch コメントの空値を UNKNOWN に統一

### DIFF
--- a/.github/workflows/dependabot-alert-watch.yml
+++ b/.github/workflows/dependabot-alert-watch.yml
@@ -33,7 +33,7 @@ jobs:
           extract() {
             local key="$1"
             local value
-            value="$(grep -E "^${key}:" tmp/dependabot-alert-watch.log | tail -n1 | sed "s/^${key}:[[:space:]]*//" || true)"
+            value="$(grep -E "^${key}:" tmp/dependabot-alert-watch.log | tail -n1 | sed "s/^${key}:[[:space:]]*//")"
             if [[ -z "${value}" ]]; then
               echo "UNKNOWN"
             else


### PR DESCRIPTION
## 概要
- `.github/workflows/dependabot-alert-watch.yml` の `extract` にフォールバックを追加し、キー未抽出時は `UNKNOWN` を出力
- #1153 の自動ステータスコメントに `script status` を追加

## 背景
- 手動実行（run: 22251907738）で #1153 の自動コメント値が空になるケースを確認したため。
- 値欠落時でも空文字を残さず、監視失敗/抽出失敗を判別可能にする。

## テスト
- workflow 変更のため静的変更のみ（ローカル実行なし）

Refs #1153
