### PR TITLE
test: cover draft generation in agent-first MVP e2e flow

### DIFF
--- a/packages/frontend/e2e/backend-agent-first-mvp.spec.ts
+++ b/packages/frontend/e2e/backend-agent-first-mvp.spec.ts
@@ -266,6 +266,8 @@ test('agent mvp: 請求ドラフト生成→承認→送信の通しが成立す
   await ensureOk(regenerateRes);
   const regeneratedDraft = await regenerateRes.json();
   expect(regeneratedDraft?.kind).toBe('invoice_send');
+  expect(typeof regeneratedDraft?.draft?.subject).toBe('string');
+  expect(typeof regeneratedDraft?.draft?.body).toBe('string');
   expect(Number(regeneratedDraft?.diff?.changeCount ?? 0)).toBeGreaterThan(0);
 
   const submitRes = await request.post(


### PR DESCRIPTION
## 概要
Issue #1206 の E2E要件（請求ドラフト生成→承認→送信）に合わせ、`backend-agent-first-mvp` シナリオを拡張しました。

> このPRは #1227（Draft API実装）に依存する stacked PR です。

## 変更内容
- `packages/frontend/e2e/backend-agent-first-mvp.spec.ts` を更新
  - `POST /drafts` で `invoice_send` ドラフト生成を実施
  - `POST /drafts/regenerate` で再生成と差分確認を実施
  - 既存の submit → approval → send フローを継続
  - 監査ログ `draft_generated` / `draft_regenerated` を確認

## 確認
- `npm run e2e --prefix packages/frontend -- --list e2e/backend-agent-first-mvp.spec.ts`
- `npx prettier --check packages/frontend/e2e/backend-agent-first-mvp.spec.ts`
- `npm run lint --prefix packages/frontend`
