### PR TITLE
fix(ci): eslint readiness 失敗時に #914 を BLOCKED 表示で同期

### DIFF
--- a/.github/workflows/eslint10-readiness-watch.yml
+++ b/.github/workflows/eslint10-readiness-watch.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Warn when check script failed
         if: steps.check.outputs.status != '0'
         run: |
-          echo "::warning title=eslint10 readiness check::check script failed (status=${{ steps.check.outputs.status }}). Issue #914 status comment is marked as BLOCKED."
+          echo "::warning title=eslint10 readiness check::check script failed (status=${{ steps.check.outputs.status }}). Issue #914 status comment will be attempted to be marked as BLOCKED by the following sync step."
 
       - name: Sync issue #914 status comment
         env:
@@ -116,7 +116,7 @@ jobs:
               "- 実行時刻: ${now}" \
               "- status: \`BLOCKED\`" \
               "- script status: \`${CHECK_STATUS}\`" \
-              "- note: チェックスクリプトが失敗したため、再開判定の同期をスキップしました（詳細は workflow ログ/artifact を参照）。" \
+              "- note: チェックスクリプトが失敗したため、再開判定の詳細取得/評価に失敗し、詳細の更新を省略しました（詳細は workflow ログ/artifact を参照）。" \
               "" \
               "workflow run: ${run_url}" \
               "${marker}" \


### PR DESCRIPTION
## 概要
`eslint10-readiness-watch` の失敗時可観測性を改善し、#914 のステータスコメントを stale にしないようにします。

## 変更内容
- `.github/workflows/eslint10-readiness-watch.yml`
  - `Sync issue #914 status comment` を成功/失敗の単一stepに統合
  - `script status != 0` の場合、#914 の marker コメントを `BLOCKED` として更新
  - warning 文言を `BLOCKED` 同期前提に修正
  - `Notify issue #914 when ready` に `status == 0` 条件を追加

## 動作確認
- workflow_dispatch（branch）: https://github.com/itdojp/ITDO_ERP4/actions/runs/22253159937
  - `Check eslint@10 readiness`: success
  - `Sync issue`: success
  - `Warn when check script failed`: skipped（status=0）
- ローカル: `./scripts/check-eslint10-readiness.sh`（ready: false）

## 期待効果
- 監視失敗時でも #914 に最新runへの導線が残り、運用判断が容易になります。
