### PR TITLE
feat(leave): add group-based applicability scope for leave types

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -6975,6 +6975,15 @@
                   "active": {
                     "type": "boolean"
                   },
+                  "applicableGroupIds": {
+                    "items": {
+                      "maxLength": 200,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "maxItems": 200,
+                    "type": "array"
+                  },
                   "attachmentPolicy": {
                     "anyOf": [
                       {
@@ -7091,6 +7100,16 @@
                 "properties": {
                   "active": {
                     "type": "boolean"
+                  },
+                  "applicableGroupIds": {
+                    "items": {
+                      "maxLength": 200,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "maxItems": 200,
+                    "nullable": true,
+                    "type": "array"
                   },
                   "attachmentPolicy": {
                     "anyOf": [

--- a/packages/backend/prisma/migrations/20260302030000_add_leave_type_applicable_group_ids/migration.sql
+++ b/packages/backend/prisma/migrations/20260302030000_add_leave_type_applicable_group_ids/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "LeaveType"
+ADD COLUMN "applicableGroupIds" JSONB;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -663,6 +663,7 @@ model LeaveType {
   unit             String   @default("daily") // daily/hourly/mixed
   requiresApproval Boolean  @default(true)
   attachmentPolicy String   @default("optional") // required/optional/none
+  applicableGroupIds Json? // target groupAccount ids. null/empty means applicable to all.
   active           Boolean  @default(true)
   displayOrder     Int      @default(100)
   effectiveFrom    DateTime @default(now())

--- a/packages/backend/src/routes/leave.ts
+++ b/packages/backend/src/routes/leave.ts
@@ -1,4 +1,5 @@
 import { FastifyInstance } from 'fastify';
+import { Prisma } from '@prisma/client';
 import { prisma } from '../services/db.js';
 import { submitApprovalWithUpdate } from '../services/approval.js';
 import { createApprovalPendingNotifications } from '../services/appNotifications.js';
@@ -27,6 +28,7 @@ import {
   leaveTypeAttachmentPolicies,
   leaveTypeUnits,
   listLeaveTypes,
+  normalizeLeaveTypeApplicableGroupIds,
   normalizeLeaveTypeInput,
 } from '../services/leaveTypes.js';
 
@@ -50,6 +52,12 @@ function normalizeListLimit(value: unknown) {
   return Math.max(1, Math.min(300, Math.floor(value)));
 }
 
+function hasGroupIntersection(lhs: string[], rhs: string[]) {
+  if (!lhs.length || !rhs.length) return false;
+  const set = new Set(lhs);
+  return rhs.some((value) => set.has(value));
+}
+
 export async function registerLeaveRoutes(app: FastifyInstance) {
   app.get(
     '/leave-types',
@@ -64,9 +72,22 @@ export async function registerLeaveRoutes(app: FastifyInstance) {
       const includeInactive =
         (roles.includes('admin') || roles.includes('mgmt')) &&
         (req.query as { includeInactive?: boolean })?.includeInactive === true;
+      const actorGroupIds = Array.isArray(req.user?.groupAccountIds)
+        ? req.user.groupAccountIds
+        : [];
+      const isPrivileged = roles.includes('admin') || roles.includes('mgmt');
       const items = await listLeaveTypes({ includeInactive });
+      const visibleItems = isPrivileged
+        ? items
+        : items.filter((item) => {
+            const applicableGroupIds = normalizeLeaveTypeApplicableGroupIds(
+              item.applicableGroupIds,
+            );
+            if (!applicableGroupIds.length) return true;
+            return hasGroupIntersection(applicableGroupIds, actorGroupIds);
+          });
       return {
-        items: items.map((item) => ({
+        items: visibleItems.map((item) => ({
           code: item.code,
           name: item.name,
           description: item.description,
@@ -74,6 +95,9 @@ export async function registerLeaveRoutes(app: FastifyInstance) {
           unit: item.unit,
           requiresApproval: item.requiresApproval,
           attachmentPolicy: item.attachmentPolicy,
+          applicableGroupIds: normalizeLeaveTypeApplicableGroupIds(
+            item.applicableGroupIds,
+          ),
           active: item.active,
           displayOrder: item.displayOrder,
           effectiveFrom: item.effectiveFrom,
@@ -97,6 +121,7 @@ export async function registerLeaveRoutes(app: FastifyInstance) {
         unit: string;
         requiresApproval: boolean;
         attachmentPolicy: string;
+        applicableGroupIds?: string[];
         displayOrder?: number;
         active?: boolean;
         effectiveFrom?: string;
@@ -138,6 +163,35 @@ export async function registerLeaveRoutes(app: FastifyInstance) {
           },
         });
       }
+      let applicableGroupIds: string[] = [];
+      if (body.applicableGroupIds !== undefined) {
+        if (!Array.isArray(body.applicableGroupIds)) {
+          return reply.status(400).send({
+            error: {
+              code: 'INVALID_APPLICABLE_GROUP_IDS',
+              message: 'applicableGroupIds must be an array of group ids',
+            },
+          });
+        }
+        applicableGroupIds = normalizeLeaveTypeApplicableGroupIds(
+          body.applicableGroupIds,
+        );
+        const existing = await prisma.groupAccount.findMany({
+          where: { id: { in: applicableGroupIds } },
+          select: { id: true },
+        });
+        const existingSet = new Set(existing.map((item) => item.id));
+        const missing = applicableGroupIds.filter((id) => !existingSet.has(id));
+        if (missing.length) {
+          return reply.status(400).send({
+            error: {
+              code: 'INVALID_APPLICABLE_GROUP_IDS',
+              message: 'unknown group ids are included in applicableGroupIds',
+              details: { missingGroupIds: missing },
+            },
+          });
+        }
+      }
       const effectiveFrom = body.effectiveFrom
         ? new Date(body.effectiveFrom)
         : new Date();
@@ -159,6 +213,9 @@ export async function registerLeaveRoutes(app: FastifyInstance) {
             unit: body.unit,
             requiresApproval: body.requiresApproval,
             attachmentPolicy: body.attachmentPolicy,
+            applicableGroupIds: applicableGroupIds.length
+              ? applicableGroupIds
+              : undefined,
             displayOrder: body.displayOrder ?? 100,
             active: body.active ?? true,
             effectiveFrom,
@@ -254,6 +311,43 @@ export async function registerLeaveRoutes(app: FastifyInstance) {
           });
         }
         update.attachmentPolicy = body.attachmentPolicy;
+      }
+      if (Object.prototype.hasOwnProperty.call(body, 'applicableGroupIds')) {
+        if (body.applicableGroupIds === null) {
+          update.applicableGroupIds = Prisma.DbNull;
+        } else {
+          if (!Array.isArray(body.applicableGroupIds)) {
+            return reply.status(400).send({
+              error: {
+                code: 'INVALID_APPLICABLE_GROUP_IDS',
+                message: 'applicableGroupIds must be an array of group ids',
+              },
+            });
+          }
+          const applicableGroupIds = normalizeLeaveTypeApplicableGroupIds(
+            body.applicableGroupIds,
+          );
+          const existing = await prisma.groupAccount.findMany({
+            where: { id: { in: applicableGroupIds } },
+            select: { id: true },
+          });
+          const existingSet = new Set(existing.map((item) => item.id));
+          const missing = applicableGroupIds.filter(
+            (id) => !existingSet.has(id),
+          );
+          if (missing.length) {
+            return reply.status(400).send({
+              error: {
+                code: 'INVALID_APPLICABLE_GROUP_IDS',
+                message: 'unknown group ids are included in applicableGroupIds',
+                details: { missingGroupIds: missing },
+              },
+            });
+          }
+          update.applicableGroupIds = applicableGroupIds.length
+            ? applicableGroupIds
+            : Prisma.DbNull;
+        }
       }
       if (typeof body.effectiveFrom === 'string') {
         const effectiveFrom = new Date(body.effectiveFrom);
@@ -408,6 +502,35 @@ export async function registerLeaveRoutes(app: FastifyInstance) {
             message: 'leaveType must be an active leave type code',
           },
         });
+      }
+      const applicableGroupIds = normalizeLeaveTypeApplicableGroupIds(
+        leaveType.applicableGroupIds,
+      );
+      if (applicableGroupIds.length) {
+        let targetUserGroupIds = Array.isArray(req.user?.groupAccountIds)
+          ? req.user.groupAccountIds
+          : [];
+        if (!targetUserGroupIds.length || currentUserId !== body.userId) {
+          const targetUser = await prisma.userAccount.findUnique({
+            where: { userName: body.userId },
+            select: {
+              memberships: {
+                select: { group: { select: { id: true } } },
+              },
+            },
+          });
+          targetUserGroupIds = (targetUser?.memberships ?? []).map(
+            (item) => item.group.id,
+          );
+        }
+        if (!hasGroupIntersection(applicableGroupIds, targetUserGroupIds)) {
+          return reply.status(403).send({
+            error: {
+              code: 'LEAVE_TYPE_NOT_APPLICABLE',
+              message: 'selected leaveType is not applicable to this user',
+            },
+          });
+        }
       }
       if (requestedLeaveUnit === 'hourly' && !usesHourlyLeave) {
         return reply.status(400).send({

--- a/packages/backend/src/routes/validators.ts
+++ b/packages/backend/src/routes/validators.ts
@@ -1061,6 +1061,11 @@ export const leaveTypeCreateSchema = {
         Type.Literal('optional'),
         Type.Literal('none'),
       ]),
+      applicableGroupIds: Type.Optional(
+        Type.Array(Type.String({ minLength: 1, maxLength: 200 }), {
+          maxItems: 200,
+        }),
+      ),
       displayOrder: Type.Optional(
         Type.Integer({ minimum: 0, maximum: 100000 }),
       ),
@@ -1092,6 +1097,14 @@ export const leaveTypeUpdateSchema = {
           Type.Literal('required'),
           Type.Literal('optional'),
           Type.Literal('none'),
+        ]),
+      ),
+      applicableGroupIds: Type.Optional(
+        Type.Union([
+          Type.Array(Type.String({ minLength: 1, maxLength: 200 }), {
+            maxItems: 200,
+          }),
+          Type.Null(),
         ]),
       ),
       displayOrder: Type.Optional(

--- a/packages/backend/src/services/leaveTypes.ts
+++ b/packages/backend/src/services/leaveTypes.ts
@@ -72,6 +72,18 @@ function normalizeLeaveTypeCode(code: string) {
   return code.trim().toLowerCase();
 }
 
+export function normalizeLeaveTypeApplicableGroupIds(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  const ids: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== 'string') continue;
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    ids.push(trimmed);
+  }
+  return Array.from(new Set(ids));
+}
+
 export async function ensureDefaultLeaveTypes(options?: {
   actorId?: string | null;
   client?: Prisma.TransactionClient | typeof prisma;

--- a/packages/backend/test/leaveTypeRoutes.test.js
+++ b/packages/backend/test/leaveTypeRoutes.test.js
@@ -61,11 +61,19 @@ function withServer(fn) {
   );
 }
 
-function userHeaders() {
-  return {
+function userHeaders(userId = 'normal-user', options = {}) {
+  const headers = {
     'x-user-id': 'normal-user',
     'x-roles': 'user',
   };
+  headers['x-user-id'] = userId;
+  if (
+    Array.isArray(options.groupAccountIds) &&
+    options.groupAccountIds.length > 0
+  ) {
+    headers['x-group-account-ids'] = options.groupAccountIds.join(',');
+  }
+  return headers;
 }
 
 function adminHeaders() {
@@ -188,6 +196,80 @@ test('POST /leave-requests rejects unit mismatch for leave type', async () => {
         assert.equal(res.statusCode, 400, res.body);
         const body = JSON.parse(res.body);
         assert.equal(body?.error?.code, 'LEAVE_TYPE_UNIT_MISMATCH');
+      });
+    },
+  );
+});
+
+test('POST /leave-requests rejects leave type not applicable for user groups', async () => {
+  await withPrismaStubs(
+    {
+      'leaveType.findMany': async () => [
+        { code: 'paid' },
+        { code: 'special' },
+        { code: 'substitute' },
+        { code: 'compensatory' },
+        { code: 'unpaid' },
+      ],
+      'leaveType.findFirst': async () => ({
+        code: 'special',
+        unit: 'daily',
+        active: true,
+        applicableGroupIds: ['employment-fulltime'],
+      }),
+    },
+    async () => {
+      await withServer(async (server) => {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/leave-requests',
+          headers: userHeaders('normal-user', {
+            groupAccountIds: ['employment-contract'],
+          }),
+          payload: {
+            userId: 'normal-user',
+            leaveType: 'special',
+            leaveUnit: 'daily',
+            startDate: '2026-03-01',
+            endDate: '2026-03-01',
+          },
+        });
+        assert.equal(res.statusCode, 403, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.error?.code, 'LEAVE_TYPE_NOT_APPLICABLE');
+      });
+    },
+  );
+});
+
+test('POST /leave-requests rejects non-string leaveUnit payload', async () => {
+  await withPrismaStubs(
+    {
+      'leaveType.findMany': async () => [
+        { code: 'paid' },
+        { code: 'special' },
+        { code: 'substitute' },
+        { code: 'compensatory' },
+        { code: 'unpaid' },
+      ],
+    },
+    async () => {
+      await withServer(async (server) => {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/leave-requests',
+          headers: userHeaders(),
+          payload: {
+            userId: 'normal-user',
+            leaveType: 'special',
+            leaveUnit: { invalid: true },
+            startDate: '2026-03-01',
+            endDate: '2026-03-01',
+          },
+        });
+        assert.equal(res.statusCode, 400, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.error?.code, 'INVALID_LEAVE_UNIT');
       });
     },
   );

--- a/packages/frontend/src/sections/LeaveRequests.tsx
+++ b/packages/frontend/src/sections/LeaveRequests.tsx
@@ -101,6 +101,7 @@ type LeaveTypeOption = {
   isPaid: boolean;
   unit: 'daily' | 'hourly' | 'mixed';
   attachmentPolicy: 'required' | 'optional' | 'none';
+  applicableGroupIds?: string[];
   active: boolean;
   displayOrder: number;
 };


### PR DESCRIPTION
## 概要
#1282 Phase2 の残り（適用範囲の最小導入）として、休暇種別の適用対象を groupAccount ベースで制御できるようにしました。

## 変更内容
- backend
  - `LeaveType` に `applicableGroupIds`（JSON）を追加（migration含む）
  - `GET /leave-types`
    - 一般ユーザーは「対象グループが空（全体適用）」または「自分の groupAccountIds と交差する種別」のみ取得
    - admin/mgmt は従来どおり全件取得可
  - `POST/PATCH /leave-types`
    - `applicableGroupIds` 入力を受け付け
    - unknown group id を `INVALID_APPLICABLE_GROUP_IDS` で拒否
  - `POST /leave-requests`
    - 申請者が種別の適用グループに属さない場合 `LEAVE_TYPE_NOT_APPLICABLE` を返却
- frontend
  - `LeaveTypeOption` 型に `applicableGroupIds` を追加（API追従）
- tests
  - `leaveTypeRoutes.test.js` に以下を追加
    - 非適用グループユーザーでの申請拒否
    - `leaveUnit` 非文字列入力の拒否

## 仕様メモ
- 「雇用区分」は groupAccount で表現する前提で先行導入。
- `applicableGroupIds` が `null/[]` の場合は全体適用。

## テスト
- `npm run prisma:generate --prefix packages/backend`
- `npm run lint --prefix packages/backend`
- `npm run typecheck --prefix packages/backend`
- `npm run build --prefix packages/backend`
- `npm run test --prefix packages/backend`
- `npm run test:ci --prefix packages/backend -- test/leaveTypeRoutes.test.js`
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run format:check --prefix packages/frontend`
- OpenAPI再生成 + 差分反映

## 関連
- #1282
- #1268
