### PR TITLE
test(backend): report-subscriptions ルートの統合テストを追加

### DIFF
--- a/packages/backend/test/reportSubscriptionRoutes.test.js
+++ b/packages/backend/test/reportSubscriptionRoutes.test.js
@@ -254,7 +254,9 @@ test('PATCH /report-subscriptions/:id returns not_found when subscription does n
         });
         assert.equal(res.statusCode, 404, res.body);
         const body = JSON.parse(res.body);
-        assert.equal(body?.error?.code, 'not_found');
+        const errorCode =
+          typeof body?.error === 'string' ? body.error : body?.error?.code;
+        assert.equal(errorCode, 'not_found');
       });
     },
   );


### PR DESCRIPTION
## 概要
- `reportSubscriptions` ルートの統合テストを新規追加し、RBAC・入力検証・クエリ変換・更新分岐を固定

## 追加したテスト
- `GET /report-subscriptions`
  - admin/mgmt 以外は `forbidden`
  - `orderBy(createdAt desc)` で取得
- `GET /report-deliveries`
  - 不正な `limit/offset` は `limit=50, offset=0` にフォールバック
  - `limit` 上限 200、`subscriptionId` フィルタ適用
- `POST /report-subscriptions`
  - `format=csv` / `channels=['dashboard']` / `isEnabled=true` のデフォルト
  - `createdBy/updatedBy` に actor を設定
  - `format` 不正値は `VALIDATION_ERROR`
- `PATCH /report-subscriptions/:id`
  - 対象なし `not_found`
  - 空白 `reportKey` は `INVALID_REPORT_KEY`
  - 更新可能項目（name/schedule/recipients/channels/isEnabled）の反映と reportKey/format 維持

## 実行確認
- `npm run test:ci --prefix packages/backend -- test/reportSubscriptionRoutes.test.js`
- `npm run test:ci --prefix packages/backend -- test/purchaseOrderRoutes.test.js test/invoiceListGetRoutes.test.js test/invoiceMutationRoutes.test.js test/reportSubscriptionRoutes.test.js`
