### PR TITLE
test(expense): expand hasReceipt coverage for attachment-only evidence

### DIFF
--- a/packages/backend/test/expenseSchema.test.js
+++ b/packages/backend/test/expenseSchema.test.js
@@ -96,6 +96,26 @@ test('expenseSchema: keeps backward-compatible lines payload', async () => {
   await app.close();
 });
 
+test('expenseSchema: accepts null receiptUrl payload for backward compatibility', async () => {
+  const app = await buildValidatorServer('/validate/expense', expenseSchema);
+  const res = await app.inject({
+    method: 'POST',
+    url: '/validate/expense',
+    payload: {
+      projectId: 'project-1',
+      userId: 'user-1',
+      category: 'travel',
+      amount: 1000,
+      currency: 'JPY',
+      incurredOn: '2026-02-19',
+      receiptUrl: null,
+    },
+  });
+
+  assert.equal(res.statusCode, 200);
+  await app.close();
+});
+
 test('expenseCommentCreateSchema: accepts kind/body', async () => {
   const app = await buildValidatorServer(
     '/validate/comment',
@@ -323,6 +343,45 @@ test('buildExpenseCreateDraft: validates amount even when lines are omitted', ()
   assert.equal(result.error.message, 'amount is invalid');
 });
 
+test('buildExpenseCreateDraft: normalizes blank receiptUrl to null', () => {
+  const result = buildExpenseCreateDraft({
+    body: {
+      projectId: 'project-1',
+      userId: 'user-1',
+      category: 'travel',
+      amount: 1000,
+      currency: 'JPY',
+      incurredOn: '2026-02-19',
+      receiptUrl: '   ',
+    },
+    actorUserId: 'user-1',
+  });
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.sanitizedBody.receiptUrl, null);
+});
+
+test('buildExpenseCreateDraft: trims receiptUrl when provided', () => {
+  const result = buildExpenseCreateDraft({
+    body: {
+      projectId: 'project-1',
+      userId: 'user-1',
+      category: 'travel',
+      amount: 1000,
+      currency: 'JPY',
+      incurredOn: '2026-02-19',
+      receiptUrl: ' https://example.com/receipt.pdf ',
+    },
+    actorUserId: 'user-1',
+  });
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(
+    result.sanitizedBody.receiptUrl,
+    'https://example.com/receipt.pdf',
+  );
+});
+
 test('hasExpenseSubmitEvidence: true when receiptUrl exists', () => {
   const ok = hasExpenseSubmitEvidence({
     receiptUrl: 'https://example.com/legacy-receipt.pdf',
@@ -364,6 +423,24 @@ test('applyExpenseHasReceiptFilter: hasReceipt=true adds receipt-or-attachment c
   });
 });
 
+test('applyExpenseHasReceiptFilter: hasReceipt=true keeps existing AND conditions', () => {
+  const where = { AND: [{ status: 'approved' }] };
+  applyExpenseHasReceiptFilter(where, true);
+  assert.deepEqual(where, {
+    AND: [
+      { status: 'approved' },
+      {
+        OR: [
+          {
+            AND: [{ receiptUrl: { not: null } }, { receiptUrl: { not: '' } }],
+          },
+          { attachments: { some: {} } },
+        ],
+      },
+    ],
+  });
+});
+
 test('applyExpenseHasReceiptFilter: hasReceipt=false keeps existing AND and appends none condition', () => {
   const where = { AND: [{ status: 'approved' }] };
   applyExpenseHasReceiptFilter(where, false);
@@ -386,6 +463,34 @@ test('applyExpensePaidAtDateRangeFilter: applies paidFrom/paidTo with paidTo exc
   assert.deepEqual(where, {
     paidAt: {
       gte: new Date('2026-02-01T00:00:00.000Z'),
+      lt: new Date('2026-03-01T00:00:00.000Z'),
+    },
+  });
+});
+
+test('applyExpensePaidAtDateRangeFilter: applies paidFrom only', () => {
+  const where = {};
+  applyExpensePaidAtDateRangeFilter(
+    where,
+    new Date('2026-02-01T00:00:00.000Z'),
+    null,
+  );
+  assert.deepEqual(where, {
+    paidAt: {
+      gte: new Date('2026-02-01T00:00:00.000Z'),
+    },
+  });
+});
+
+test('applyExpensePaidAtDateRangeFilter: applies paidTo only with exclusive bound', () => {
+  const where = {};
+  applyExpensePaidAtDateRangeFilter(
+    where,
+    null,
+    new Date('2026-02-28T00:00:00.000Z'),
+  );
+  assert.deepEqual(where, {
+    paidAt: {
       lt: new Date('2026-03-01T00:00:00.000Z'),
     },
   });

--- a/packages/frontend/e2e/backend-expense-list-has-receipt-boolean-query.spec.ts
+++ b/packages/frontend/e2e/backend-expense-list-has-receipt-boolean-query.spec.ts
@@ -37,7 +37,10 @@ test('expense list hasReceipt query accepts true/false and 1/0 forms @core', asy
   const suffix = runId();
   const expenseUserId = `e2e-expense-receipt-query-${suffix}@example.com`;
 
-  const createExpense = async (withReceipt: boolean) => {
+  const createExpense = async (input: {
+    withReceipt: boolean;
+    withAttachment?: boolean;
+  }) => {
     const createRes = await request.post(`${apiBase}/expenses`, {
       headers: adminHeaders,
       data: {
@@ -47,9 +50,21 @@ test('expense list hasReceipt query accepts true/false and 1/0 forms @core', asy
         amount: 1000,
         currency: 'JPY',
         incurredOn: '2026-04-01',
-        ...(withReceipt
+        ...(input.withReceipt
           ? {
               receiptUrl: `https://example.com/e2e/receipt-query-${suffix}.pdf`,
+            }
+          : {}),
+        ...(input.withAttachment
+          ? {
+              attachments: [
+                {
+                  fileUrl: `https://example.com/e2e/receipt-query-attachment-${suffix}.pdf`,
+                  fileName: `receipt-query-attachment-${suffix}.pdf`,
+                  contentType: 'application/pdf',
+                  fileSizeBytes: 2048,
+                },
+              ],
             }
           : {}),
       },
@@ -61,8 +76,12 @@ test('expense list hasReceipt query accepts true/false and 1/0 forms @core', asy
     return expenseId;
   };
 
-  const withReceiptId = await createExpense(true);
-  const withoutReceiptId = await createExpense(false);
+  const withReceiptId = await createExpense({ withReceipt: true });
+  const withAttachmentOnlyId = await createExpense({
+    withReceipt: false,
+    withAttachment: true,
+  });
+  const withoutReceiptId = await createExpense({ withReceipt: false });
 
   const fetchIds = async (hasReceipt: string) => {
     const res = await request.get(
@@ -73,18 +92,22 @@ test('expense list hasReceipt query accepts true/false and 1/0 forms @core', asy
     );
     await ensureOk(res);
     const payload = await res.json();
-    return new Set((payload?.items ?? []).map((item: any) => String(item?.id ?? '')));
+    return new Set(
+      (payload?.items ?? []).map((item: any) => String(item?.id ?? '')),
+    );
   };
 
   for (const queryValue of ['true', '1']) {
     const ids = await fetchIds(queryValue);
     expect(ids.has(withReceiptId)).toBe(true);
+    expect(ids.has(withAttachmentOnlyId)).toBe(true);
     expect(ids.has(withoutReceiptId)).toBe(false);
   }
 
   for (const queryValue of ['false', '0']) {
     const ids = await fetchIds(queryValue);
     expect(ids.has(withReceiptId)).toBe(false);
+    expect(ids.has(withAttachmentOnlyId)).toBe(false);
     expect(ids.has(withoutReceiptId)).toBe(true);
   }
 


### PR DESCRIPTION
## 概要
- `GET /expenses` の `hasReceipt` フィルタについて、`receiptUrl` だけでなく `attachments` のみ証憑でも `true/1` に含まれることを E2E で明示的に検証
- 経費ヘルパーの単体テストを追加し、`receiptUrl` 正規化（空白→`null`/trim）と `paidFrom`/`paidTo` 片側指定の境界条件をカバー
- `applyExpenseHasReceiptFilter` が既存 `AND` 条件を維持することを追加検証

## 変更ファイル
- `packages/frontend/e2e/backend-expense-list-has-receipt-boolean-query.spec.ts`
- `packages/backend/test/expenseSchema.test.js`

## テスト
- `npm run test --prefix packages/backend`
- `npm run typecheck --prefix packages/frontend`
- `npm run lint --prefix packages/frontend`
- `E2E_CAPTURE=0 E2E_GREP="hasReceipt query accepts" ./scripts/e2e-frontend.sh`
