### PR TITLE
fix(chat): align project-room mention candidates with project members

### DIFF
--- a/packages/backend/src/routes/chatRooms.ts
+++ b/packages/backend/src/routes/chatRooms.ts
@@ -1929,11 +1929,14 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
       });
       if (!access) return reply;
 
-      const chatRoomMembers = await prisma.chatRoomMember.findMany({
-        where: { roomId: access.room.id, deletedAt: null },
-        select: { userId: true },
-        orderBy: { userId: 'asc' },
-      });
+      const chatRoomMembers =
+        access.room.type !== 'project' || access.room.allowExternalUsers
+          ? await prisma.chatRoomMember.findMany({
+              where: { roomId: access.room.id, deletedAt: null },
+              select: { userId: true },
+              orderBy: { userId: 'asc' },
+            })
+          : [];
       const projectMembers =
         access.room.type === 'project'
           ? await prisma.projectMember.findMany({

--- a/packages/backend/test/chatRoomsMentionCandidatesProjectRoom.test.js
+++ b/packages/backend/test/chatRoomsMentionCandidatesProjectRoom.test.js
@@ -77,6 +77,7 @@ function headers() {
 }
 
 test('GET /chat-rooms/:roomId/mention-candidates includes project members for project room', async () => {
+  let chatRoomMemberCalled = false;
   await withPrismaStubs(
     {
       'chatRoom.findUnique': async () => ({
@@ -88,6 +89,61 @@ test('GET /chat-rooms/:roomId/mention-candidates includes project members for pr
         posterGroupIds: [],
         deletedAt: null,
         allowExternalUsers: false,
+      }),
+      'chatRoomMember.findMany': async () => {
+        chatRoomMemberCalled = true;
+        return [{ userId: 'external-member' }];
+      },
+      'projectMember.findMany': async () => [{ userId: 'project-member' }],
+      'userAccount.findMany': async () => [
+        {
+          userName: 'requester',
+          externalId: 'requester',
+          displayName: 'Requester',
+        },
+        {
+          userName: 'project-member',
+          externalId: 'project-member',
+          displayName: 'Project Member',
+        },
+        {
+          userName: 'external-member',
+          externalId: 'external-member',
+          displayName: 'External Member',
+        },
+      ],
+    },
+    async () => {
+      await withServer(async (server) => {
+        const res = await server.inject({
+          method: 'GET',
+          url: '/chat-rooms/proj-1/mention-candidates',
+          headers: headers(),
+        });
+        assert.equal(res.statusCode, 200, res.body);
+        const body = JSON.parse(res.body);
+        const userIds = Array.isArray(body?.users)
+          ? body.users.map((user) => user.userId).sort()
+          : [];
+        assert.deepEqual(userIds, ['project-member', 'requester']);
+      });
+    },
+  );
+  assert.equal(chatRoomMemberCalled, false);
+});
+
+test('GET /chat-rooms/:roomId/mention-candidates includes room members when project room allows external users', async () => {
+  await withPrismaStubs(
+    {
+      'chatRoom.findUnique': async () => ({
+        id: 'proj-1',
+        type: 'project',
+        isOfficial: true,
+        groupId: null,
+        viewerGroupIds: [],
+        posterGroupIds: [],
+        deletedAt: null,
+        allowExternalUsers: true,
       }),
       'chatRoomMember.findMany': async () => [{ userId: 'external-member' }],
       'projectMember.findMany': async () => [{ userId: 'project-member' }],


### PR DESCRIPTION
## 概要
Issue #1314 の機能差分解消として、`/chat-rooms/:roomId/mention-candidates` の project room 挙動を修正しました。  
これまで room系APIでは project room の候補が実質「自分のみ」になり、project系APIと不一致でした。

## 変更内容
- `packages/backend/src/routes/chatRooms.ts`
  - `room.type='project'` の場合、`projectMember` を候補に含めるよう変更
  - 既存の `chatRoomMember` 候補も維持し、project member + room member + current user を統合
- `packages/backend/test/chatRoomsMentionCandidatesProjectRoom.test.js`
  - project room の mention-candidates が `project-member` を返すことを回帰テスト化

## 期待効果
- project系/room系でメンション候補の挙動差を縮小
- B3（チャットAPI統合）における frontend 切替時のUX後退を防止

## テスト
- `npm run build --prefix packages/backend`
- `npm run test:ci --prefix packages/backend -- test/chatRoomsMentionCandidatesProjectRoom.test.js`
- `npm run lint --prefix packages/backend`
- `npm run format:check --prefix packages/backend`

## 関連
- #1314
