### PR TITLE
fix: SCIM更新時の個人総務チャット会員同期を補完

### DIFF
--- a/packages/backend/src/routes/scim.ts
+++ b/packages/backend/src/routes/scim.ts
@@ -459,8 +459,10 @@ async function syncPersonalGaRoomMembership(options: {
   req: FastifyRequest;
   before: ScimUserSnapshot;
   after: ScimUserSnapshot;
+  client?: Prisma.TransactionClient;
 }) {
   const { req, before, after } = options;
+  const client = options.client ?? prisma;
   const beforeChatUserId = resolveChatUserId(before);
   const afterChatUserId = resolveChatUserId(after);
   const activeChanged = before.active !== after.active;
@@ -480,6 +482,7 @@ async function syncPersonalGaRoomMembership(options: {
       userName: after.userName,
       displayName: after.displayName,
       createdBy: actor,
+      client,
     });
     await logAudit({
       action: 'personal_ga_room_member_reactivated',
@@ -502,6 +505,7 @@ async function syncPersonalGaRoomMembership(options: {
         userId: beforeChatUserId,
         updatedBy: actor,
         reason: 'scim_user_identifier_changed',
+        client,
       });
       if (deactivated.updatedCount > 0) {
         await logAudit({
@@ -531,6 +535,7 @@ async function syncPersonalGaRoomMembership(options: {
       userId: targetUserId,
       updatedBy: actor,
       reason: 'scim_user_deactivated',
+      client,
     });
     if (deactivated.updatedCount > 0) {
       await logAudit({
@@ -774,22 +779,45 @@ export async function registerScimRoutes(app: FastifyInstance) {
     }
     let updated;
     try {
-      updated = await prisma.userAccount.update({
-        where: { id },
-        data: {
-          externalId: normalized.externalId,
-          userName: normalized.userName,
-          displayName: normalized.displayName,
-          givenName: normalized.givenName,
-          familyName: normalized.familyName,
-          active: normalized.active ?? true,
-          emails: normalized.emails as Prisma.InputJsonValue | undefined,
-          phoneNumbers: normalized.phones as Prisma.InputJsonValue | undefined,
-          department: normalized.department,
-          organization: normalized.organization,
-          managerUserId: normalized.managerUserId,
-          scimMeta: payload as Prisma.InputJsonValue,
-        },
+      updated = await prisma.$transaction(async (tx) => {
+        const next = await tx.userAccount.update({
+          where: { id },
+          data: {
+            externalId: normalized.externalId,
+            userName: normalized.userName,
+            displayName: normalized.displayName,
+            givenName: normalized.givenName,
+            familyName: normalized.familyName,
+            active: normalized.active ?? true,
+            emails: normalized.emails as Prisma.InputJsonValue | undefined,
+            phoneNumbers: normalized.phones as
+              | Prisma.InputJsonValue
+              | undefined,
+            department: normalized.department,
+            organization: normalized.organization,
+            managerUserId: normalized.managerUserId,
+            scimMeta: payload as Prisma.InputJsonValue,
+          },
+        });
+        await syncPersonalGaRoomMembership({
+          req,
+          before: {
+            id: current.id,
+            externalId: current.externalId,
+            userName: current.userName,
+            displayName: current.displayName,
+            active: current.active,
+          },
+          after: {
+            id: next.id,
+            externalId: next.externalId,
+            userName: next.userName,
+            displayName: next.displayName,
+            active: next.active,
+          },
+          client: tx,
+        });
+        return next;
       });
     } catch (err) {
       if (
@@ -800,23 +828,6 @@ export async function registerScimRoutes(app: FastifyInstance) {
       }
       throw err;
     }
-    await syncPersonalGaRoomMembership({
-      req,
-      before: {
-        id: current.id,
-        externalId: current.externalId,
-        userName: current.userName,
-        displayName: current.displayName,
-        active: current.active,
-      },
-      after: {
-        id: updated.id,
-        externalId: updated.externalId,
-        userName: updated.userName,
-        displayName: updated.displayName,
-        active: updated.active,
-      },
-    });
     await logAudit({
       action: 'scim_user_update',
       targetTable: 'UserAccount',
@@ -928,26 +939,30 @@ export async function registerScimRoutes(app: FastifyInstance) {
         .send(scimError(400, 'externalId_required_for_userName_update'));
     }
     try {
-      const updated = await prisma.userAccount.update({
-        where: { id },
-        data: update,
-      });
-      await syncPersonalGaRoomMembership({
-        req,
-        before: {
-          id: current.id,
-          externalId: current.externalId,
-          userName: current.userName,
-          displayName: current.displayName,
-          active: current.active,
-        },
-        after: {
-          id: updated.id,
-          externalId: updated.externalId,
-          userName: updated.userName,
-          displayName: updated.displayName,
-          active: updated.active,
-        },
+      const updated = await prisma.$transaction(async (tx) => {
+        const next = await tx.userAccount.update({
+          where: { id },
+          data: update,
+        });
+        await syncPersonalGaRoomMembership({
+          req,
+          before: {
+            id: current.id,
+            externalId: current.externalId,
+            userName: current.userName,
+            displayName: current.displayName,
+            active: current.active,
+          },
+          after: {
+            id: next.id,
+            externalId: next.externalId,
+            userName: next.userName,
+            displayName: next.displayName,
+            active: next.active,
+          },
+          client: tx,
+        });
+        return next;
       });
       await logAudit({
         action: 'scim_user_patch',

--- a/packages/backend/test/scimPersonalGaLifecycle.test.js
+++ b/packages/backend/test/scimPersonalGaLifecycle.test.js
@@ -9,8 +9,10 @@ const MIN_DATABASE_URL = 'postgresql://user:pass@localhost:5432/postgres';
 function withPrismaStubs(stubs, fn) {
   const restores = [];
   for (const [path, stub] of Object.entries(stubs)) {
-    const [model, method] = path.split('.');
-    const target = prisma[model];
+    const segments = path.split('.');
+    const model = segments.length > 1 ? segments[0] : null;
+    const method = segments.length > 1 ? segments[1] : segments[0];
+    const target = model ? prisma[model] : prisma;
     if (!target || typeof target[method] !== 'function') {
       throw new Error(`invalid stub target: ${path}`);
     }
@@ -100,6 +102,7 @@ test('PUT /scim/v2/Users/:id deactivates previous personal GA member when identi
   const auditLogs = [];
   await withPrismaStubs(
     {
+      $transaction: async (handler) => handler(prisma),
       'userAccount.findUnique': async () => buildScimUser(),
       'userAccount.findFirst': async () => null,
       'userAccount.update': async () =>
@@ -159,6 +162,7 @@ test('PUT /scim/v2/Users/:id deactivates personal GA member when active=false', 
   const auditLogs = [];
   await withPrismaStubs(
     {
+      $transaction: async (handler) => handler(prisma),
       'userAccount.findUnique': async () => buildScimUser(),
       'userAccount.findFirst': async () => null,
       'userAccount.update': async () =>
@@ -212,4 +216,127 @@ test('PUT /scim/v2/Users/:id deactivates personal GA member when active=false', 
   assert.equal(actions.includes('personal_ga_room_member_deactivated'), true);
   assert.equal(actions.includes('personal_ga_room_member_reactivated'), false);
   assert.equal(actions.includes('scim_user_update'), true);
+});
+
+test('PATCH /scim/v2/Users/:id switches personal GA member when externalId is replaced', async () => {
+  const memberUpserts = [];
+  const memberDeactivations = [];
+  const auditLogs = [];
+  await withPrismaStubs(
+    {
+      $transaction: async (handler) => handler(prisma),
+      'userAccount.findUnique': async () => buildScimUser(),
+      'userAccount.update': async (args) =>
+        buildScimUser({
+          externalId: args?.data?.externalId ?? 'employee-2',
+          updatedAt: new Date('2026-03-03T00:00:00.000Z'),
+        }),
+      'groupAccount.upsert': async () => ({ id: 'general_affairs' }),
+      'chatRoom.upsert': async () => ({ id: 'pga_room_1' }),
+      'chatRoomMember.upsert': async (args) => {
+        memberUpserts.push(args);
+        return { roomId: 'pga_room_1', userId: 'employee-2', role: 'owner' };
+      },
+      'chatRoomMember.updateMany': async (args) => {
+        memberDeactivations.push(args);
+        return { count: 1 };
+      },
+      'auditLog.create': async (args) => {
+        auditLogs.push(args.data);
+        return { id: `audit-${auditLogs.length}` };
+      },
+    },
+    async () => {
+      await withServer(async (server) => {
+        const res = await server.inject({
+          method: 'PATCH',
+          url: '/scim/v2/Users/ua-1',
+          headers: scimHeaders(),
+          payload: {
+            Operations: [
+              {
+                op: 'replace',
+                path: 'externalId',
+                value: {
+                  externalId: 'employee-2',
+                },
+              },
+            ],
+          },
+        });
+        assert.equal(res.statusCode, 200, res.body);
+      });
+    },
+  );
+
+  assert.equal(memberUpserts.length, 1);
+  assert.equal(memberUpserts[0]?.where?.roomId_userId?.userId, 'employee-2');
+  assert.equal(memberDeactivations.length, 1);
+  assert.equal(memberDeactivations[0]?.where?.userId, 'employee-1');
+  const actions = auditLogs.map((entry) => entry.action);
+  assert.equal(actions.includes('personal_ga_room_member_reactivated'), true);
+  assert.equal(actions.includes('personal_ga_room_member_deactivated'), true);
+  assert.equal(actions.includes('scim_user_patch'), true);
+});
+
+test('PATCH /scim/v2/Users/:id remove active deactivates personal GA member', async () => {
+  const memberDeactivations = [];
+  const auditLogs = [];
+  await withPrismaStubs(
+    {
+      $transaction: async (handler) => handler(prisma),
+      'userAccount.findUnique': async () => buildScimUser(),
+      'userAccount.update': async () =>
+        buildScimUser({
+          active: false,
+          updatedAt: new Date('2026-03-03T00:00:00.000Z'),
+        }),
+      'groupAccount.upsert': async () => {
+        throw new Error('groupAccount.upsert should not be called');
+      },
+      'chatRoom.upsert': async () => {
+        throw new Error('chatRoom.upsert should not be called');
+      },
+      'chatRoomMember.upsert': async () => {
+        throw new Error('chatRoomMember.upsert should not be called');
+      },
+      'chatRoomMember.updateMany': async (args) => {
+        memberDeactivations.push(args);
+        return { count: 1 };
+      },
+      'auditLog.create': async (args) => {
+        auditLogs.push(args.data);
+        return { id: `audit-${auditLogs.length}` };
+      },
+    },
+    async () => {
+      await withServer(async (server) => {
+        const res = await server.inject({
+          method: 'PATCH',
+          url: '/scim/v2/Users/ua-1',
+          headers: scimHeaders(),
+          payload: {
+            Operations: [
+              {
+                op: 'remove',
+                path: 'active',
+              },
+            ],
+          },
+        });
+        assert.equal(res.statusCode, 200, res.body);
+      });
+    },
+  );
+
+  assert.equal(memberDeactivations.length, 1);
+  assert.equal(memberDeactivations[0]?.where?.userId, 'employee-1');
+  assert.equal(
+    memberDeactivations[0]?.data?.deletedReason,
+    'scim_user_deactivated',
+  );
+  const actions = auditLogs.map((entry) => entry.action);
+  assert.equal(actions.includes('personal_ga_room_member_deactivated'), true);
+  assert.equal(actions.includes('personal_ga_room_member_reactivated'), false);
+  assert.equal(actions.includes('scim_user_patch'), true);
 });


### PR DESCRIPTION
## 対応内容
- SCIM User `PUT/PATCH` 更新時に、個人総務チャット会員を差分同期する処理を追加
  - `active` 変更（有効化/無効化）時の会員復元・無効化
  - `externalId/userName`（チャット識別子）変更時の旧識別子会員の無効化 + 新識別子会員の復元
- 上記同期時に監査ログを出力
  - `personal_ga_room_member_reactivated`
  - `personal_ga_room_member_deactivated`
- 回帰防止として SCIM PUT のテストを追加
  - 識別子変更時の会員切替
  - `active=false` 時の会員無効化

## 目的
- Issue #1270 の未完了項目「退職/異動時のアクセス権更新と監査」の実装補完

## 実行した確認
- `npm run lint --prefix packages/backend`
- `npm run test --prefix packages/backend -- test/scimPersonalGaLifecycle.test.js`
