### PR TITLE
test(security): add regression coverage for dependabot alert watch

### DIFF
--- a/packages/backend/test/readinessScripts.test.js
+++ b/packages/backend/test/readinessScripts.test.js
@@ -67,6 +67,99 @@ function withMockBin(commands, fn) {
   });
 }
 
+function hasCommand(name) {
+  const result = spawnSync('/bin/bash', ['-lc', `command -v ${name}`], {
+    env: process.env,
+    encoding: 'utf8',
+  });
+  return result.status === 0;
+}
+
+function writeDependabotLockfile(lockfilePath, versions = {}) {
+  const data = {
+    googleapis: versions.googleapis || '171.4.0',
+    googleapisCommon: versions.googleapisCommon || '8.0.1',
+    qs: versions.qs || '6.15.0',
+    fastXmlParser: versions.fastXmlParser || '5.3.6',
+  };
+
+  writeFileSync(
+    lockfilePath,
+    JSON.stringify(
+      {
+        packages: {
+          'node_modules/googleapis': { version: data.googleapis },
+          'node_modules/googleapis-common': { version: data.googleapisCommon },
+          'node_modules/qs': { version: data.qs },
+          'node_modules/fast-xml-parser': { version: data.fastXmlParser },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+const DEPENDABOT_LOW_ALERT_JSON =
+  '{"number":10,"state":"OPEN","vulnerableManifestPath":"packages/backend/package-lock.json","vulnerableRequirements":">= 6.7.0, <= 6.14.1","securityVulnerability":{"severity":"LOW","package":{"name":"qs"},"firstPatchedVersion":{"identifier":"6.14.2"}},"securityAdvisory":{"ghsaId":"GHSA-w7fw-mjwx-w883","summary":"qs advisory"}}';
+const DEPENDABOT_HIGH_OPEN_ALERT_JSON =
+  '{"number":11,"state":"OPEN","vulnerableManifestPath":"packages/backend/package-lock.json","vulnerableRequirements":"< 5.3.6","securityVulnerability":{"severity":"HIGH","package":{"name":"fast-xml-parser"},"firstPatchedVersion":{"identifier":"5.3.6"}},"securityAdvisory":{"ghsaId":"GHSA-jmr7-xgp7-cmfj","summary":"fast-xml-parser advisory"}}';
+
+function makeDependabotGhStub(mode = 'highNotFound') {
+  const lines = [
+    '#!/usr/bin/env bash',
+    'set -euo pipefail',
+    'if [[ "$1" != "api" ]]; then',
+    '  echo "unexpected gh invocation: $*" >&2',
+    '  exit 2',
+    'fi',
+    'case "$2" in',
+    '  repos/*/dependabot/alerts/10)',
+    "    cat <<'JSON'",
+    DEPENDABOT_LOW_ALERT_JSON,
+    'JSON',
+    '    ;;',
+    '  repos/*/dependabot/alerts/11)',
+  ];
+
+  if (mode === 'highOpen') {
+    lines.push("    cat <<'JSON'");
+    lines.push(DEPENDABOT_HIGH_OPEN_ALERT_JSON);
+    lines.push('JSON');
+    lines.push('    ;;');
+  } else {
+    lines.push('    echo "gh: No alert found for alert number 11 (HTTP 404)" >&2');
+    lines.push('    exit 1');
+    lines.push('    ;;');
+  }
+
+  lines.push('  *)');
+  lines.push('    echo "unexpected gh api path: $2" >&2');
+  lines.push('    exit 2');
+  lines.push('    ;;');
+  lines.push('esac');
+  return lines.join('\n');
+}
+
+function makeDependabotNpmStub(versions = {}) {
+  const googleapis = versions.googleapis || '171.4.0';
+  const googleapisCommon = versions.googleapisCommon || '8.0.1';
+  return [
+    '#!/usr/bin/env bash',
+    'set -euo pipefail',
+    'if [[ "$1" == "view" && "$3" == "version" && "$4" == "--json" ]]; then',
+    '  case "$2" in',
+    `    googleapis) echo '"${googleapis}"' ;;`,
+    `    googleapis-common) echo '"${googleapisCommon}"' ;;`,
+    '    *) echo "null" ;;',
+    '  esac',
+    '  exit 0',
+    'fi',
+    'echo "unexpected npm invocation: $*" >&2',
+    'exit 2',
+  ].join('\n');
+}
+
 test('check-po-migration-input-readiness: fails when INPUT_DIR is missing', () => {
   const res = runScript('check-po-migration-input-readiness.sh', {
     INPUT_DIR: '',
@@ -446,65 +539,21 @@ test('run-and-record-po-migration-rehearsal: skips record when run fails and REC
   });
 });
 
-test('check-dependabot-alerts: treats optional high alert 404 as NOT_FOUND', () => {
+test('check-dependabot-alerts: treats optional high alert 404 as NOT_FOUND', (t) => {
+  if (!hasCommand('jq')) {
+    t.skip('jq is required by check-dependabot-alerts.sh');
+    return;
+  }
+
   withTempDir((dir) => {
     const lockfile = path.join(dir, 'package-lock.json');
-    writeFileSync(
-      lockfile,
-      JSON.stringify(
-        {
-          packages: {
-            'node_modules/googleapis': { version: '171.4.0' },
-            'node_modules/googleapis-common': { version: '8.0.1' },
-            'node_modules/qs': { version: '6.15.0' },
-            'node_modules/fast-xml-parser': { version: '5.3.6' },
-          },
-        },
-        null,
-        2,
-      ),
-    );
-
-    const ghStub = [
-      '#!/usr/bin/env bash',
-      'set -euo pipefail',
-      'if [[ "$1" != "api" ]]; then',
-      '  echo "unexpected gh invocation: $*" >&2',
-      '  exit 2',
-      'fi',
-      'case "$2" in',
-      '  repos/*/dependabot/alerts/10)',
-      "    cat <<'JSON'",
-      '{"number":10,"state":"OPEN","vulnerableManifestPath":"packages/backend/package-lock.json","vulnerableRequirements":">= 6.7.0, <= 6.14.1","securityVulnerability":{"severity":"LOW","package":{"name":"qs"},"firstPatchedVersion":{"identifier":"6.14.2"}},"securityAdvisory":{"ghsaId":"GHSA-w7fw-mjwx-w883","summary":"qs advisory"}}',
-      'JSON',
-      '    ;;',
-      '  repos/*/dependabot/alerts/11)',
-      '    echo "gh: No alert found for alert number 11 (HTTP 404)" >&2',
-      '    exit 1',
-      '    ;;',
-      '  *)',
-      '    echo "unexpected gh api path: $2" >&2',
-      '    exit 2',
-      '    ;;',
-      'esac',
-    ].join('\n');
-
-    const npmStub = [
-      '#!/usr/bin/env bash',
-      'set -euo pipefail',
-      'if [[ "$1" == "view" && "$3" == "version" && "$4" == "--json" ]]; then',
-      '  case "$2" in',
-      '    googleapis) echo \'\"171.4.0\"\' ;;',
-      '    googleapis-common) echo \'\"8.0.1\"\' ;;',
-      '    *) echo "null" ;;',
-      '  esac',
-      '  exit 0',
-      'fi',
-      'echo "unexpected npm invocation: $*" >&2',
-      'exit 2',
-    ].join('\n');
-
-    withMockBin({ gh: ghStub, npm: npmStub }, (binDir) => {
+    writeDependabotLockfile(lockfile);
+    withMockBin(
+      {
+        gh: makeDependabotGhStub('highNotFound'),
+        npm: makeDependabotNpmStub(),
+      },
+      (binDir) => {
       const res = runScript('check-dependabot-alerts.sh', {
         GITHUB_REPOSITORY: 'itdojp/ITDO_ERP4',
         ALERT_LOW_NUMBER: '10',
@@ -517,70 +566,26 @@ test('check-dependabot-alerts: treats optional high alert 404 as NOT_FOUND', () 
       assert.match(String(res.stderr), /treating as NOT_FOUND/);
       assert.match(String(res.stdout), /alertHighState: NOT_FOUND/);
       assert.match(String(res.stdout), /actionRequired: false/);
-    });
+      },
+    );
   });
 });
 
-test('check-dependabot-alerts: exits with STRICT error when high alert is OPEN', () => {
+test('check-dependabot-alerts: exits with STRICT error when high alert is OPEN', (t) => {
+  if (!hasCommand('jq')) {
+    t.skip('jq is required by check-dependabot-alerts.sh');
+    return;
+  }
+
   withTempDir((dir) => {
     const lockfile = path.join(dir, 'package-lock.json');
-    writeFileSync(
-      lockfile,
-      JSON.stringify(
-        {
-          packages: {
-            'node_modules/googleapis': { version: '171.4.0' },
-            'node_modules/googleapis-common': { version: '8.0.1' },
-            'node_modules/qs': { version: '6.15.0' },
-            'node_modules/fast-xml-parser': { version: '5.3.6' },
-          },
-        },
-        null,
-        2,
-      ),
-    );
-
-    const ghStub = [
-      '#!/usr/bin/env bash',
-      'set -euo pipefail',
-      'if [[ "$1" != "api" ]]; then',
-      '  echo "unexpected gh invocation: $*" >&2',
-      '  exit 2',
-      'fi',
-      'case "$2" in',
-      '  repos/*/dependabot/alerts/10)',
-      "    cat <<'JSON'",
-      '{"number":10,"state":"OPEN","vulnerableManifestPath":"packages/backend/package-lock.json","vulnerableRequirements":">= 6.7.0, <= 6.14.1","securityVulnerability":{"severity":"LOW","package":{"name":"qs"},"firstPatchedVersion":{"identifier":"6.14.2"}},"securityAdvisory":{"ghsaId":"GHSA-w7fw-mjwx-w883","summary":"qs advisory"}}',
-      'JSON',
-      '    ;;',
-      '  repos/*/dependabot/alerts/11)',
-      "    cat <<'JSON'",
-      '{"number":11,"state":"OPEN","vulnerableManifestPath":"packages/backend/package-lock.json","vulnerableRequirements":"< 5.3.6","securityVulnerability":{"severity":"HIGH","package":{"name":"fast-xml-parser"},"firstPatchedVersion":{"identifier":"5.3.6"}},"securityAdvisory":{"ghsaId":"GHSA-jmr7-xgp7-cmfj","summary":"fast-xml-parser advisory"}}',
-      'JSON',
-      '    ;;',
-      '  *)',
-      '    echo "unexpected gh api path: $2" >&2',
-      '    exit 2',
-      '    ;;',
-      'esac',
-    ].join('\n');
-
-    const npmStub = [
-      '#!/usr/bin/env bash',
-      'set -euo pipefail',
-      'if [[ "$1" == "view" && "$3" == "version" && "$4" == "--json" ]]; then',
-      '  case "$2" in',
-      '    googleapis) echo \'\"171.4.0\"\' ;;',
-      '    googleapis-common) echo \'\"8.0.1\"\' ;;',
-      '    *) echo "null" ;;',
-      '  esac',
-      '  exit 0',
-      'fi',
-      'echo "unexpected npm invocation: $*" >&2',
-      'exit 2',
-    ].join('\n');
-
-    withMockBin({ gh: ghStub, npm: npmStub }, (binDir) => {
+    writeDependabotLockfile(lockfile);
+    withMockBin(
+      {
+        gh: makeDependabotGhStub('highOpen'),
+        npm: makeDependabotNpmStub(),
+      },
+      (binDir) => {
       const res = runScript('check-dependabot-alerts.sh', {
         GITHUB_REPOSITORY: 'itdojp/ITDO_ERP4',
         ALERT_LOW_NUMBER: '10',
@@ -596,6 +601,7 @@ test('check-dependabot-alerts: exits with STRICT error when high alert is OPEN',
       );
       assert.match(String(res.stdout), /alertHighState: OPEN/);
       assert.match(String(res.stdout), /actionRequired: true/);
-    });
+      },
+    );
   });
 });


### PR DESCRIPTION
## 概要
#1303 で追加した Dependabot Alert Watch のフォールバック挙動に対して、回帰テストを追加します。

## 変更内容
- `packages/backend/test/readinessScripts.test.js` に以下を追加
  - high alert が 404 の場合に `NOT_FOUND` として扱い、`actionRequired=false` で終了すること
  - high alert が `OPEN` の場合に `STRICT=1` で exit code 2 になること
- テスト内で `gh` / `npm` のスタブを使い、API・レジストリに依存せず判定ロジックを検証

## 検証
- `node --test packages/backend/test/readinessScripts.test.js`

## 関連
- #1153
- #1303
