### PR TITLE
docs: update trial go/no-go checklist status

### DIFF
--- a/docs/ops/release-checklist.md
+++ b/docs/ops/release-checklist.md
@@ -7,11 +7,11 @@
 - [ ] バックアップ手順を実施可能（`docs/ops/backup-restore.md`）
 
 ## 試験稼働 Go/No-Go（2026-02-26 時点）
-- [ ] `main` の `CI` が2連続成功（直近失敗: `22425842948` / `e2e-frontend`、対処PR: `#1262`）
-- [x] `Link Check` は直近5実行で成功（例: `22425842966`）
-- [x] `security-audit` は最新実行で成功（`22425842948` の `security-audit` job）
-- [ ] 既知の運用残課題を解消または受容判断（`#543` `#544` `#914` `#1153`）
-- [ ] Go/No-Go 判定ログを `#1260` に集約
+- [ ] `main` の `CI` が2連続成功（直近失敗: [22425842948](https://github.com/itdojp/ITDO_ERP4/actions/runs/22425842948) / `e2e-frontend`、対処PR: #1262）
+- [x] `Link Check` は直近5実行で成功（例: [22425842966](https://github.com/itdojp/ITDO_ERP4/actions/runs/22425842966)）
+- [x] `security-audit` は最新実行で成功（[22425842948](https://github.com/itdojp/ITDO_ERP4/actions/runs/22425842948) の `security-audit` job）
+- [ ] 既知の運用残課題を解消または受容判断（#543 #544 #914 #1153）
+- [ ] Go/No-Go 判定ログを #1260 に集約
 
 ## 実施
 - [ ] タグ付け（`vX.Y.Z`）


### PR DESCRIPTION
## 背景
- 試験稼働前ブロッカー #1260 の TODO にある docs/ops/release-checklist.md 現状化を先行実施。

## 変更内容
- docs/ops/release-checklist.md に「試験稼働 Go/No-Go（2026-02-26 時点）」セクションを追加
- 直近 main 実行結果に基づく実施状態を明記
  - CI 2連続成功: 未達
  - Link Check: 直近成功
  - security-audit: 直近成功
- 未解消の運用残課題（#543 #544 #914 #1153）と #1260 への集約タスクを明示

## 確認
- ドキュメント更新のみ（実行コマンドなし）

refs #1260
