### PR TITLE
docs: #1236 完了後の test-gaps 状態同期

### DIFF
--- a/docs/quality/test-gaps.md
+++ b/docs/quality/test-gaps.md
@@ -25,8 +25,8 @@
 | 承認アクションガード（approve/reject） | 部分実装 | `phase2_core` と explicit env の組合せ境界を追加 |
 | Agent-First E2E（失敗系） | 完了 | 承認不足（`APPROVAL_REQUIRED`）/証跡不足（`EVIDENCE_REQUIRED`）/理由不足（`REASON_REQUIRED`）を `packages/frontend/e2e/backend-agent-first-mvp.spec.ts` で検証 |
 | manual-test-checklist と自動テスト対応 | 部分実装 | Agent-First失敗系の自動テスト参照を明示 |
-| #543 preflight（入力不足/形式不正） | 未実装 | `check-po-migration-input-readiness.sh` の主要失敗分岐を自動テスト化 |
-| #544 readiness（前提不足時の失敗理由） | 未実装 | `check-backup-s3-readiness.sh` の前提検証をモック化して自動テスト化 |
+| #543 preflight（入力不足/形式不正） | 完了 | `packages/backend/test/readinessScripts.test.js` で `check-po-migration-input-readiness.sh` の主要失敗分岐（INPUT_DIR未指定 / ONLY不正 / STRICT=0）を自動検証 |
+| #544 readiness（前提不足時の失敗理由） | 完了 | `packages/backend/test/readinessScripts.test.js` で `check-backup-s3-readiness.sh` の主要失敗分岐（aws未導入 / EXPECT_SSE不正）を自動検証 |
 
 ## 領域別の整理（現状）
 


### PR DESCRIPTION
## 概要
- `docs/quality/test-gaps.md` の A優先再分類テーブルを最新化
- #543/#544 の前提待ち以外タスクが完了済みであることを反映

## 変更点
- `#543 preflight` の現状を `未実装 -> 完了` へ更新
- `#544 readiness` の現状を `未実装 -> 完了` へ更新
- 両行に対応テスト (`packages/backend/test/readinessScripts.test.js`) を明記

## 補足
- 実データ移行本体 (#543) と S3確定値反映本体 (#544) は引き続き前提値待ちです。