### PR TITLE
feat(leave): 種別別の申請単位制約と添付要件バリデーションを追加

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -6788,7 +6788,9 @@
                   "leaveType": {
                     "type": "string"
                   },
-                  "leaveUnit": {},
+                  "leaveUnit": {
+                    "description": "Leave request unit. Allowed values are 'daily' and 'hourly' (validated in handler for backward compatibility)."
+                  },
                   "notes": {
                     "type": "string"
                   },

--- a/packages/backend/src/routes/leave.ts
+++ b/packages/backend/src/routes/leave.ts
@@ -345,6 +345,18 @@ export async function registerLeaveRoutes(app: FastifyInstance) {
       }
       const usesHourlyLeave =
         startTimeMinutes !== null || endTimeMinutes !== null;
+      const hasLeaveUnit =
+        body !== null &&
+        typeof body === 'object' &&
+        Object.prototype.hasOwnProperty.call(body, 'leaveUnit');
+      if (hasLeaveUnit && typeof body.leaveUnit !== 'string') {
+        return reply.status(400).send({
+          error: {
+            code: 'INVALID_LEAVE_UNIT',
+            message: 'leaveUnit must be daily or hourly',
+          },
+        });
+      }
       const requestedLeaveUnitRaw =
         typeof body.leaveUnit === 'string'
           ? body.leaveUnit.trim().toLowerCase()
@@ -730,9 +742,16 @@ export async function registerLeaveRoutes(app: FastifyInstance) {
         },
         select: { internalRefs: true, externalUrls: true },
       });
-      const internalRefs = Array.isArray(annotation?.internalRefs)
+      const rawInternalRefs = Array.isArray(annotation?.internalRefs)
         ? (annotation?.internalRefs as Array<Record<string, unknown>>)
         : [];
+      const normalizedInternalRefs = rawInternalRefs.flatMap((ref) => {
+        if (!ref || typeof ref !== 'object') return [];
+        const kind = typeof ref.kind === 'string' ? ref.kind.trim() : '';
+        const refId = typeof ref.id === 'string' ? ref.id.trim() : '';
+        if (!kind || !refId) return [];
+        return [{ kind, refId }];
+      });
       const externalUrls = Array.isArray(annotation?.externalUrls)
         ? annotation.externalUrls
             .filter(
@@ -746,7 +765,7 @@ export async function registerLeaveRoutes(app: FastifyInstance) {
         includeInactive: true,
       });
       const hasAttachmentEvidence =
-        externalUrls.length > 0 || internalRefs.length > 0;
+        externalUrls.length > 0 || normalizedInternalRefs.length > 0;
       if (
         leaveType?.attachmentPolicy === 'required' &&
         !hasAttachmentEvidence
@@ -759,12 +778,9 @@ export async function registerLeaveRoutes(app: FastifyInstance) {
           },
         });
       }
-      const hasConsultationEvidence = internalRefs.some((ref) => {
-        if (!ref || typeof ref !== 'object') return false;
-        const kind = typeof ref.kind === 'string' ? ref.kind.trim() : '';
-        const refId = typeof ref.id === 'string' ? ref.id.trim() : '';
-        return kind === 'chat_message' && Boolean(refId);
-      });
+      const hasConsultationEvidence = normalizedInternalRefs.some(
+        (ref) => ref.kind === 'chat_message',
+      );
 
       if (!hasConsultationEvidence) {
         if (!noConsultationConfirmed || !noConsultationReason) {

--- a/packages/backend/src/routes/validators.ts
+++ b/packages/backend/src/routes/validators.ts
@@ -1002,7 +1002,12 @@ export const leaveRequestSchema = {
     // NOTE: `openapi-diff` flags it as a breaking change to introduce a new field with a
     // stricter schema when the previous schema allowed unknown properties. We keep these
     // fields schema-loose and validate in the handler.
-    leaveUnit: Type.Optional(Type.Any()),
+    leaveUnit: Type.Optional(
+      Type.Any({
+        description:
+          "Leave request unit. Allowed values are 'daily' and 'hourly' (validated in handler for backward compatibility).",
+      }),
+    ),
     startTime: Type.Optional(Type.Any()),
     endTime: Type.Optional(Type.Any()),
     hours: Type.Optional(Type.Number({ minimum: 0 })),

--- a/packages/backend/test/leaveTypeRoutes.test.js
+++ b/packages/backend/test/leaveTypeRoutes.test.js
@@ -272,3 +272,113 @@ test('PATCH /leave-types normalizes blank description to null', async () => {
   );
   assert.equal(updatePayload?.description, null);
 });
+
+test('POST /leave-requests/:id/submit rejects required attachment when missing evidence', async () => {
+  await withPrismaStubs(
+    {
+      'leaveType.findMany': async () => [
+        { code: 'paid' },
+        { code: 'special' },
+        { code: 'substitute' },
+        { code: 'compensatory' },
+        { code: 'unpaid' },
+      ],
+      'leaveRequest.findUnique': async () => ({
+        id: 'leave-1',
+        userId: 'normal-user',
+        status: 'draft',
+        leaveType: 'special',
+        startDate: new Date('2026-03-01T00:00:00.000Z'),
+        endDate: new Date('2026-03-01T00:00:00.000Z'),
+        startTimeMinutes: null,
+        endTimeMinutes: null,
+        minutes: null,
+        hours: 8,
+      }),
+      'actionPolicy.findMany': async () => [],
+      'leaveSetting.upsert': async () => ({
+        id: 'default',
+        timeUnitMinutes: 10,
+        defaultWorkdayMinutes: 480,
+      }),
+      'timeEntry.count': async () => 0,
+      'annotation.findUnique': async () => ({
+        internalRefs: [],
+        externalUrls: [],
+      }),
+      'leaveType.findFirst': async () => ({
+        code: 'special',
+        attachmentPolicy: 'required',
+        active: true,
+      }),
+    },
+    async () => {
+      await withServer(async (server) => {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/leave-requests/leave-1/submit',
+          headers: userHeaders(),
+          payload: {},
+        });
+        assert.equal(res.statusCode, 400, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.error?.code, 'ATTACHMENT_EVIDENCE_REQUIRED');
+      });
+    },
+  );
+});
+
+test('POST /leave-requests/:id/submit proceeds past attachment check when evidence exists', async () => {
+  await withPrismaStubs(
+    {
+      'leaveType.findMany': async () => [
+        { code: 'paid' },
+        { code: 'special' },
+        { code: 'substitute' },
+        { code: 'compensatory' },
+        { code: 'unpaid' },
+      ],
+      'leaveRequest.findUnique': async () => ({
+        id: 'leave-2',
+        userId: 'normal-user',
+        status: 'draft',
+        leaveType: 'special',
+        startDate: new Date('2026-03-01T00:00:00.000Z'),
+        endDate: new Date('2026-03-01T00:00:00.000Z'),
+        startTimeMinutes: null,
+        endTimeMinutes: null,
+        minutes: null,
+        hours: 8,
+      }),
+      'actionPolicy.findMany': async () => [],
+      'leaveSetting.upsert': async () => ({
+        id: 'default',
+        timeUnitMinutes: 10,
+        defaultWorkdayMinutes: 480,
+      }),
+      'timeEntry.count': async () => 0,
+      'annotation.findUnique': async () => ({
+        internalRefs: [],
+        externalUrls: ['https://example.com/evidence'],
+      }),
+      'leaveType.findFirst': async () => ({
+        code: 'special',
+        attachmentPolicy: 'required',
+        active: true,
+      }),
+    },
+    async () => {
+      await withServer(async (server) => {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/leave-requests/leave-2/submit',
+          headers: userHeaders(),
+          payload: {},
+        });
+        assert.equal(res.statusCode, 400, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.error?.code, 'NO_CONSULTATION_REASON_REQUIRED');
+      });
+    },
+  );
+});

--- a/packages/frontend/src/sections/LeaveRequests.tsx
+++ b/packages/frontend/src/sections/LeaveRequests.tsx
@@ -322,6 +322,9 @@ export const LeaveRequests: React.FC = () => {
     if (selectedLeaveType?.unit === 'hourly') return ['hourly'];
     return ['daily', 'hourly'];
   }, [selectedLeaveType]);
+  const effectiveRequestUnit = allowedRequestUnits.includes(form.requestUnit)
+    ? form.requestUnit
+    : allowedRequestUnits[0];
 
   const normalizeRequestUnit = (
     prev: typeof form,
@@ -372,7 +375,7 @@ export const LeaveRequests: React.FC = () => {
       setMessage('開始日/終了日は必須です');
       return;
     }
-    const requestUnit = form.requestUnit;
+    const requestUnit = effectiveRequestUnit;
     const payload: {
       userId: string;
       leaveType: string;
@@ -775,7 +778,7 @@ export const LeaveRequests: React.FC = () => {
             <span>申請単位</span>
             <select
               aria-label="休暇申請単位"
-              value={form.requestUnit}
+              value={effectiveRequestUnit}
               onChange={(e) =>
                 setForm((prev) =>
                   normalizeRequestUnit(
@@ -834,7 +837,7 @@ export const LeaveRequests: React.FC = () => {
                   ...prev,
                   startDate: e.target.value,
                   endDate:
-                    prev.requestUnit === 'hourly'
+                    effectiveRequestUnit === 'hourly'
                       ? e.target.value
                       : prev.endDate,
                 }))
@@ -848,10 +851,10 @@ export const LeaveRequests: React.FC = () => {
               type="date"
               value={form.endDate}
               onChange={(e) => setForm({ ...form, endDate: e.target.value })}
-              disabled={form.requestUnit === 'hourly'}
+              disabled={effectiveRequestUnit === 'hourly'}
             />
           </label>
-          {form.requestUnit === 'hourly' ? (
+          {effectiveRequestUnit === 'hourly' ? (
             <>
               <label className="row" style={{ gap: 6, alignItems: 'center' }}>
                 <span>開始時刻</span>


### PR DESCRIPTION
## 概要
- #1282 Phase2 のうち、以下を先行実装
  - 種別別の取得単位制約（日/時間）
  - 添付要件（required）の submit 前バリデーション
- 併せてフロントで種別に応じた申請単位UI制御と注意表示を追加

## 変更内容
- backend
  - `POST /leave-requests`
    - `leaveUnit`（daily/hourly）入力を受け付け、`leaveType.unit` と整合チェック
    - 単位不整合時に `LEAVE_TYPE_UNIT_MISMATCH` を返却
  - `POST /leave-requests/:id/submit`
    - `leaveType.attachmentPolicy === "required"` の場合、
      `Annotation.externalUrls/internalRefs` に1件以上の証跡がないと
      `ATTACHMENT_EVIDENCE_REQUIRED` を返却
  - `leaveRequestSchema` に `leaveUnit` を追加（従来方針に合わせて schema-loose）
  - ルートテスト追加（単位不整合の拒否）
- frontend
  - `LeaveRequests` で `leaveType.unit` に応じて申請単位選択肢を制限
  - payload に `leaveUnit` を送信
  - `attachmentPolicy=required` の注意メッセージ表示
- API
  - `docs/api/openapi.json` を更新（`leaveUnit` 反映）

## テスト
- `npm run lint --prefix packages/backend`
- `npm run typecheck --prefix packages/backend`
- `npm run format:check --prefix packages/backend`
- `npm run build --prefix packages/backend`
- `npm run test --prefix packages/backend`
- `npm run test:ci --prefix packages/backend -- test/leaveTypeRoutes.test.js`
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run format:check --prefix packages/frontend`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public node scripts/export-openapi.mjs --out tmp/openapi.json`

## 補足
- 雇用区分/拠点による適用範囲制御は未着手（Phase2の残タスク）。
- E2E拡充は次PRで対応予定。

## 関連
- #1282
- #1268
