### PR TITLE
docs(policy): add fail-safe ops runbook and update coverage matrix

### DIFF
--- a/docs/manual/agent-write-guardrails-guide.md
+++ b/docs/manual/agent-write-guardrails-guide.md
@@ -67,6 +67,7 @@
    - `make action-policy-fallback-report`
    - `make action-policy-fallback-report-json`
 3. 集計キー（`flowType:actionKey:targetTable`）で未収束箇所を特定し、ポリシー追加に反映する。
+4. 補足: `action_policy_fallback_allowed` は実装上、`flowType/actionKey/targetTable` ごとにプロセス内で 1 回だけ記録されるため、レポートの `count` は実発生回数ではなくキー検出用の下限値として扱う。
 
 ## 実行フロー（請求送信の標準例）
 

--- a/docs/requirements/action-policy-high-risk-apis.md
+++ b/docs/requirements/action-policy-high-risk-apis.md
@@ -169,8 +169,9 @@ Phase 2 で先行する Draft は以下を対象とする。
 - 日次集計コマンド
   - `make action-policy-fallback-report`
   - `make action-policy-fallback-report-json`
-- 集計対象: `audit_logs.action='action_policy_fallback_allowed'`
+- 集計対象: AuditLog の `action='action_policy_fallback_allowed'`
 - 集計キー: `flowType:actionKey:targetTable`
+- 補足: `action_policy_fallback_allowed` は実装上、`flowType/actionKey/targetTable` ごとにプロセス内で 1 回だけ監査ログを記録するため、日次レポートの `count` は厳密件数ではなく「少なくとも当該キーで発生した」下限値として解釈する。
 
 ## 9. 実装時チェックリスト（Phase 2）
 


### PR DESCRIPTION
## 概要
Issue #1312 の残タスク（運用手順 docs 追記）として、ActionPolicy fail-safe の運用手順を明文化し、カバレッジ記述を最新化します。

## 変更内容
- `docs/manual/agent-write-guardrails-guide.md`
  - `ActionPolicy fail-safe` 運用手順を追加
  - 追記項目: ポリシー追加 / 例外運用 / ロールバック / 監査集計
  - 監査集計コマンド `make action-policy-fallback-report` / `...-json` を明記
- `docs/requirements/action-policy-high-risk-apis.md`
  - テストカバレッジ時点を更新（2026-03-04）
  - `time/leave` のpreset enforceテストを反映
  - フォールバック可視化運用（集計キー/コマンド）を追記

## 検証
- `node scripts/check-doc-image-links.mjs`

## 関連
- #1312
- #1308
