### PR TITLE
test(policy): add approval action allow-path coverage

### DIFF
--- a/packages/backend/test/approvalActionPolicyPreset.test.js
+++ b/packages/backend/test/approvalActionPolicyPreset.test.js
@@ -181,7 +181,8 @@ test('POST /approval-instances/:id/act approve: policy allow reaches act path (n
               assert.equal(res.statusCode, 400, res.body);
               const payload = JSON.parse(res.body);
               assert.equal(payload?.error, 'approval_action_failed');
-              assert.notEqual(payload?.error?.code, 'ACTION_POLICY_DENIED');
+              assert.equal(payload?.message, 'mock-act-failure');
+              assert.equal(typeof payload?.error, 'string');
             } finally {
               await server.close();
             }
@@ -237,7 +238,8 @@ test('POST /approval-instances/:id/act reject: policy allow reaches act path (no
               assert.equal(res.statusCode, 400, res.body);
               const payload = JSON.parse(res.body);
               assert.equal(payload?.error, 'approval_action_failed');
-              assert.notEqual(payload?.error?.code, 'ACTION_POLICY_DENIED');
+              assert.equal(payload?.message, 'mock-act-failure');
+              assert.equal(typeof payload?.error, 'string');
             } finally {
               await server.close();
             }


### PR DESCRIPTION
## 概要
- ActionPolicy fail-safe 移行テストの不足分として、承認アクション `approve/reject` の「定義→許可」経路を追加
- `phase2_core` 下で policy が存在する場合、`ACTION_POLICY_DENIED` ではなく下流 `act` 処理へ到達することを確認

## 変更ファイル
- packages/backend/test/approvalActionPolicyPreset.test.js

## テスト
- npm run build --prefix packages/backend
- npm run test:ci --prefix packages/backend -- test/approvalActionPolicyPreset.test.js

## 関連
- #1312
- #1308
