### PR TITLE
docs: sync EvidenceSnapshot subject / evidence-pack v2

### DIFF
--- a/docs/requirements/workflow-evidence-pack.md
+++ b/docs/requirements/workflow-evidence-pack.md
@@ -102,8 +102,8 @@
   - `mask=1|0`（省略時は `1`。PIIマスク適用）
 - 出力:
   - `format=json`: `payload` + `integrity`（sha256/digest/canonicalization）
-    - `payload.schemaVersion` は `evidence-pack/v2`
-    - v2 追加フィールド:
+    - 現行実装: `payload.schemaVersion` は `evidence-pack/v1`
+    - 将来予定（Issue #1308 A3）: `evidence-pack/v2` で以下を追加
       - `payload.workflowHistory`（承認step + 監査イベント）
       - `payload.attachments`（添付のメタデータ + ハッシュ。添付本体は含めない）
   - `format=pdf`: JSON出力と同一内容をPDF化した添付ファイル（監査提出向け）
@@ -149,7 +149,8 @@
 - 再生成時は `reasonText` 必須 + 監査ログ
 - 監査提出JSONのエクスポートは監査ログに `digest` を記録
 - JSONエクスポート既定は `mask=1` とし、外部URL/抜粋/ユーザ識別子等をPIIマスクする
-  - `mask=0`（unmasked）は `admin/mgmt` のみに制限する（外部提出用途を想定）
+  - 現行実装: `mask=0`（unmasked）も利用可能（承認閲覧可能ユーザ）
+  - 将来予定（Issue #1308 A3）: `mask=0` は `admin/mgmt` のみに制限する（外部提出用途を想定）
 
 ## Phase2（Issue #961）進捗
 


### PR DESCRIPTION
ISSUE #1313

- docs/requirements/workflow-evidence-pack.md を現行実装に合わせて更新
  - EvidenceSnapshot items.subject（time_entry / leave_request）
  - Evidence Pack export/archive（現行: evidence-pack/v1, mask=0 の現状）
  - 将来予定（#1308 A3）として evidence-pack/v2（workflowHistory / attachments, mask=0 制限）も明記

Copilot指摘（v2/mask=0 の実装差分）は「現行/将来予定」を分けて解消済み