### PR TITLE
fix: prevent project member forbidden responses from crashing backend

### DIFF
--- a/packages/backend/src/routes/projects.ts
+++ b/packages/backend/src/routes/projects.ts
@@ -452,7 +452,7 @@ export async function registerProjectRoutes(app: FastifyInstance) {
       const roles = req.user?.roles || [];
       if (!isPrivilegedRole(roles)) {
         const allowed = await ensureProjectLeader(req, reply, projectId);
-        if (!allowed) return;
+        if (!allowed) return reply;
       }
       const items = await prisma.projectMember.findMany({
         where: { projectId },
@@ -476,7 +476,7 @@ export async function registerProjectRoutes(app: FastifyInstance) {
       const roles = req.user?.roles || [];
       if (!isPrivilegedRole(roles)) {
         const allowed = await ensureProjectLeader(req, reply, projectId);
-        if (!allowed) return;
+        if (!allowed) return reply;
       }
       const keyword = (q || '').trim().slice(0, 64);
       if (keyword.length < 2) {
@@ -539,7 +539,7 @@ export async function registerProjectRoutes(app: FastifyInstance) {
       const isPrivileged = isPrivilegedRole(roles);
       if (!isPrivileged) {
         const allowed = await ensureProjectLeader(req, reply, projectId);
-        if (!allowed) return;
+        if (!allowed) return reply;
       }
       const project = await prisma.project.findUnique({
         where: { id: projectId },
@@ -687,7 +687,7 @@ export async function registerProjectRoutes(app: FastifyInstance) {
       const isPrivileged = isPrivilegedRole(roles);
       if (!isPrivileged) {
         const allowed = await ensureProjectLeader(req, reply, projectId);
-        if (!allowed) return;
+        if (!allowed) return reply;
       }
       const project = await prisma.project.findUnique({
         where: { id: projectId },
@@ -824,7 +824,7 @@ export async function registerProjectRoutes(app: FastifyInstance) {
       const isPrivileged = isPrivilegedRole(roles);
       if (!isPrivileged) {
         const allowed = await ensureProjectLeader(req, reply, projectId);
-        if (!allowed) return;
+        if (!allowed) return reply;
       }
       const member = await prisma.projectMember.findUnique({
         where: { projectId_userId: { projectId, userId: targetUserId } },
@@ -1658,7 +1658,7 @@ export async function registerProjectRoutes(app: FastifyInstance) {
       const isPrivileged = isPrivilegedRole(roles);
       if (!isPrivileged) {
         const allowed = await ensureProjectLeader(req, reply, projectId);
-        if (!allowed) return;
+        if (!allowed) return reply;
       }
       const body = req.body as any;
       const name = typeof body.name === 'string' ? body.name.trim() : '';

--- a/packages/backend/test/projectMemberRoutes.test.js
+++ b/packages/backend/test/projectMemberRoutes.test.js
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildServer } from '../dist/server.js';
+import { prisma } from '../dist/services/db.js';
+
+const MIN_DATABASE_URL = 'postgresql://user:pass@localhost:5432/postgres';
+
+function withPrismaStubs(stubs, fn) {
+  const restores = [];
+  for (const [path, stub] of Object.entries(stubs)) {
+    const [model, method] = path.split('.');
+    const target = prisma[model];
+    if (!target || typeof target[method] !== 'function') {
+      throw new Error(`invalid stub target: ${path}`);
+    }
+    const original = target[method];
+    target[method] = stub;
+    restores.push(() => {
+      target[method] = original;
+    });
+  }
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => {
+      for (const restore of restores.reverse()) restore();
+    });
+}
+
+function withEnv(overrides, fn) {
+  const prev = new Map();
+  for (const [key, value] of Object.entries(overrides)) {
+    prev.set(key, process.env[key]);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => {
+      for (const [key, value] of prev.entries()) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    });
+}
+
+function userHeaders(userId = 'member-user') {
+  return {
+    'x-user-id': userId,
+    'x-roles': 'user',
+    'x-project-ids': '00000000-0000-0000-0000-000000000001',
+  };
+}
+
+function withServer(fn) {
+  return withEnv(
+    {
+      DATABASE_URL: process.env.DATABASE_URL || MIN_DATABASE_URL,
+      AUTH_MODE: 'header',
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        await fn(server);
+      } finally {
+        await server.close();
+      }
+    },
+  );
+}
+
+test('POST /projects/:id/members forbidden response does not destabilize server', async () => {
+  await withPrismaStubs(
+    {
+      'projectMember.findFirst': async () => null,
+    },
+    async () => {
+      await withServer(async (server) => {
+        const projectId = '00000000-0000-0000-0000-000000000001';
+        const requestBody = {
+          userId: 'candidate@example.com',
+          role: 'member',
+        };
+
+        const forbidden1 = await server.inject({
+          method: 'POST',
+          url: `/projects/${projectId}/members`,
+          headers: userHeaders('member-1'),
+          payload: requestBody,
+        });
+        assert.equal(forbidden1.statusCode, 403, forbidden1.body);
+        const forbidden1Body = JSON.parse(forbidden1.body);
+        const forbidden1Code =
+          typeof forbidden1Body?.error === 'string'
+            ? forbidden1Body.error
+            : forbidden1Body?.error?.code;
+        assert.equal(forbidden1Code, 'forbidden_project');
+
+        const health = await server.inject({ method: 'GET', url: '/health' });
+        assert.equal(health.statusCode, 200, health.body);
+
+        const forbidden2 = await server.inject({
+          method: 'POST',
+          url: `/projects/${projectId}/members`,
+          headers: userHeaders('member-2'),
+          payload: requestBody,
+        });
+        assert.equal(forbidden2.statusCode, 403, forbidden2.body);
+        const forbidden2Body = JSON.parse(forbidden2.body);
+        const forbidden2Code =
+          typeof forbidden2Body?.error === 'string'
+            ? forbidden2Body.error
+            : forbidden2Body?.error?.code;
+        assert.equal(forbidden2Code, 'forbidden_project');
+      });
+    },
+  );
+});


### PR DESCRIPTION
## 背景
PR #1261 をマージ後の `main` CI (`22425842948`) で `e2e-frontend` が再度失敗しました。

失敗時の `tmp/e2e-backend.log` で以下を確認:
- `POST /projects/:projectId/members` の 403 応答直後に
  `Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent to the client`
- backend プロセスが終了し、以降のE2Eケースが `ERR_CONNECTION_REFUSED` で連鎖失敗

## 変更内容
- `packages/backend/src/routes/projects.ts`
  - `ensureProjectLeader` の deny 時に `return reply;` を返すよう統一（6箇所）
  - reply送信済み状態でのハンドラ継続を防止
- `packages/backend/test/projectMemberRoutes.test.js`（新規）
  - `POST /projects/:id/members` の forbidden 応答後も server が健全であることを回帰テスト化

## ローカル確認
- `npm run build --prefix packages/backend`
- `DATABASE_URL='postgresql://user:pass@localhost:5432/postgres?schema=public' AUTH_MODE=header node --test packages/backend/test/projectMemberRoutes.test.js`

## 関連
- refs #1260
- 起点: main CI run `22425842948`
