### PR TITLE
test+docs: issue1236のPhase0/1/4を先行実施

### DIFF
--- a/docs/manual/manual-test-checklist.md
+++ b/docs/manual/manual-test-checklist.md
@@ -18,6 +18,17 @@
 - [x] POST/GET/PATCH /report-subscriptions → /report-subscriptions/:id/run で report_deliveries が作成される
 - [x] /jobs/report-subscriptions/run と /jobs/report-deliveries/retry が動作する
 
+### Agent-First ガードレール（自動テスト参照）
+
+- [x] `ACTION_POLICY_ENFORCEMENT_PRESET=phase2_core` で send 系が policy 未定義時に拒否される（`ACTION_POLICY_DENIED`）
+  - 参照: `packages/backend/test/sendPolicyEnforcementPreset.test.js`
+- [x] send 系で承認不足/証跡不足が拒否される（`APPROVAL_REQUIRED` / `EVIDENCE_REQUIRED`）
+  - 参照: `packages/backend/test/sendPolicyEnforcementPreset.test.js`, `packages/backend/test/approvalEvidenceGate.test.js`
+- [x] 承認アクション（`/approval-instances/:id/act`）で preset 強制時に policy 未定義拒否となる
+  - 参照: `packages/backend/test/approvalActionPolicyPreset.test.js`
+- [x] `ACTION_POLICY_REQUIRED_ACTIONS` 明示指定が preset より優先される
+  - 参照: `packages/backend/test/sendPolicyEnforcementPreset.test.js`
+
 ### チャット（確認依頼 ack required）
 
 - [x] GET /projects/:projectId/chat-ack-candidates?q= で候補（users/groups）が取得できる（q は2文字以上）

--- a/docs/quality/agent-first-mvp-test-plan.md
+++ b/docs/quality/agent-first-mvp-test-plan.md
@@ -13,6 +13,7 @@ Issue #1200 で定義した MVP 受け入れ条件を、自動テストで再現
 | --- | --- | --- |
 | UI非依存で Project/Billing の状況を説明できる | `project-360` / `billing-360` を API 呼び出しで取得し、主要サマリを検証する | `packages/frontend/e2e/backend-agent-first-mvp.spec.ts`（`agent read api: ...`） |
 | 請求ドラフト生成→承認→送信を理由・証跡付きで追跡できる | 請求作成（draft）→ submit → approval approve → send を通し実行し、send log と承認監査を確認する | `packages/frontend/e2e/backend-agent-first-mvp.spec.ts`（`agent mvp: ...`） |
+| ガードレール違反時に標準エラーで拒否される | policy未定義/承認不足/証跡不足/理由不足を拒否し、エラーコードが一貫していることを確認する | backend route/integration: `packages/backend/test/sendPolicyEnforcementPreset.test.js`, `packages/backend/test/approvalActionPolicyPreset.test.js`, `packages/backend/test/approvalEvidenceGate.test.js`, `packages/backend/test/actionPolicyErrors.test.js` |
 | エージェント実行を監査から再現できる（権限主体・根拠・実行API） | 監査ログの `_request.id` / `_request.source` / `_auth.principalUserId` / `_auth.actorUserId` を検証する | E2E: `packages/frontend/e2e/backend-agent-first-mvp.spec.ts` + backend integration: `packages/backend/test/auditContextAgent.test.js`, `packages/backend/test/authDelegated.test.js` |
 
 ## 実行コマンド
@@ -20,6 +21,9 @@ Issue #1200 で定義した MVP 受け入れ条件を、自動テストで再現
 ```bash
 # backend integration
 npm run test:ci --prefix packages/backend -- test/agent360Routes.test.js test/authDelegated.test.js test/auditContextAgent.test.js
+
+# backend guardrail negative cases
+npm run test --prefix packages/backend -- test/sendPolicyEnforcementPreset.test.js test/approvalActionPolicyPreset.test.js test/approvalEvidenceGate.test.js test/actionPolicyErrors.test.js
 
 # e2e（対象シナリオのみ）
 E2E_SCOPE=core E2E_GREP="agent read api|agent mvp" E2E_CAPTURE=0 ./scripts/e2e-frontend.sh

--- a/docs/quality/test-gaps.md
+++ b/docs/quality/test-gaps.md
@@ -15,6 +15,19 @@
 - B: 重要だが当面は手動/限定範囲で許容（段階導入）
 - C: 改善/拡張（後回しでよい）
 
+## A優先の再分類（2026-02-24）
+
+`#1236` の実施開始時点で、A優先のうち「着手対象」を以下に固定する。
+
+| 項目 | 現状 | 不足ケース（次PRで消し込む対象） |
+| --- | --- | --- |
+| Phase2 send系ガード（preset + policy + approval/evidence） | 部分実装 | `EVIDENCE_REQUIRED` の route-level 検証、explicit env が preset より優先される境界 |
+| 承認アクションガード（approve/reject） | 部分実装 | `phase2_core` と explicit env の組合せ境界を追加 |
+| Agent-First E2E（失敗系） | 未実装 | 承認不足/証跡不足/理由不足の拒否シナリオをAPI通しで検証 |
+| manual-test-checklist と自動テスト対応 | 部分実装 | Agent-First失敗系の自動テスト参照を明示 |
+| #543 preflight（入力不足/形式不正） | 未実装 | `check-po-migration-input-readiness.sh` の主要失敗分岐を自動テスト化 |
+| #544 readiness（前提不足時の失敗理由） | 未実装 | `check-backup-s3-readiness.sh` の前提検証をモック化して自動テスト化 |
+
 ## 領域別の整理（現状）
 
 | 領域                    | 代表シナリオ                                                                 | 現状の自動テスト                                                                                                                                                                                                                                                                                                                                                | 優先度 | 次の一手                                                           |

--- a/docs/requirements/action-policy-high-risk-apis.md
+++ b/docs/requirements/action-policy-high-risk-apis.md
@@ -105,6 +105,7 @@ Phase 2 で先行する Draft は以下を対象とする。
 
 - `approval_open` 系 guard 失敗は `APPROVAL_REQUIRED` に正規化する。
 - それ以外の policy deny は `ACTION_POLICY_DENIED` に統一する。
+- `REASON_REQUIRED` の入力項目はエンドポイントで異なる（`/approval-instances/:id/act` は body `reason`、送信系は query `reasonText`）。
 
 ## 6. Approval + Evidence 必須化（段階導入）
 

--- a/packages/backend/test/readinessScripts.test.js
+++ b/packages/backend/test/readinessScripts.test.js
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  chmodSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const ROOT_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../..',
+);
+const SCRIPTS_DIR = path.join(ROOT_DIR, 'scripts');
+
+function runScript(scriptName, env = {}) {
+  const scriptPath = path.join(SCRIPTS_DIR, scriptName);
+  const result = spawnSync('/bin/bash', [scriptPath], {
+    cwd: ROOT_DIR,
+    env: {
+      ...process.env,
+      ...env,
+    },
+    encoding: 'utf8',
+  });
+  return result;
+}
+
+function withTempDir(fn) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'erp4-readiness-'));
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function withFakeAwsBin(fn) {
+  return withTempDir((dir) => {
+    const binDir = path.join(dir, 'bin');
+    const awsPath = path.join(binDir, 'aws');
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(awsPath, '#!/usr/bin/env bash\necho fake-aws >/dev/null\n');
+    chmodSync(awsPath, 0o755);
+    return fn(binDir);
+  });
+}
+
+test('check-po-migration-input-readiness: fails when INPUT_DIR is missing', () => {
+  const res = runScript('check-po-migration-input-readiness.sh', {
+    INPUT_DIR: '',
+  });
+  assert.notEqual(res.status, 0);
+  assert.match(String(res.stderr), /INPUT_DIR is required/);
+});
+
+test('check-po-migration-input-readiness: fails on invalid ONLY scope', () => {
+  withTempDir((dir) => {
+    const res = runScript('check-po-migration-input-readiness.sh', {
+      INPUT_DIR: dir,
+      INPUT_FORMAT: 'csv',
+      ONLY: 'invalid_scope',
+    });
+    assert.notEqual(res.status, 0);
+    assert.match(String(res.stderr), /invalid scope in ONLY/);
+  });
+});
+
+test('check-po-migration-input-readiness: STRICT=0 passes with empty input directory', () => {
+  withTempDir((dir) => {
+    const res = runScript('check-po-migration-input-readiness.sh', {
+      INPUT_DIR: dir,
+      INPUT_FORMAT: 'csv',
+      STRICT: '0',
+    });
+    assert.equal(res.status, 0, `${res.stderr}\n${res.stdout}`);
+    assert.match(String(res.stdout), /preflight completed/);
+  });
+});
+
+test('check-backup-s3-readiness: fails when aws command is missing', () => {
+  const res = runScript('check-backup-s3-readiness.sh', {
+    S3_BUCKET: 'dummy-bucket',
+    PATH: '/non-existent-path',
+  });
+  assert.notEqual(res.status, 0);
+  assert.match(String(res.stderr), /missing command: aws/);
+});
+
+test('check-backup-s3-readiness: validates EXPECT_SSE value before AWS calls', () => {
+  withFakeAwsBin((binDir) => {
+    const res = runScript('check-backup-s3-readiness.sh', {
+      S3_BUCKET: 'dummy-bucket',
+      EXPECT_SSE: 'invalid',
+      PATH: `${binDir}:${process.env.PATH || ''}`,
+    });
+    assert.notEqual(res.status, 0);
+    assert.match(String(res.stderr), /EXPECT_SSE must be one of/);
+  });
+});

--- a/packages/backend/test/sendPolicyEnforcementPreset.test.js
+++ b/packages/backend/test/sendPolicyEnforcementPreset.test.js
@@ -85,6 +85,13 @@ function purchaseOrderDraft() {
   };
 }
 
+function approvalInstanceApproved() {
+  return {
+    id: 'approval-001',
+    status: 'approved',
+  };
+}
+
 test('POST /invoices/:id/send: phase2_core preset denies when policy is missing', async () => {
   await withEnv(
     {
@@ -194,6 +201,125 @@ test('POST /invoices/:id/send: phase2_core requires approval+evidence after poli
             assert.equal(res.statusCode, 403, res.body);
             const payload = JSON.parse(res.body);
             assert.equal(payload?.error?.code, 'APPROVAL_REQUIRED');
+          } finally {
+            await server.close();
+          }
+        },
+      );
+    },
+  );
+});
+
+test('POST /invoices/:id/send: phase2_core returns EVIDENCE_REQUIRED when approval exists without snapshot', async () => {
+  await withEnv(
+    {
+      DATABASE_URL: process.env.DATABASE_URL || MIN_DATABASE_URL,
+      AUTH_MODE: 'header',
+      ACTION_POLICY_ENFORCEMENT_PRESET: 'phase2_core',
+      ACTION_POLICY_REQUIRED_ACTIONS: '',
+      APPROVAL_EVIDENCE_REQUIRED_ACTIONS: '',
+    },
+    async () => {
+      await withPrismaStubs(
+        {
+          'invoice.findUnique': async () => invoiceDraft(),
+          'actionPolicy.findMany': async () => [
+            {
+              id: 'policy-allow-send',
+              flowType: 'invoice',
+              actionKey: 'send',
+              priority: 100,
+              isEnabled: true,
+              subjects: null,
+              stateConstraints: null,
+              requireReason: false,
+              guards: null,
+            },
+          ],
+          'approvalInstance.findFirst': async () => approvalInstanceApproved(),
+          'evidenceSnapshot.findFirst': async () => null,
+        },
+        async () => {
+          const server = await buildServer({ logger: false });
+          try {
+            const res = await server.inject({
+              method: 'POST',
+              url: '/invoices/inv-001/send',
+              headers: adminHeaders(),
+            });
+            assert.equal(res.statusCode, 403, res.body);
+            const payload = JSON.parse(res.body);
+            assert.equal(payload?.error?.code, 'EVIDENCE_REQUIRED');
+          } finally {
+            await server.close();
+          }
+        },
+      );
+    },
+  );
+});
+
+test('POST /invoices/:id/send: explicit ACTION_POLICY_REQUIRED_ACTIONS works even when preset is off', async () => {
+  await withEnv(
+    {
+      DATABASE_URL: process.env.DATABASE_URL || MIN_DATABASE_URL,
+      AUTH_MODE: 'header',
+      ACTION_POLICY_ENFORCEMENT_PRESET: 'off',
+      ACTION_POLICY_REQUIRED_ACTIONS: 'invoice:send',
+      APPROVAL_EVIDENCE_REQUIRED_ACTIONS: 'vendor_invoice:submit',
+    },
+    async () => {
+      await withPrismaStubs(
+        {
+          'invoice.findUnique': async () => invoiceDraft(),
+          'actionPolicy.findMany': async () => [],
+        },
+        async () => {
+          const server = await buildServer({ logger: false });
+          try {
+            const res = await server.inject({
+              method: 'POST',
+              url: '/invoices/inv-001/send',
+              headers: adminHeaders(),
+            });
+            assert.equal(res.statusCode, 403, res.body);
+            const payload = JSON.parse(res.body);
+            assert.equal(payload?.error?.code, 'ACTION_POLICY_DENIED');
+          } finally {
+            await server.close();
+          }
+        },
+      );
+    },
+  );
+});
+
+test('POST /invoices/:id/send: explicit env rules override phase2_core preset', async () => {
+  await withEnv(
+    {
+      DATABASE_URL: process.env.DATABASE_URL || MIN_DATABASE_URL,
+      AUTH_MODE: 'header',
+      ACTION_POLICY_ENFORCEMENT_PRESET: 'phase2_core',
+      ACTION_POLICY_REQUIRED_ACTIONS: 'vendor_invoice:submit',
+      APPROVAL_EVIDENCE_REQUIRED_ACTIONS: 'vendor_invoice:submit',
+    },
+    async () => {
+      await withPrismaStubs(
+        {
+          'invoice.findUnique': async () => invoiceDraft(),
+          'actionPolicy.findMany': async () => [],
+        },
+        async () => {
+          const server = await buildServer({ logger: false });
+          try {
+            const res = await server.inject({
+              method: 'POST',
+              url: '/invoices/inv-001/send?templateId=missing-template',
+              headers: adminHeaders(),
+            });
+            assert.equal(res.statusCode, 404, res.body);
+            const payload = JSON.parse(res.body);
+            assert.equal(payload?.error?.code, 'template_not_found');
           } finally {
             await server.close();
           }


### PR DESCRIPTION
## 概要
Issue #1236 の Phase 0 / Phase 1 / Phase 3(一部) / Phase 4 を先行実施しました。

## 変更内容

### 1) Phase 0: ギャップ再分類
- `docs/quality/test-gaps.md`
  - A優先の再分類セクションを追加
  - 現状ステータス（未実装/部分実装）と不足ケースを固定

### 2) Phase 1: backend テスト拡充
- `packages/backend/test/sendPolicyEnforcementPreset.test.js`
  - `EVIDENCE_REQUIRED`（承認済み・証跡不足）を route-level で検証
  - `ACTION_POLICY_REQUIRED_ACTIONS` の explicit 指定が preset=off でも有効であることを検証
  - explicit env が `phase2_core` preset より優先される境界を検証

### 3) Phase 4: #543/#544 前段品質の自動化
- 追加: `packages/backend/test/readinessScripts.test.js`
  - `check-po-migration-input-readiness.sh`
    - INPUT_DIR未指定
    - invalid ONLY
    - STRICT=0 の空ディレクトリ許容
  - `check-backup-s3-readiness.sh`
    - aws コマンド未導入
    - `EXPECT_SSE` 不正値

### 4) Phase 3: docs 同期（一部）
- `docs/manual/manual-test-checklist.md`
  - Agent-First ガードレールの自動テスト参照を追加
- `docs/quality/agent-first-mvp-test-plan.md`
  - 失敗系（denyコード）検証を追加
- `docs/requirements/action-policy-high-risk-apis.md`
  - `REASON_REQUIRED` の入力項目差（`reason` / `reasonText`）を明記

## 検証
- `npm run test --prefix packages/backend -- test/sendPolicyEnforcementPreset.test.js test/approvalActionPolicyPreset.test.js test/readinessScripts.test.js test/approvalEvidenceGate.test.js test/actionPolicyErrors.test.js`
- `npm run lint --prefix packages/backend`

## Issue
- refs #1236
