### PR TITLE
test(backend): vendor docs read ルートの統合テストを追加

### DIFF
--- a/packages/backend/test/vendorDocReadRoutes.test.js
+++ b/packages/backend/test/vendorDocReadRoutes.test.js
@@ -217,6 +217,26 @@ test('GET /vendor-invoices/:id/allocations returns NOT_FOUND for deleted invoice
   );
 });
 
+test('GET /vendor-invoices/:id/allocations returns NOT_FOUND when invoice is missing', async () => {
+  await withPrismaStubs(
+    {
+      'vendorInvoice.findUnique': async () => null,
+    },
+    async () => {
+      await withServer(async (server) => {
+        const res = await server.inject({
+          method: 'GET',
+          url: '/vendor-invoices/vi-missing/allocations',
+          headers: adminHeaders(),
+        });
+        assert.equal(res.statusCode, 404, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.error?.code, 'NOT_FOUND');
+      });
+    },
+  );
+});
+
 test('GET /vendor-invoices/:id/allocations returns invoice and allocation rows', async () => {
   let capturedAllocArgs = null;
   await withPrismaStubs(


### PR DESCRIPTION
## 概要
- `vendorDocs` の read 系ルート統合テストを追加し、RBAC・NOT_FOUND・集計レスポンスの分岐を固定

## 追加したテスト
- RBAC
  - `GET /vendor-invoices` は admin/mgmt 以外を `forbidden`
- `GET /vendor-quotes`
  - filter (`projectId`/`vendorId`/`status`) と `take=100` を検証
- `GET /vendor-quotes/:id`
  - `NOT_FOUND`
- `GET /vendor-invoices`
  - filter と `purchaseOrder` include を検証
- `GET /vendor-invoices/:id`
  - `NOT_FOUND`
- `GET /vendor-invoices/:id/allocations`
  - invoice 不在/削除済み時 `NOT_FOUND`
  - 正常系で invoice + allocations 返却、`createdAt asc` を検証
- `GET /vendor-invoices/:id/lines`
  - `NOT_FOUND`
  - 正常系で `totals`（amount/tax/gross/diff）と `poLineUsage` 集計を検証

## 実行確認
- `npm run test:ci --prefix packages/backend -- test/vendorDocReadRoutes.test.js`
- `npm run test:ci --prefix packages/backend -- test/purchaseOrderRoutes.test.js test/invoiceListGetRoutes.test.js test/invoiceMutationRoutes.test.js test/vendorDocReadRoutes.test.js`
