### PR TITLE
fix(ci): Dependabot監視失敗の reason を #1153 に明示

### DIFF
--- a/.github/workflows/dependabot-alert-watch.yml
+++ b/.github/workflows/dependabot-alert-watch.yml
@@ -70,8 +70,8 @@ jobs:
               echo "INVALID_REPOSITORY"
               return
             fi
-            if grep -qi 'No such file or directory' tmp/dependabot-alert-watch.log; then
-              echo "FILE_NOT_FOUND"
+            if grep -q 'No such file or directory' tmp/dependabot-alert-watch.log; then
+              echo "NO_SUCH_FILE_OR_DIRECTORY"
               return
             fi
             echo "UNKNOWN_FAILURE"
@@ -116,7 +116,7 @@ jobs:
             echo "| upstream updated | \`${{ steps.check.outputs.upstream_updated }}\` |"
             echo "| action required | \`${{ steps.check.outputs.action_required }}\` |"
             echo "| script status | \`${{ steps.check.outputs.status }}\` |"
-            echo "| failure reason | \`${{ steps.check.outputs.failure_reason }}\` |"
+            echo "| result reason | \`${{ steps.check.outputs.failure_reason }}\` |"
             echo ""
             echo "Manual check command:"
             echo "\`make dependabot-alerts-check\`"
@@ -185,7 +185,7 @@ jobs:
               "- 実行時刻: ${now}" \
               "- status: \`BLOCKED\`" \
               "- script status: \`${CHECK_STATUS}\`" \
-              "- failure reason: \`${FAILURE_REASON}\`" \
+              "- result reason: \`${FAILURE_REASON}\`" \
               "- note: チェックスクリプトが失敗したため、#1153 の状態同期をスキップしました。" \
               "- action: ${action_message}" \
               "" \

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -45,7 +45,7 @@
   - bot ステータスコメントは毎回更新する
   - `script status == 0` のときは alert詳細をコメントし、Issue状態同期も実行する
   - `script status != 0` のときは warning を出し、botステータスコメントを `BLOCKED` として更新する（Issue状態同期は行わない）
-  - `failure reason` を併記し、`PERMISSION_DENIED` の場合は `DEPENDABOT_ALERTS_TOKEN` 設定を優先確認する
+  - `result reason`（失敗時理由コード）を併記し、`PERMISSION_DENIED` の場合は `DEPENDABOT_ALERTS_TOKEN` 設定を優先確認する
   - `actionRequired=true` または alert `#10` が `OPEN` の場合は open を維持（closed なら再オープン）
   - alert `#10` が `OPEN` でなく `actionRequired=false` の場合は自動クローズ
 


### PR DESCRIPTION
## 概要
Dependabot watch の失敗時診断を強化し、#1153 の marker コメントに失敗理由を明示します。

## 変更内容
- `.github/workflows/dependabot-alert-watch.yml`
  - `failure_reason` をログから分類して `GITHUB_OUTPUT` に追加
    - `PERMISSION_DENIED` / `MISSING_GH` / `MISSING_NPM` / `MISSING_NODE` / `MISSING_JQ` / `INVALID_REPOSITORY` / `FILE_NOT_FOUND` / `UNKNOWN_FAILURE`
  - summary に `failure reason` 行を追加
  - warning 文言を `failure_reason` に応じて分岐
  - #1153 の status comment に `failure reason` を追加
  - `PERMISSION_DENIED` 時は action を token/権限確認に特化
- `docs/security/supply-chain.md`
  - `failure reason` 運用を追記

## 動作確認
- ローカル: `make dependabot-alerts-check`（OK）
- workflow_dispatch（branch）:
  - run: https://github.com/itdojp/ITDO_ERP4/actions/runs/22253238049
  - #1153 marker comment に以下を確認
    - `status: BLOCKED`
    - `failure reason: PERMISSION_DENIED`

## 期待効果
- 失敗時の初動が速くなり、`DEPENDABOT_ALERTS_TOKEN` 設定漏れとその他障害を切り分けやすくなります。
