### PR TITLE
test(integration): 再試行戦略と失敗時挙動の自動検証を追加

### DIFF
--- a/docs/requirements/hr-crm-integration.md
+++ b/docs/requirements/hr-crm-integration.md
@@ -114,6 +114,12 @@
 - 失敗理由を監査ログに残す
 
 ## 運用検証（手順）
+### 自動テスト（backend integration）
+- `packages/backend/test/integrationRetryRoutes.test.js`
+  - `/jobs/integrations/run` が `nextRetryAt <= now` かつ `retryCount < retryMax` の失敗 run のみ再実行すること
+  - `simulateFailure=true` 時に `retryCount` と `nextRetryAt`（指数バックオフ）が更新されること
+  - `status=disabled` の setting が `/integration-settings/:id/run` で拒否されること
+
 ### 手動実行
 - `/integration-settings/:id/run` を実行し、`integration_runs` に status=success が記録されることを確認。
 - `metrics` に件数（CRM指標: customers/vendors/contacts、HR指標: users/wellbeing）が入ることを確認。

--- a/packages/backend/test/integrationRetryRoutes.test.js
+++ b/packages/backend/test/integrationRetryRoutes.test.js
@@ -1,0 +1,228 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildServer } from '../dist/server.js';
+import { prisma } from '../dist/services/db.js';
+
+const MIN_DATABASE_URL = 'postgresql://user:pass@localhost:5432/postgres';
+
+function withPrismaStubs(stubs, fn) {
+  const restores = [];
+  for (const [path, stub] of Object.entries(stubs)) {
+    const [model, method] = path.split('.');
+    const target = prisma[model];
+    if (!target || typeof target[method] !== 'function') {
+      throw new Error(`invalid stub target: ${path}`);
+    }
+    const original = target[method];
+    target[method] = stub;
+    restores.push(() => {
+      target[method] = original;
+    });
+  }
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => {
+      for (const restore of restores.reverse()) restore();
+    });
+}
+
+test('POST /jobs/integrations/run retries eligible failed runs and skips over-limit runs', async () => {
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+
+  const retryEligibleRun = {
+    id: 'run-retry-eligible',
+    settingId: 'setting-crm-1',
+    status: 'failed',
+    retryCount: 0,
+    nextRetryAt: new Date('2026-02-23T18:00:00.000Z'),
+    setting: {
+      id: 'setting-crm-1',
+      type: 'crm',
+      config: { retryMax: 2, retryBaseMinutes: 5 },
+    },
+  };
+  const overLimitRun = {
+    id: 'run-retry-over-limit',
+    settingId: 'setting-crm-2',
+    status: 'failed',
+    retryCount: 2,
+    nextRetryAt: new Date('2026-02-23T18:00:00.000Z'),
+    setting: {
+      id: 'setting-crm-2',
+      type: 'crm',
+      config: { retryMax: 2, retryBaseMinutes: 5 },
+    },
+  };
+
+  const integrationRunUpdateCalls = [];
+  const integrationSettingUpdateCalls = [];
+
+  await withPrismaStubs(
+    {
+      'integrationRun.findMany': async () => [retryEligibleRun, overLimitRun],
+      'integrationRun.update': async (args) => {
+        integrationRunUpdateCalls.push(args);
+        const data = args?.data || {};
+        return {
+          id: args?.where?.id,
+          status: data.status || 'running',
+          retryCount: data.retryCount ?? 0,
+        };
+      },
+      'integrationSetting.findMany': async () => [],
+      'integrationSetting.update': async (args) => {
+        integrationSettingUpdateCalls.push(args);
+        return { id: args?.where?.id };
+      },
+      'customer.count': async () => 3,
+      'vendor.count': async () => 2,
+      'contact.count': async () => 1,
+      'alertSetting.findMany': async () => [],
+      'alert.updateMany': async () => ({ count: 0 }),
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/jobs/integrations/run',
+          headers: {
+            'x-user-id': 'admin-user',
+            'x-roles': 'admin',
+          },
+        });
+        assert.equal(res.statusCode, 200, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body.ok, true);
+        assert.equal(body.retryCount, 1);
+        assert.equal(body.scheduledCount, 0);
+        assert.deepEqual(body.retries, [
+          { id: retryEligibleRun.id, status: 'success' },
+        ]);
+      } finally {
+        await server.close();
+      }
+    },
+  );
+
+  const retryRunIds = new Set(
+    integrationRunUpdateCalls.map((call) => String(call?.where?.id ?? '')),
+  );
+  assert.equal(retryRunIds.has(retryEligibleRun.id), true);
+  assert.equal(retryRunIds.has(overLimitRun.id), false);
+
+  const eligibleStatusUpdates = integrationRunUpdateCalls
+    .filter((call) => call?.where?.id === retryEligibleRun.id)
+    .map((call) => String(call?.data?.status ?? ''));
+  assert.deepEqual(eligibleStatusUpdates, ['running', 'success']);
+  assert.equal(integrationSettingUpdateCalls.length, 1);
+  assert.equal(integrationSettingUpdateCalls[0]?.where?.id, 'setting-crm-1');
+});
+
+test('POST /integration-settings/:id/run sets retry metadata with exponential backoff on failure', async () => {
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+
+  const setting = {
+    id: 'setting-failed-run',
+    type: 'crm',
+    status: 'active',
+    config: {
+      simulateFailure: true,
+      retryMax: 3,
+      retryBaseMinutes: 5,
+    },
+  };
+
+  let failedUpdateCall = null;
+
+  await withPrismaStubs(
+    {
+      'integrationSetting.findUnique': async () => setting,
+      'integrationRun.create': async () => ({
+        id: 'run-failed-once',
+        retryCount: 0,
+      }),
+      'integrationRun.update': async (args) => {
+        failedUpdateCall = args;
+        return {
+          id: 'run-failed-once',
+          status: args?.data?.status,
+          retryCount: args?.data?.retryCount ?? 0,
+          nextRetryAt: args?.data?.nextRetryAt ?? null,
+          message: args?.data?.message ?? null,
+        };
+      },
+      'integrationSetting.update': async () => ({ id: setting.id }),
+      'alertSetting.findMany': async () => [],
+      'alert.updateMany': async () => ({ count: 0 }),
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      const before = Date.now();
+      try {
+        const res = await server.inject({
+          method: 'POST',
+          url: `/integration-settings/${encodeURIComponent(setting.id)}/run`,
+          headers: {
+            'x-user-id': 'admin-user',
+            'x-roles': 'admin',
+          },
+        });
+        assert.equal(res.statusCode, 200, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body.status, 'failed');
+        assert.equal(body.retryCount, 1);
+        assert.equal(body.message, 'simulate_failure');
+        assert.equal(typeof body.nextRetryAt, 'string');
+        const nextRetryMs = new Date(body.nextRetryAt).getTime();
+        const expectedMs = 5 * 60 * 1000;
+        // Allow small timing jitter around request execution time.
+        assert.ok(nextRetryMs >= before + expectedMs - 2000);
+        assert.ok(nextRetryMs <= Date.now() + expectedMs + 2000);
+      } finally {
+        await server.close();
+      }
+    },
+  );
+
+  assert.equal(String(failedUpdateCall?.data?.status ?? ''), 'failed');
+  assert.equal(Number(failedUpdateCall?.data?.retryCount ?? 0), 1);
+  assert.ok(failedUpdateCall?.data?.nextRetryAt instanceof Date);
+});
+
+test('POST /integration-settings/:id/run returns 409 when setting is disabled', async () => {
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+
+  await withPrismaStubs(
+    {
+      'integrationSetting.findUnique': async () => ({
+        id: 'setting-disabled',
+        status: 'disabled',
+        type: 'crm',
+        config: {},
+      }),
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/integration-settings/setting-disabled/run',
+          headers: {
+            'x-user-id': 'admin-user',
+            'x-roles': 'admin',
+          },
+        });
+        assert.equal(res.statusCode, 409, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(String(body?.error?.code ?? ''), 'disabled');
+      } finally {
+        await server.close();
+      }
+    },
+  );
+});


### PR DESCRIPTION
## 概要
Issue #1207（Integration Hub 拡張）のうち、再試行戦略・失敗時挙動の自動検証を backend integration test として追加しました。

## 変更内容
- `packages/backend/test/integrationRetryRoutes.test.js` を追加
  - `POST /jobs/integrations/run`
    - `nextRetryAt <= now` かつ `retryCount < retryMax` の失敗 run のみ再試行すること
    - `retryCount >= retryMax` の run を再試行しないこと
  - `POST /integration-settings/:id/run`
    - `simulateFailure=true` 時に `retryCount` と `nextRetryAt`（指数バックオフ）が更新されること
    - `status=disabled` の setting で 409 を返すこと
- `docs/requirements/hr-crm-integration.md` を更新
  - 上記自動テストの観点を「運用検証（手順）」に追加

## テスト
- `npm run lint --prefix packages/backend`
- `npm run test --prefix packages/backend -- test/integrationRetryRoutes.test.js`

Refs #1207
