### PR TITLE
ops: #543 リハーサル実行と記録の一括フローを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint format-check typecheck build test e2e ui-evidence mobile-regression-log frontend-dev-api podman-smoke pr-comments audit design-system-package-check eslint10-readiness-check dependabot-alerts-check dependabot-token-readiness-check backup-s3-readiness-check backup-s3-readiness-record po-migration-input-readiness-check po-migration-record av-staging-evidence av-staging-gate av-staging-readiness
+.PHONY: lint format-check typecheck build test e2e ui-evidence mobile-regression-log frontend-dev-api podman-smoke pr-comments audit design-system-package-check eslint10-readiness-check dependabot-alerts-check dependabot-token-readiness-check backup-s3-readiness-check backup-s3-readiness-record po-migration-input-readiness-check po-migration-record po-migration-run-and-record av-staging-evidence av-staging-gate av-staging-readiness
 
 lint:
 	npm run lint --prefix packages/backend
@@ -66,6 +66,9 @@ po-migration-input-readiness-check:
 
 po-migration-record:
 	./scripts/record-po-migration-rehearsal.sh
+
+po-migration-run-and-record:
+	./scripts/run-and-record-po-migration-rehearsal.sh
 
 av-staging-evidence:
 	./scripts/record-chat-attachments-av-staging.sh

--- a/docs/requirements/migration-runbook.md
+++ b/docs/requirements/migration-runbook.md
@@ -66,6 +66,20 @@ INPUT_DIR=tmp/migration/po INPUT_FORMAT=csv APPLY=1 RUN_INTEGRITY=1 \
 - `packages/backend/dist/services/db.js` が無い場合は事前に `npm run build --prefix packages/backend` が必要。
 - 結果記録テンプレート: `docs/test-results/po-migration-rehearsal-template.md`
 
+### 3.0.1 実行 + 記録を一括で行う（推奨）
+`scripts/run-and-record-po-migration-rehearsal.sh` は、リハーサル実行と `docs/test-results` への記録を一括で行う。
+
+```bash
+INPUT_DIR=tmp/migration/po INPUT_FORMAT=csv APPLY=1 RUN_INTEGRITY=1 \
+  ./scripts/run-and-record-po-migration-rehearsal.sh
+```
+
+補足:
+- `RECORD_ON_FAIL=1`（既定）のため、実行失敗時も記録を残せる。
+- `RUN_LABEL=r1` / `DATE_STAMP=YYYY-MM-DD` / `OUT_DIR=...` で出力先を制御できる。
+- Makefile 経由でも実行可能:
+  - `INPUT_DIR=tmp/migration/po INPUT_FORMAT=csv APPLY=1 RUN_INTEGRITY=1 make po-migration-run-and-record`
+
 ### 3.1 dry-run（DBへ書き込まない）
 ```bash
 npx --prefix packages/backend ts-node --project packages/backend/tsconfig.json scripts/migrate-po.ts \

--- a/docs/test-results/README.md
+++ b/docs/test-results/README.md
@@ -12,6 +12,7 @@
 - 入口: docs/test-results/perf/README.md
 
 ### Template
+- PO移行リハーサル記録テンプレート: docs/test-results/po-migration-rehearsal-template.md
 - S3バックアップ readiness 記録テンプレート: docs/test-results/backup-s3-readiness-template.md
 - チャット添付AV（Staging）検証テンプレート: docs/test-results/chat-attachments-av-staging-template.md
 - DRリストア運用検証テンプレート: docs/test-results/dr-restore-template.md

--- a/packages/backend/test/readinessScripts.test.js
+++ b/packages/backend/test/readinessScripts.test.js
@@ -310,3 +310,125 @@ test('record-po-migration-rehearsal: auto increments run suffix when RUN_LABEL i
     );
   });
 });
+
+test('run-and-record-po-migration-rehearsal: records report when run succeeds', () => {
+  withTempDir((dir) => {
+    const runStub = path.join(dir, 'run-stub.sh');
+    const recordStub = path.join(dir, 'record-stub.sh');
+    const logDir = path.join(dir, 'logs');
+    const outDir = path.join(dir, 'out');
+
+    writeFileSync(
+      runStub,
+      [
+        '#!/usr/bin/env bash',
+        'set -euo pipefail',
+        'mkdir -p "${LOG_DIR}"',
+        'echo "run-ok" > "${LOG_DIR}/run.log"',
+      ].join('\n'),
+    );
+    writeFileSync(
+      recordStub,
+      [
+        '#!/usr/bin/env bash',
+        'set -euo pipefail',
+        'mkdir -p "${LOG_DIR}"',
+        'echo "${DATE_STAMP}|${RUN_LABEL}|${OUT_DIR:-}" > "${LOG_DIR}/record.log"',
+      ].join('\n'),
+    );
+    chmodSync(runStub, 0o755);
+    chmodSync(recordStub, 0o755);
+
+    const res = runScript('run-and-record-po-migration-rehearsal.sh', {
+      RUN_SCRIPT_PATH: runStub,
+      RECORD_SCRIPT_PATH: recordStub,
+      LOG_DIR: logDir,
+      DATE_STAMP: '2026-02-24',
+      RUN_LABEL: 'r1',
+      OUT_DIR: outDir,
+    });
+    assert.equal(res.status, 0, `${res.stderr}\n${res.stdout}`);
+    assert.equal(existsSync(path.join(logDir, 'run.log')), true);
+    assert.equal(existsSync(path.join(logDir, 'record.log')), true);
+    const record = readFileSync(path.join(logDir, 'record.log'), 'utf8');
+    assert.match(record, /2026-02-24\|r1\|/);
+  });
+});
+
+test('run-and-record-po-migration-rehearsal: records even when run fails if RECORD_ON_FAIL=1', () => {
+  withTempDir((dir) => {
+    const runStub = path.join(dir, 'run-stub.sh');
+    const recordStub = path.join(dir, 'record-stub.sh');
+    const logDir = path.join(dir, 'logs');
+
+    writeFileSync(
+      runStub,
+      [
+        '#!/usr/bin/env bash',
+        'set -euo pipefail',
+        'mkdir -p "${LOG_DIR}"',
+        'echo "run-fail" > "${LOG_DIR}/run.log"',
+        'exit 33',
+      ].join('\n'),
+    );
+    writeFileSync(
+      recordStub,
+      [
+        '#!/usr/bin/env bash',
+        'set -euo pipefail',
+        'mkdir -p "${LOG_DIR}"',
+        'echo "record-on-fail" > "${LOG_DIR}/record.log"',
+      ].join('\n'),
+    );
+    chmodSync(runStub, 0o755);
+    chmodSync(recordStub, 0o755);
+
+    const res = runScript('run-and-record-po-migration-rehearsal.sh', {
+      RUN_SCRIPT_PATH: runStub,
+      RECORD_SCRIPT_PATH: recordStub,
+      LOG_DIR: logDir,
+      RECORD_ON_FAIL: '1',
+    });
+    assert.equal(res.status, 33);
+    assert.equal(existsSync(path.join(logDir, 'record.log')), true);
+  });
+});
+
+test('run-and-record-po-migration-rehearsal: skips record when run fails and RECORD_ON_FAIL=0', () => {
+  withTempDir((dir) => {
+    const runStub = path.join(dir, 'run-stub.sh');
+    const recordStub = path.join(dir, 'record-stub.sh');
+    const logDir = path.join(dir, 'logs');
+
+    writeFileSync(
+      runStub,
+      [
+        '#!/usr/bin/env bash',
+        'set -euo pipefail',
+        'mkdir -p "${LOG_DIR}"',
+        'echo "run-fail" > "${LOG_DIR}/run.log"',
+        'exit 34',
+      ].join('\n'),
+    );
+    writeFileSync(
+      recordStub,
+      [
+        '#!/usr/bin/env bash',
+        'set -euo pipefail',
+        'mkdir -p "${LOG_DIR}"',
+        'echo "should-not-run" > "${LOG_DIR}/record.log"',
+      ].join('\n'),
+    );
+    chmodSync(runStub, 0o755);
+    chmodSync(recordStub, 0o755);
+
+    const res = runScript('run-and-record-po-migration-rehearsal.sh', {
+      RUN_SCRIPT_PATH: runStub,
+      RECORD_SCRIPT_PATH: recordStub,
+      LOG_DIR: logDir,
+      RECORD_ON_FAIL: '0',
+    });
+    assert.equal(res.status, 34);
+    assert.equal(existsSync(path.join(logDir, 'record.log')), false);
+  });
+});

--- a/scripts/run-and-record-po-migration-rehearsal.sh
+++ b/scripts/run-and-record-po-migration-rehearsal.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_DIR="${LOG_DIR:-$ROOT_DIR/tmp/migration/logs/po-real-$(date +%Y%m%d-%H%M%S)}"
+DATE_STAMP="${DATE_STAMP:-$(date +%F)}"
+RUN_LABEL="${RUN_LABEL:-}"
+OUT_DIR="${OUT_DIR:-}"
+RECORD_ON_FAIL="${RECORD_ON_FAIL:-1}"
+RUN_SCRIPT="${RUN_SCRIPT_PATH:-$ROOT_DIR/scripts/run-po-migration-rehearsal.sh}"
+RECORD_SCRIPT="${RECORD_SCRIPT_PATH:-$ROOT_DIR/scripts/record-po-migration-rehearsal.sh}"
+
+usage() {
+  cat <<USAGE
+Usage:
+  INPUT_DIR=tmp/migration/po-real INPUT_FORMAT=csv APPLY=1 RUN_INTEGRITY=1 \\
+    ./scripts/run-and-record-po-migration-rehearsal.sh
+
+Optional env:
+  LOG_DIR=...         # shared log dir for run/record
+  DATE_STAMP=YYYY-MM-DD
+  RUN_LABEL=r1|r2...
+  OUT_DIR=...         # record output dir (default: docs/test-results)
+  RECORD_ON_FAIL=1    # 1: run failure時も記録作成（default）
+USAGE
+}
+
+log() {
+  echo "[run-and-record-po-migration] $*"
+}
+
+die() {
+  echo "[run-and-record-po-migration][ERROR] $*" >&2
+  exit 1
+}
+
+main() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+  fi
+
+  if [[ "$RECORD_ON_FAIL" != "0" && "$RECORD_ON_FAIL" != "1" ]]; then
+    die "RECORD_ON_FAIL must be 0|1"
+  fi
+  if [[ ! -f "$RUN_SCRIPT" ]]; then
+    die "run script not found: $RUN_SCRIPT"
+  fi
+  if [[ ! -f "$RECORD_SCRIPT" ]]; then
+    die "record script not found: $RECORD_SCRIPT"
+  fi
+
+  log "run script: $RUN_SCRIPT"
+  log "record script: $RECORD_SCRIPT"
+  log "log dir: $LOG_DIR"
+
+  set +e
+  LOG_DIR="$LOG_DIR" "$RUN_SCRIPT" "$@"
+  run_status=$?
+  set -e
+
+  if [[ "$run_status" == "0" || "$RECORD_ON_FAIL" == "1" ]]; then
+    log "recording rehearsal report"
+    if [[ -n "$OUT_DIR" ]]; then
+      LOG_DIR="$LOG_DIR" DATE_STAMP="$DATE_STAMP" RUN_LABEL="$RUN_LABEL" OUT_DIR="$OUT_DIR" "$RECORD_SCRIPT"
+    else
+      LOG_DIR="$LOG_DIR" DATE_STAMP="$DATE_STAMP" RUN_LABEL="$RUN_LABEL" "$RECORD_SCRIPT"
+    fi
+  else
+    log "skip report recording because run failed and RECORD_ON_FAIL=0"
+  fi
+
+  if [[ "$run_status" != "0" ]]; then
+    log "run finished with non-zero status: $run_status"
+    exit "$run_status"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## 概要
Issue #543 の前提待ち期間で進められる運用改善として、PO移行リハーサルの「実行 + 記録」を一括で回せるフローを追加しました。

## 変更内容
- `scripts/run-and-record-po-migration-rehearsal.sh` を追加
  - `run-po-migration-rehearsal.sh` 実行後、`record-po-migration-rehearsal.sh` を同じ `LOG_DIR` で連続実行
  - `RECORD_ON_FAIL=1`（既定）で失敗時も記録を残せる
  - `RUN_SCRIPT_PATH` / `RECORD_SCRIPT_PATH` はテスト時の差し替え用
- `Makefile` に `po-migration-run-and-record` ターゲットを追加
- `docs/requirements/migration-runbook.md` に一括実行手順を追記
- `docs/test-results/README.md` のテンプレート一覧に `po-migration-rehearsal-template.md` を明記
- `packages/backend/test/readinessScripts.test.js` に wrapper の回帰テストを追加
  - 成功時に記録される
  - 失敗時も `RECORD_ON_FAIL=1` なら記録される
  - `RECORD_ON_FAIL=0` なら記録スキップ

## テスト
- `bash -n scripts/run-and-record-po-migration-rehearsal.sh`
- `npm run build --prefix packages/backend`
- `node packages/backend/scripts/run-tests.js packages/backend/test/readinessScripts.test.js`
