### PR TITLE
test(e2e): stabilize admin jobs leave-upcoming scenario

### DIFF
--- a/packages/frontend/e2e/frontend-admin-jobs-notification-jobs.spec.ts
+++ b/packages/frontend/e2e/frontend-admin-jobs-notification-jobs.spec.ts
@@ -245,8 +245,12 @@ test('frontend admin jobs: chat ack reminder / leave upcoming run and dashboard 
   );
   await ensureOk(ackCreateRes);
 
-  const suffixDigits = Number(suffix.replace(/\D/g, '').slice(-3) || '0');
-  const leaveOffsetDays = 7 + (suffixDigits % 20);
+  const suffixHash = Array.from(suffix).reduce(
+    (acc, ch) => acc + ch.charCodeAt(0),
+    0,
+  );
+  // Spread test leave dates over a 7-26 day window to reduce cross-run collisions.
+  const leaveOffsetDays = 7 + (suffixHash % 20);
   const leaveDate = new Date(Date.now() + leaveOffsetDays * 24 * 60 * 60 * 1000)
     .toISOString()
     .slice(0, 10);


### PR DESCRIPTION
## 概要
`main` の `CI / e2e-frontend` で発生した `LEAVE_REQUEST_CONFLICT` に対する安定化修正です。

- 失敗run: https://github.com/itdojp/ITDO_ERP4/actions/runs/22600714066
- 失敗内容: `frontend-admin-jobs-notification-jobs` が固定日（現在+2日）で休暇申請を作成し、同一ユーザー/同日で他E2Eケースと衝突して 409 (`LEAVE_REQUEST_CONFLICT`)。

## 変更内容
- `packages/frontend/e2e/frontend-admin-jobs-notification-jobs.spec.ts`
  - `leaveDate` を固定オフセット（+2日）から、`runId` 由来の可変オフセット（7〜26日）へ変更
  - 既存の active user 制約（chat ack request の requiredUserIds）を壊さないよう、`leaveUserId` は既存の `e2e-member-1@example.com` を維持

## テスト
```bash
E2E_GREP="frontend admin jobs: chat ack reminder / leave upcoming run and dashboard reflection|frontend leave submit validation" E2E_SCOPE=extended E2E_CAPTURE=0 ./scripts/e2e-frontend.sh
```
- 結果: 3 passed / 0 failed

