### PR TITLE
test(backend): chat-ack-links ルートの統合テストを追加

### DIFF
--- a/packages/backend/test/chatAckLinksRoutes.test.js
+++ b/packages/backend/test/chatAckLinksRoutes.test.js
@@ -27,27 +27,6 @@ function withPrismaStubs(stubs, fn) {
     });
 }
 
-function withAuthEnv(fn) {
-  const prevDatabaseUrl = process.env.DATABASE_URL;
-  const prevAuthMode = process.env.AUTH_MODE;
-  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
-  process.env.AUTH_MODE = 'header';
-  return Promise.resolve()
-    .then(fn)
-    .finally(() => {
-      if (prevDatabaseUrl === undefined) {
-        delete process.env.DATABASE_URL;
-      } else {
-        process.env.DATABASE_URL = prevDatabaseUrl;
-      }
-      if (prevAuthMode === undefined) {
-        delete process.env.AUTH_MODE;
-      } else {
-        process.env.AUTH_MODE = prevAuthMode;
-      }
-    });
-}
-
 function adminHeaders() {
   return {
     'x-user-id': 'admin-user',
@@ -63,311 +42,311 @@ function userHeaders() {
 }
 
 test('GET /chat-ack-links denies non admin/mgmt role', async () => {
-  await withAuthEnv(async () => {
-    const server = await buildServer({ logger: false });
-    try {
-      const res = await server.inject({
-        method: 'GET',
-        url: '/chat-ack-links?ackRequestId=ack-001',
-        headers: userHeaders(),
-      });
-      assert.equal(res.statusCode, 403, res.body);
-    } finally {
-      await server.close();
-    }
-  });
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+  const server = await buildServer({ logger: false });
+  try {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/chat-ack-links?ackRequestId=ack-001',
+      headers: userHeaders(),
+    });
+    assert.equal(res.statusCode, 403, res.body);
+  } finally {
+    await server.close();
+  }
 });
 
 test('GET /chat-ack-links returns MISSING_QUERY when query values are blank', async () => {
-  await withAuthEnv(async () => {
-    const server = await buildServer({ logger: false });
-    try {
-      const res = await server.inject({
-        method: 'GET',
-        url: '/chat-ack-links?ackRequestId=%20%20',
-        headers: adminHeaders(),
-      });
-      assert.equal(res.statusCode, 400, res.body);
-      const body = JSON.parse(res.body);
-      assert.equal(body?.error?.code, 'MISSING_QUERY');
-    } finally {
-      await server.close();
-    }
-  });
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+  const server = await buildServer({ logger: false });
+  try {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/chat-ack-links?ackRequestId=%20%20',
+      headers: adminHeaders(),
+    });
+    assert.equal(res.statusCode, 400, res.body);
+    const body = JSON.parse(res.body);
+    assert.equal(body?.error?.code, 'MISSING_QUERY');
+  } finally {
+    await server.close();
+  }
 });
 
 test('GET /chat-ack-links validates targetId when targetTable is provided', async () => {
-  await withAuthEnv(async () => {
-    const server = await buildServer({ logger: false });
-    try {
-      const res = await server.inject({
-        method: 'GET',
-        url: '/chat-ack-links?ackRequestId=ack-001&targetTable=approval_instances&targetId=%20%20',
-        headers: adminHeaders(),
-      });
-      assert.equal(res.statusCode, 400, res.body);
-      const body = JSON.parse(res.body);
-      assert.equal(body?.error?.code, 'INVALID_QUERY');
-    } finally {
-      await server.close();
-    }
-  });
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+  const server = await buildServer({ logger: false });
+  try {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/chat-ack-links?ackRequestId=ack-001&targetTable=approval_instances&targetId=%20%20',
+      headers: adminHeaders(),
+    });
+    assert.equal(res.statusCode, 400, res.body);
+    const body = JSON.parse(res.body);
+    assert.equal(body?.error?.code, 'INVALID_QUERY');
+  } finally {
+    await server.close();
+  }
 });
 
 test('GET /chat-ack-links rejects disallowed targetTable', async () => {
-  await withAuthEnv(async () => {
-    const server = await buildServer({ logger: false });
-    try {
-      const res = await server.inject({
-        method: 'GET',
-        url: '/chat-ack-links?targetTable=vendor_invoices&targetId=vi-001',
-        headers: adminHeaders(),
-      });
-      assert.equal(res.statusCode, 400, res.body);
-      const body = JSON.parse(res.body);
-      assert.equal(body?.error?.code, 'INVALID_TARGET_TABLE');
-    } finally {
-      await server.close();
-    }
-  });
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+  const server = await buildServer({ logger: false });
+  try {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/chat-ack-links?targetTable=vendor_invoices&targetId=vi-001',
+      headers: adminHeaders(),
+    });
+    assert.equal(res.statusCode, 400, res.body);
+    const body = JSON.parse(res.body);
+    assert.equal(body?.error?.code, 'INVALID_TARGET_TABLE');
+  } finally {
+    await server.close();
+  }
 });
 
 test('GET /chat-ack-links applies query filters and limit clamp', async () => {
-  await withAuthEnv(async () => {
-    let capturedArgs = null;
-    await withPrismaStubs(
-      {
-        'chatAckLink.findMany': async (args) => {
-          capturedArgs = args;
-          return [{ id: 'link-001', ackRequestId: 'ack-001' }];
-        },
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+  let capturedArgs = null;
+  await withPrismaStubs(
+    {
+      'chatAckLink.findMany': async (args) => {
+        capturedArgs = args;
+        return [{ id: 'link-001', ackRequestId: 'ack-001' }];
       },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'GET',
-            url: '/chat-ack-links?ackRequestId=ack-001&limit=999',
-            headers: adminHeaders(),
-          });
-          assert.equal(res.statusCode, 200, res.body);
-          const body = JSON.parse(res.body);
-          assert.equal(Array.isArray(body?.items), true);
-          assert.equal(body.items.length, 1);
-          assert.equal(capturedArgs?.where?.ackRequestId, 'ack-001');
-          assert.equal(capturedArgs?.take, 200);
-          assert.deepEqual(capturedArgs?.orderBy, { createdAt: 'desc' });
-        } finally {
-          await server.close();
-        }
-      },
-    );
-  });
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'GET',
+          url: '/chat-ack-links?ackRequestId=ack-001&limit=999',
+          headers: adminHeaders(),
+        });
+        assert.equal(res.statusCode, 200, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(Array.isArray(body?.items), true);
+        assert.equal(body.items.length, 1);
+        assert.equal(capturedArgs?.where?.ackRequestId, 'ack-001');
+        assert.equal(capturedArgs?.take, 200);
+        assert.deepEqual(capturedArgs?.orderBy, { createdAt: 'desc' });
+      } finally {
+        await server.close();
+      }
+    },
+  );
 });
 
 test('POST /chat-ack-links returns TARGET_NOT_FOUND when target does not exist', async () => {
-  await withAuthEnv(async () => {
-    await withPrismaStubs(
-      {
-        'approvalInstance.findUnique': async () => null,
-      },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'POST',
-            url: '/chat-ack-links',
-            headers: adminHeaders(),
-            payload: {
-              ackRequestId: 'ack-001',
-              targetTable: 'approval_instances',
-              targetId: 'approval-missing',
-            },
-          });
-          assert.equal(res.statusCode, 404, res.body);
-          const body = JSON.parse(res.body);
-          assert.equal(body?.error?.code, 'TARGET_NOT_FOUND');
-        } finally {
-          await server.close();
-        }
-      },
-    );
-  });
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+  await withPrismaStubs(
+    {
+      'approvalInstance.findUnique': async () => null,
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/chat-ack-links',
+          headers: adminHeaders(),
+          payload: {
+            ackRequestId: 'ack-001',
+            targetTable: 'approval_instances',
+            targetId: 'approval-missing',
+          },
+        });
+        assert.equal(res.statusCode, 404, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.error?.code, 'TARGET_NOT_FOUND');
+      } finally {
+        await server.close();
+      }
+    },
+  );
 });
 
 test('POST /chat-ack-links returns ACK_REQUEST_CANCELED for canceled request', async () => {
-  await withAuthEnv(async () => {
-    await withPrismaStubs(
-      {
-        'approvalInstance.findUnique': async () => ({ id: 'approval-001' }),
-        'chatAckRequest.findUnique': async () => ({
-          id: 'ack-001',
-          messageId: 'msg-001',
-          canceledAt: new Date('2026-02-25T00:00:00.000Z'),
-          message: { deletedAt: null },
-        }),
-      },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'POST',
-            url: '/chat-ack-links',
-            headers: adminHeaders(),
-            payload: {
-              ackRequestId: 'ack-001',
-              targetTable: 'approval_instances',
-              targetId: 'approval-001',
-            },
-          });
-          assert.equal(res.statusCode, 409, res.body);
-          const body = JSON.parse(res.body);
-          assert.equal(body?.error?.code, 'ACK_REQUEST_CANCELED');
-        } finally {
-          await server.close();
-        }
-      },
-    );
-  });
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+  await withPrismaStubs(
+    {
+      'approvalInstance.findUnique': async () => ({ id: 'approval-001' }),
+      'chatAckRequest.findUnique': async () => ({
+        id: 'ack-001',
+        messageId: 'msg-001',
+        canceledAt: new Date('2026-02-25T00:00:00.000Z'),
+        message: { deletedAt: null },
+      }),
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/chat-ack-links',
+          headers: adminHeaders(),
+          payload: {
+            ackRequestId: 'ack-001',
+            targetTable: 'approval_instances',
+            targetId: 'approval-001',
+          },
+        });
+        assert.equal(res.statusCode, 409, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.error?.code, 'ACK_REQUEST_CANCELED');
+      } finally {
+        await server.close();
+      }
+    },
+  );
 });
 
 test('POST /chat-ack-links creates link and writes audit log', async () => {
-  await withAuthEnv(async () => {
-    let capturedCreateArgs = null;
-    let capturedAuditArgs = null;
-    await withPrismaStubs(
-      {
-        'approvalInstance.findUnique': async () => ({ id: 'approval-001' }),
-        'chatAckRequest.findUnique': async () => ({
-          id: 'ack-001',
-          messageId: 'msg-001',
-          canceledAt: null,
-          message: { deletedAt: null },
-        }),
-        'chatAckLink.create': async (args) => {
-          capturedCreateArgs = args;
-          return {
-            id: 'link-001',
-            ackRequestId: 'ack-001',
-            messageId: 'msg-001',
-            targetTable: 'approval_instances',
-            targetId: 'approval-001',
-            flowType: 'expense',
-            actionKey: 'submit',
-            createdBy: 'admin-user',
-            updatedBy: 'admin-user',
-          };
-        },
-        'auditLog.create': async (args) => {
-          capturedAuditArgs = args;
-          return { id: 'audit-001' };
-        },
-      },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'POST',
-            url: '/chat-ack-links',
-            headers: adminHeaders(),
-            payload: {
-              ackRequestId: 'ack-001',
-              targetTable: 'approval_instances',
-              targetId: 'approval-001',
-              flowType: 'expense',
-              actionKey: 'submit',
-            },
-          });
-          assert.equal(res.statusCode, 200, res.body);
-          const body = JSON.parse(res.body);
-          assert.equal(body?.id, 'link-001');
-          assert.equal(capturedCreateArgs?.data?.ackRequestId, 'ack-001');
-          assert.equal(
-            capturedCreateArgs?.data?.targetTable,
-            'approval_instances',
-          );
-          assert.equal(capturedCreateArgs?.data?.targetId, 'approval-001');
-          assert.equal(capturedCreateArgs?.data?.flowType, 'expense');
-          assert.equal(capturedCreateArgs?.data?.actionKey, 'submit');
-          assert.equal(capturedAuditArgs?.data?.action, 'chat_ack_link_created');
-          assert.equal(capturedAuditArgs?.data?.targetTable, 'chat_ack_links');
-          assert.equal(capturedAuditArgs?.data?.targetId, 'link-001');
-        } finally {
-          await server.close();
-        }
-      },
-    );
-  });
-});
-
-test('DELETE /chat-ack-links/:id returns NOT_FOUND when link is absent', async () => {
-  await withAuthEnv(async () => {
-    await withPrismaStubs(
-      {
-        'chatAckLink.findUnique': async () => null,
-      },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'DELETE',
-            url: '/chat-ack-links/link-missing',
-            headers: adminHeaders(),
-          });
-          assert.equal(res.statusCode, 404, res.body);
-          const body = JSON.parse(res.body);
-          assert.equal(body?.error?.code, 'NOT_FOUND');
-        } finally {
-          await server.close();
-        }
-      },
-    );
-  });
-});
-
-test('DELETE /chat-ack-links/:id deletes link and writes audit log', async () => {
-  await withAuthEnv(async () => {
-    let capturedDeleteArgs = null;
-    let capturedAuditArgs = null;
-    await withPrismaStubs(
-      {
-        'chatAckLink.findUnique': async () => ({
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+  let capturedCreateArgs = null;
+  let capturedAuditArgs = null;
+  await withPrismaStubs(
+    {
+      'approvalInstance.findUnique': async () => ({ id: 'approval-001' }),
+      'chatAckRequest.findUnique': async () => ({
+        id: 'ack-001',
+        messageId: 'msg-001',
+        canceledAt: null,
+        message: { deletedAt: null },
+      }),
+      'chatAckLink.create': async (args) => {
+        capturedCreateArgs = args;
+        return {
           id: 'link-001',
           ackRequestId: 'ack-001',
           messageId: 'msg-001',
           targetTable: 'approval_instances',
           targetId: 'approval-001',
-          flowType: null,
-          actionKey: null,
-        }),
-        'chatAckLink.delete': async (args) => {
-          capturedDeleteArgs = args;
-          return { id: 'link-001' };
-        },
-        'auditLog.create': async (args) => {
-          capturedAuditArgs = args;
-          return { id: 'audit-001' };
-        },
+          flowType: 'expense',
+          actionKey: 'submit',
+          createdBy: 'admin-user',
+          updatedBy: 'admin-user',
+        };
       },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'DELETE',
-            url: '/chat-ack-links/link-001',
-            headers: adminHeaders(),
-          });
-          assert.equal(res.statusCode, 200, res.body);
-          const body = JSON.parse(res.body);
-          assert.equal(body?.ok, true);
-          assert.equal(capturedDeleteArgs?.where?.id, 'link-001');
-          assert.equal(capturedAuditArgs?.data?.action, 'chat_ack_link_deleted');
-          assert.equal(capturedAuditArgs?.data?.targetTable, 'chat_ack_links');
-          assert.equal(capturedAuditArgs?.data?.targetId, 'link-001');
-        } finally {
-          await server.close();
-        }
+      'auditLog.create': async (args) => {
+        capturedAuditArgs = args;
+        return { id: 'audit-001' };
       },
-    );
-  });
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/chat-ack-links',
+          headers: adminHeaders(),
+          payload: {
+            ackRequestId: 'ack-001',
+            targetTable: 'approval_instances',
+            targetId: 'approval-001',
+            flowType: 'expense',
+            actionKey: 'submit',
+          },
+        });
+        assert.equal(res.statusCode, 200, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.id, 'link-001');
+        assert.equal(capturedCreateArgs?.data?.ackRequestId, 'ack-001');
+        assert.equal(
+          capturedCreateArgs?.data?.targetTable,
+          'approval_instances',
+        );
+        assert.equal(capturedCreateArgs?.data?.targetId, 'approval-001');
+        assert.equal(capturedCreateArgs?.data?.flowType, 'expense');
+        assert.equal(capturedCreateArgs?.data?.actionKey, 'submit');
+        assert.equal(capturedAuditArgs?.data?.action, 'chat_ack_link_created');
+        assert.equal(capturedAuditArgs?.data?.targetTable, 'chat_ack_links');
+        assert.equal(capturedAuditArgs?.data?.targetId, 'link-001');
+      } finally {
+        await server.close();
+      }
+    },
+  );
+});
+
+test('DELETE /chat-ack-links/:id returns NOT_FOUND when link is absent', async () => {
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+  await withPrismaStubs(
+    {
+      'chatAckLink.findUnique': async () => null,
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'DELETE',
+          url: '/chat-ack-links/link-missing',
+          headers: adminHeaders(),
+        });
+        assert.equal(res.statusCode, 404, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.error?.code, 'NOT_FOUND');
+      } finally {
+        await server.close();
+      }
+    },
+  );
+});
+
+test('DELETE /chat-ack-links/:id deletes link and writes audit log', async () => {
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+  let capturedDeleteArgs = null;
+  let capturedAuditArgs = null;
+  await withPrismaStubs(
+    {
+      'chatAckLink.findUnique': async () => ({
+        id: 'link-001',
+        ackRequestId: 'ack-001',
+        messageId: 'msg-001',
+        targetTable: 'approval_instances',
+        targetId: 'approval-001',
+        flowType: null,
+        actionKey: null,
+      }),
+      'chatAckLink.delete': async (args) => {
+        capturedDeleteArgs = args;
+        return { id: 'link-001' };
+      },
+      'auditLog.create': async (args) => {
+        capturedAuditArgs = args;
+        return { id: 'audit-001' };
+      },
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'DELETE',
+          url: '/chat-ack-links/link-001',
+          headers: adminHeaders(),
+        });
+        assert.equal(res.statusCode, 200, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.ok, true);
+        assert.equal(capturedDeleteArgs?.where?.id, 'link-001');
+        assert.equal(capturedAuditArgs?.data?.action, 'chat_ack_link_deleted');
+        assert.equal(capturedAuditArgs?.data?.targetTable, 'chat_ack_links');
+        assert.equal(capturedAuditArgs?.data?.targetId, 'link-001');
+      } finally {
+        await server.close();
+      }
+    },
+  );
 });

--- a/packages/backend/test/vendorInvoiceLinkPoRoutes.test.js
+++ b/packages/backend/test/vendorInvoiceLinkPoRoutes.test.js
@@ -27,27 +27,6 @@ function withPrismaStubs(stubs, fn) {
     });
 }
 
-function withAuthEnv(fn) {
-  const prevDatabaseUrl = process.env.DATABASE_URL;
-  const prevAuthMode = process.env.AUTH_MODE;
-  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
-  process.env.AUTH_MODE = 'header';
-  return Promise.resolve()
-    .then(fn)
-    .finally(() => {
-      if (prevDatabaseUrl === undefined) {
-        delete process.env.DATABASE_URL;
-      } else {
-        process.env.DATABASE_URL = prevDatabaseUrl;
-      }
-      if (prevAuthMode === undefined) {
-        delete process.env.AUTH_MODE;
-      } else {
-        process.env.AUTH_MODE = prevAuthMode;
-      }
-    });
-}
-
 function adminHeaders() {
   return {
     'x-user-id': 'admin-user',
@@ -56,239 +35,239 @@ function adminHeaders() {
 }
 
 test('POST /vendor-invoices/:id/link-po requires reason in fallback mode after submit status', async () => {
-  await withAuthEnv(async () => {
-    await withPrismaStubs(
-      {
-        'actionPolicy.findMany': async () => [],
-        'vendorInvoice.findUnique': async () => ({
-          id: 'vi-001',
-          status: 'approved',
-          projectId: 'project-001',
-          vendorId: 'vendor-001',
-          purchaseOrderId: 'po-001',
-          deletedAt: null,
-        }),
-        'purchaseOrder.findUnique': async () => ({
-          id: 'po-002',
-          projectId: 'project-001',
-          vendorId: 'vendor-001',
-          deletedAt: null,
-        }),
-      },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'POST',
-            url: '/vendor-invoices/vi-001/link-po',
-            headers: adminHeaders(),
-            payload: {
-              purchaseOrderId: 'po-002',
-            },
-          });
-          assert.equal(res.statusCode, 400, res.body);
-          const body = JSON.parse(res.body);
-          assert.equal(body?.error?.code, 'REASON_REQUIRED');
-        } finally {
-          await server.close();
-        }
-      },
-    );
-  });
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+  await withPrismaStubs(
+    {
+      'actionPolicy.findMany': async () => [],
+      'vendorInvoice.findUnique': async () => ({
+        id: 'vi-001',
+        status: 'approved',
+        projectId: 'project-001',
+        vendorId: 'vendor-001',
+        purchaseOrderId: 'po-001',
+        deletedAt: null,
+      }),
+      'purchaseOrder.findUnique': async () => ({
+        id: 'po-002',
+        projectId: 'project-001',
+        vendorId: 'vendor-001',
+        deletedAt: null,
+      }),
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/vendor-invoices/vi-001/link-po',
+          headers: adminHeaders(),
+          payload: {
+            purchaseOrderId: 'po-002',
+          },
+        });
+        assert.equal(res.statusCode, 400, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.error?.code, 'REASON_REQUIRED');
+      } finally {
+        await server.close();
+      }
+    },
+  );
 });
 
 test('POST /vendor-invoices/:id/link-po updates PO and writes override/link audit logs', async () => {
-  await withAuthEnv(async () => {
-    const auditActions = [];
-    let capturedUpdateArgs = null;
-    await withPrismaStubs(
-      {
-        'actionPolicy.findMany': async () => [],
-        'vendorInvoice.findUnique': async () => ({
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+  const auditActions = [];
+  let capturedUpdateArgs = null;
+  await withPrismaStubs(
+    {
+      'actionPolicy.findMany': async () => [],
+      'vendorInvoice.findUnique': async () => ({
+        id: 'vi-001',
+        status: 'approved',
+        projectId: 'project-001',
+        vendorId: 'vendor-001',
+        purchaseOrderId: 'po-001',
+        deletedAt: null,
+      }),
+      'purchaseOrder.findUnique': async () => ({
+        id: 'po-002',
+        projectId: 'project-001',
+        vendorId: 'vendor-001',
+        deletedAt: null,
+      }),
+      'vendorInvoice.update': async (args) => {
+        capturedUpdateArgs = args;
+        return {
           id: 'vi-001',
-          status: 'approved',
-          projectId: 'project-001',
-          vendorId: 'vendor-001',
-          purchaseOrderId: 'po-001',
-          deletedAt: null,
-        }),
-        'purchaseOrder.findUnique': async () => ({
-          id: 'po-002',
-          projectId: 'project-001',
-          vendorId: 'vendor-001',
-          deletedAt: null,
-        }),
-        'vendorInvoice.update': async (args) => {
-          capturedUpdateArgs = args;
-          return {
-            id: 'vi-001',
+          purchaseOrderId: 'po-002',
+          purchaseOrder: { id: 'po-002', poNo: 'PO-2026-002' },
+        };
+      },
+      'auditLog.create': async (args) => {
+        auditActions.push(args?.data?.action);
+        return { id: `audit-${auditActions.length}` };
+      },
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/vendor-invoices/vi-001/link-po',
+          headers: adminHeaders(),
+          payload: {
             purchaseOrderId: 'po-002',
-            purchaseOrder: { id: 'po-002', poNo: 'PO-2026-002' },
-          };
-        },
-        'auditLog.create': async (args) => {
-          auditActions.push(args?.data?.action);
-          return { id: `audit-${auditActions.length}` };
-        },
-      },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'POST',
-            url: '/vendor-invoices/vi-001/link-po',
-            headers: adminHeaders(),
-            payload: {
-              purchaseOrderId: 'po-002',
-              reasonText: 'PO mapping correction',
-            },
-          });
-          assert.equal(res.statusCode, 200, res.body);
-          const body = JSON.parse(res.body);
-          assert.equal(body?.purchaseOrderId, 'po-002');
-          assert.equal(capturedUpdateArgs?.where?.id, 'vi-001');
-          assert.equal(capturedUpdateArgs?.data?.purchaseOrderId, 'po-002');
-          assert.deepEqual(auditActions, [
-            'vendor_invoice_link_po_override',
-            'vendor_invoice_link_po',
-          ]);
-        } finally {
-          await server.close();
-        }
-      },
-    );
-  });
+            reasonText: 'PO mapping correction',
+          },
+        });
+        assert.equal(res.statusCode, 200, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.purchaseOrderId, 'po-002');
+        assert.equal(capturedUpdateArgs?.where?.id, 'vi-001');
+        assert.equal(capturedUpdateArgs?.data?.purchaseOrderId, 'po-002');
+        assert.deepEqual(auditActions, [
+          'vendor_invoice_link_po_override',
+          'vendor_invoice_link_po',
+        ]);
+      } finally {
+        await server.close();
+      }
+    },
+  );
 });
 
 test('POST /vendor-invoices/:id/link-po rejects purchase order project mismatch', async () => {
-  await withAuthEnv(async () => {
-    await withPrismaStubs(
-      {
-        'actionPolicy.findMany': async () => [],
-        'vendorInvoice.findUnique': async () => ({
-          id: 'vi-001',
-          status: 'draft',
-          projectId: 'project-001',
-          vendorId: 'vendor-001',
-          purchaseOrderId: null,
-          deletedAt: null,
-        }),
-        'purchaseOrder.findUnique': async () => ({
-          id: 'po-002',
-          projectId: 'project-999',
-          vendorId: 'vendor-001',
-          deletedAt: null,
-        }),
-      },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'POST',
-            url: '/vendor-invoices/vi-001/link-po',
-            headers: adminHeaders(),
-            payload: {
-              purchaseOrderId: 'po-002',
-            },
-          });
-          assert.equal(res.statusCode, 400, res.body);
-          const body = JSON.parse(res.body);
-          assert.equal(body?.error?.code, 'INVALID_PURCHASE_ORDER');
-          assert.match(body?.error?.message ?? '', /project/i);
-        } finally {
-          await server.close();
-        }
-      },
-    );
-  });
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+  await withPrismaStubs(
+    {
+      'actionPolicy.findMany': async () => [],
+      'vendorInvoice.findUnique': async () => ({
+        id: 'vi-001',
+        status: 'draft',
+        projectId: 'project-001',
+        vendorId: 'vendor-001',
+        purchaseOrderId: null,
+        deletedAt: null,
+      }),
+      'purchaseOrder.findUnique': async () => ({
+        id: 'po-002',
+        projectId: 'project-999',
+        vendorId: 'vendor-001',
+        deletedAt: null,
+      }),
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/vendor-invoices/vi-001/link-po',
+          headers: adminHeaders(),
+          payload: {
+            purchaseOrderId: 'po-002',
+          },
+        });
+        assert.equal(res.statusCode, 400, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.error?.code, 'INVALID_PURCHASE_ORDER');
+        assert.match(body?.error?.message ?? '', /project/i);
+      } finally {
+        await server.close();
+      }
+    },
+  );
 });
 
 test('POST /vendor-invoices/:id/unlink-po requires reason in fallback mode after submit status', async () => {
-  await withAuthEnv(async () => {
-    await withPrismaStubs(
-      {
-        'actionPolicy.findMany': async () => [],
-        'vendorInvoice.findUnique': async () => ({
-          id: 'vi-001',
-          status: 'approved',
-          projectId: 'project-001',
-          vendorId: 'vendor-001',
-          purchaseOrderId: 'po-001',
-          deletedAt: null,
-        }),
-      },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'POST',
-            url: '/vendor-invoices/vi-001/unlink-po',
-            headers: adminHeaders(),
-            payload: {},
-          });
-          assert.equal(res.statusCode, 400, res.body);
-          const body = JSON.parse(res.body);
-          assert.equal(body?.error?.code, 'REASON_REQUIRED');
-        } finally {
-          await server.close();
-        }
-      },
-    );
-  });
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+  await withPrismaStubs(
+    {
+      'actionPolicy.findMany': async () => [],
+      'vendorInvoice.findUnique': async () => ({
+        id: 'vi-001',
+        status: 'approved',
+        projectId: 'project-001',
+        vendorId: 'vendor-001',
+        purchaseOrderId: 'po-001',
+        deletedAt: null,
+      }),
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/vendor-invoices/vi-001/unlink-po',
+          headers: adminHeaders(),
+          payload: {},
+        });
+        assert.equal(res.statusCode, 400, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.error?.code, 'REASON_REQUIRED');
+      } finally {
+        await server.close();
+      }
+    },
+  );
 });
 
 test('POST /vendor-invoices/:id/unlink-po clears PO and writes override/unlink audit logs', async () => {
-  await withAuthEnv(async () => {
-    const auditActions = [];
-    let capturedUpdateArgs = null;
-    await withPrismaStubs(
-      {
-        'actionPolicy.findMany': async () => [],
-        'vendorInvoice.findUnique': async () => ({
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+  const auditActions = [];
+  let capturedUpdateArgs = null;
+  await withPrismaStubs(
+    {
+      'actionPolicy.findMany': async () => [],
+      'vendorInvoice.findUnique': async () => ({
+        id: 'vi-001',
+        status: 'approved',
+        projectId: 'project-001',
+        vendorId: 'vendor-001',
+        purchaseOrderId: 'po-001',
+        deletedAt: null,
+      }),
+      'vendorInvoice.update': async (args) => {
+        capturedUpdateArgs = args;
+        return {
           id: 'vi-001',
-          status: 'approved',
-          projectId: 'project-001',
-          vendorId: 'vendor-001',
-          purchaseOrderId: 'po-001',
-          deletedAt: null,
-        }),
-        'vendorInvoice.update': async (args) => {
-          capturedUpdateArgs = args;
-          return {
-            id: 'vi-001',
-            purchaseOrderId: null,
-            purchaseOrder: null,
-          };
-        },
-        'auditLog.create': async (args) => {
-          auditActions.push(args?.data?.action);
-          return { id: `audit-${auditActions.length}` };
-        },
+          purchaseOrderId: null,
+          purchaseOrder: null,
+        };
       },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'POST',
-            url: '/vendor-invoices/vi-001/unlink-po',
-            headers: adminHeaders(),
-            payload: {
-              reasonText: 'Split settlement handling',
-            },
-          });
-          assert.equal(res.statusCode, 200, res.body);
-          const body = JSON.parse(res.body);
-          assert.equal(body?.purchaseOrderId, null);
-          assert.equal(capturedUpdateArgs?.where?.id, 'vi-001');
-          assert.equal(capturedUpdateArgs?.data?.purchaseOrderId, null);
-          assert.deepEqual(auditActions, [
-            'vendor_invoice_unlink_po_override',
-            'vendor_invoice_unlink_po',
-          ]);
-        } finally {
-          await server.close();
-        }
+      'auditLog.create': async (args) => {
+        auditActions.push(args?.data?.action);
+        return { id: `audit-${auditActions.length}` };
       },
-    );
-  });
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/vendor-invoices/vi-001/unlink-po',
+          headers: adminHeaders(),
+          payload: {
+            reasonText: 'Split settlement handling',
+          },
+        });
+        assert.equal(res.statusCode, 200, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.purchaseOrderId, null);
+        assert.equal(capturedUpdateArgs?.where?.id, 'vi-001');
+        assert.equal(capturedUpdateArgs?.data?.purchaseOrderId, null);
+        assert.deepEqual(auditActions, [
+          'vendor_invoice_unlink_po_override',
+          'vendor_invoice_unlink_po',
+        ]);
+      } finally {
+        await server.close();
+      }
+    },
+  );
 });


### PR DESCRIPTION
## 概要
- `chat-ack-links` ルートの未カバー分を補う統合テストを追加
- `vendor-invoices/:id/link-po|unlink-po` のポリシー/監査ログ分岐テストを追加

## 追加テスト
### chat ack links
- `GET /chat-ack-links`
  - 非管理ロール拒否
  - 空白クエリ時の `MISSING_QUERY`
  - `targetTable` 指定時の `targetId` 必須
  - 許可外 `targetTable` 拒否
  - `limit` クランプ（`999` -> `200`）と where 条件
- `POST /chat-ack-links`
  - `TARGET_NOT_FOUND`
  - `ACK_REQUEST_CANCELED`
  - 作成成功 + `chat_ack_link_created` 監査ログ
- `DELETE /chat-ack-links/:id`
  - `NOT_FOUND`
  - 削除成功 + `chat_ack_link_deleted` 監査ログ

### vendor invoice PO linking
- `POST /vendor-invoices/:id/link-po`
  - fallbackモードで submit後status の `reasonText` 必須
  - PO更新成功 + `vendor_invoice_link_po_override` / `vendor_invoice_link_po` 監査ログ
  - PO案件不一致時の `INVALID_PURCHASE_ORDER`
- `POST /vendor-invoices/:id/unlink-po`
  - fallbackモードで submit後status の `reasonText` 必須
  - 解除成功 + `vendor_invoice_unlink_po_override` / `vendor_invoice_unlink_po` 監査ログ

## 実行確認
- `npm run test:ci --prefix packages/backend -- test/chatAckLinksRoutes.test.js`
- `npm run test:ci --prefix packages/backend -- test/vendorInvoiceLinkPoRoutes.test.js`
- `npm run test:ci --prefix packages/backend -- test/chatAckLinksRoutes.test.js test/vendorInvoiceLinkPoRoutes.test.js`
  - いずれも pass