### PR TITLE
refactor(chat): share mention-candidates logic across project/room APIs

### DIFF
--- a/docs/requirements/chat-api-unification-inventory.md
+++ b/docs/requirements/chat-api-unification-inventory.md
@@ -125,5 +125,6 @@
 2. **Phase 1（安全性先行）**: room投稿の `accessLevel:'post'` を徹底（権限境界の是正）
 3. **Phase 2（backend統合）**: project path を alias 化し、roomロジックへ委譲
    - 先行実装: unread/read の集計・既読更新ロジックを `chatReadState` サービスへ共通化
+   - 先行実装: mention-candidates の候補解決ロジックを `chatMentionCandidates` サービスへ共通化
 4. **Phase 3（frontend統合）**: `ProjectChat` 呼び出しを room API へ段階移行
 5. **Phase 4（deprecate）**: 旧project系経路の無通信確認後に削除

--- a/packages/backend/src/routes/chat.ts
+++ b/packages/backend/src/routes/chat.ts
@@ -22,6 +22,7 @@ import {
   previewChatAckRecipients,
 } from '../services/chatAckRecipients.js';
 import { getChatAckLimits } from '../services/chatAckLimits.js';
+import { buildChatMentionCandidates } from '../services/chatMentionCandidates.js';
 import {
   openAttachment,
   storeAttachment,
@@ -39,7 +40,6 @@ import {
   getChatUnreadSummary,
   markChatAsRead,
 } from '../services/chatReadState.js';
-import { resolveGroupCandidatesBySelector } from '../services/groupCandidates.js';
 import { CHAT_ROLES } from './chat/shared/constants.js';
 import {
   normalizeStringArray,
@@ -544,47 +544,17 @@ export async function registerChatRoutes(app: FastifyInstance) {
       const groupAccountIds = Array.isArray(req.user?.groupAccountIds)
         ? req.user.groupAccountIds
         : [];
-      const members = await prisma.projectMember.findMany({
-        where: { projectId },
-        select: { userId: true, role: true },
-        orderBy: { userId: 'asc' },
+      return buildChatMentionCandidates({
+        room: {
+          id: projectId,
+          type: 'project',
+          // project系は現行挙動を維持し、外部メンバーは候補に含めない
+          allowExternalUsers: false,
+        },
+        requesterUserId: currentUserId,
+        groupIds,
+        groupAccountIds,
       });
-      const userIdSet = new Set(members.map((member) => member.userId));
-      if (currentUserId) {
-        userIdSet.add(currentUserId);
-      }
-      const userIds = Array.from(userIdSet);
-      const accounts = userIds.length
-        ? await prisma.userAccount.findMany({
-            where: {
-              OR: [
-                { userName: { in: userIds } },
-                { externalId: { in: userIds } },
-              ],
-              deletedAt: null,
-              active: true,
-            },
-            select: { userName: true, externalId: true, displayName: true },
-          })
-        : [];
-      const displayMap = new Map<string, string | null>();
-      for (const account of accounts) {
-        const name = account.displayName || null;
-        displayMap.set(account.userName, name);
-        if (account.externalId) displayMap.set(account.externalId, name);
-      }
-      const users = userIds
-        .map((userId) => ({
-          userId,
-          displayName: displayMap.get(userId) || null,
-        }))
-        .sort((a, b) => a.userId.localeCompare(b.userId));
-      const groups = await resolveGroupCandidatesBySelector([
-        ...groupIds,
-        ...groupAccountIds,
-      ]);
-      const allowAll = true;
-      return { users, groups, allowAll };
     },
   );
 

--- a/packages/backend/src/routes/chatRooms.ts
+++ b/packages/backend/src/routes/chatRooms.ts
@@ -20,6 +20,7 @@ import {
   previewChatAckRecipients,
 } from '../services/chatAckRecipients.js';
 import { getChatAckLimits } from '../services/chatAckLimits.js';
+import { buildChatMentionCandidates } from '../services/chatMentionCandidates.js';
 import {
   expandRoomMentionRecipients,
   resolveRoomAudienceUserIds,
@@ -28,7 +29,6 @@ import {
   getChatUnreadSummary,
   markChatAsRead,
 } from '../services/chatReadState.js';
-import { resolveGroupCandidatesBySelector } from '../services/groupCandidates.js';
 import {
   getChatExternalLlmConfig,
   getChatExternalLlmRateLimit,
@@ -1932,64 +1932,16 @@ export async function registerChatRoomRoutes(app: FastifyInstance) {
         accessLevel: 'read',
       });
       if (!access) return reply;
-
-      const chatRoomMembers =
-        access.room.type !== 'project' || access.room.allowExternalUsers
-          ? await prisma.chatRoomMember.findMany({
-              where: { roomId: access.room.id, deletedAt: null },
-              select: { userId: true },
-              orderBy: { userId: 'asc' },
-            })
-          : [];
-      const projectMembers =
-        access.room.type === 'project'
-          ? await prisma.projectMember.findMany({
-              where: { projectId: access.room.id },
-              select: { userId: true },
-              orderBy: { userId: 'asc' },
-            })
-          : [];
-
-      const userIdSet = new Set([
-        ...chatRoomMembers.map((member) => member.userId),
-        ...projectMembers.map((member) => member.userId),
-      ]);
-      userIdSet.add(userId);
-      const userIds = Array.from(userIdSet);
-      const accounts = userIds.length
-        ? await prisma.userAccount.findMany({
-            where: {
-              deletedAt: null,
-              active: true,
-              OR: [
-                { userName: { in: userIds } },
-                { externalId: { in: userIds } },
-              ],
-            },
-            select: { userName: true, externalId: true, displayName: true },
-          })
-        : [];
-      const displayMap = new Map<string, string | null>();
-      for (const account of accounts) {
-        const name = account.displayName || null;
-        displayMap.set(account.userName, name);
-        if (account.externalId) {
-          displayMap.set(account.externalId, name);
-        }
-      }
-
-      const users = userIds
-        .map((entry) => ({
-          userId: entry,
-          displayName: displayMap.get(entry) || null,
-        }))
-        .sort((a, b) => a.userId.localeCompare(b.userId));
-      const groups = await resolveGroupCandidatesBySelector([
-        ...accessContext.groupIds,
-        ...accessContext.groupAccountIds,
-      ]);
-      const allowAll = true;
-      return { users, groups, allowAll };
+      return buildChatMentionCandidates({
+        room: {
+          id: access.room.id,
+          type: access.room.type,
+          allowExternalUsers: access.room.allowExternalUsers,
+        },
+        requesterUserId: userId,
+        groupIds: accessContext.groupIds,
+        groupAccountIds: accessContext.groupAccountIds,
+      });
     },
   );
 

--- a/packages/backend/src/services/chatMentionCandidates.ts
+++ b/packages/backend/src/services/chatMentionCandidates.ts
@@ -1,0 +1,90 @@
+import type { PrismaClient } from '@prisma/client';
+import { prisma } from './db.js';
+import { resolveGroupCandidatesBySelector } from './groupCandidates.js';
+
+type ChatMentionCandidatesClient = Pick<
+  PrismaClient,
+  'chatRoomMember' | 'projectMember' | 'userAccount'
+>;
+
+type MentionCandidatesRoom = {
+  id: string;
+  type: string;
+  allowExternalUsers?: boolean | null;
+};
+
+type BuildChatMentionCandidatesInput = {
+  room: MentionCandidatesRoom;
+  requesterUserId?: string | null;
+  groupIds?: string[];
+  groupAccountIds?: string[];
+  client?: ChatMentionCandidatesClient;
+};
+
+export async function buildChatMentionCandidates(
+  input: BuildChatMentionCandidatesInput,
+) {
+  const client = input.client ?? prisma;
+  const groupIds = Array.isArray(input.groupIds) ? input.groupIds : [];
+  const groupAccountIds = Array.isArray(input.groupAccountIds)
+    ? input.groupAccountIds
+    : [];
+  const requesterUserId = (input.requesterUserId || '').trim();
+  const includeRoomMembers =
+    input.room.type !== 'project' || Boolean(input.room.allowExternalUsers);
+
+  const chatRoomMembers = includeRoomMembers
+    ? await client.chatRoomMember.findMany({
+        where: { roomId: input.room.id, deletedAt: null },
+        select: { userId: true },
+        orderBy: { userId: 'asc' },
+      })
+    : [];
+  const projectMembers =
+    input.room.type === 'project'
+      ? await client.projectMember.findMany({
+          where: { projectId: input.room.id },
+          select: { userId: true },
+          orderBy: { userId: 'asc' },
+        })
+      : [];
+
+  const userIdSet = new Set([
+    ...chatRoomMembers.map((member) => member.userId),
+    ...projectMembers.map((member) => member.userId),
+  ]);
+  if (requesterUserId) {
+    userIdSet.add(requesterUserId);
+  }
+  const userIds = Array.from(userIdSet);
+  const accounts = userIds.length
+    ? await client.userAccount.findMany({
+        where: {
+          deletedAt: null,
+          active: true,
+          OR: [{ userName: { in: userIds } }, { externalId: { in: userIds } }],
+        },
+        select: { userName: true, externalId: true, displayName: true },
+      })
+    : [];
+  const displayMap = new Map<string, string | null>();
+  for (const account of accounts) {
+    const displayName = account.displayName || null;
+    displayMap.set(account.userName, displayName);
+    if (account.externalId) {
+      displayMap.set(account.externalId, displayName);
+    }
+  }
+
+  const users = userIds
+    .map((entry) => ({
+      userId: entry,
+      displayName: displayMap.get(entry) || null,
+    }))
+    .sort((a, b) => a.userId.localeCompare(b.userId));
+  const groups = await resolveGroupCandidatesBySelector([
+    ...groupIds,
+    ...groupAccountIds,
+  ]);
+  return { users, groups, allowAll: true };
+}

--- a/packages/backend/test/chatMentionCandidatesService.test.js
+++ b/packages/backend/test/chatMentionCandidatesService.test.js
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildChatMentionCandidates } from '../dist/services/chatMentionCandidates.js';
+
+test('project room candidates skip room members when allowExternalUsers is false', async () => {
+  let chatRoomMemberCalled = false;
+  const client = {
+    chatRoomMember: {
+      findMany: async () => {
+        chatRoomMemberCalled = true;
+        return [{ userId: 'external-member' }];
+      },
+    },
+    projectMember: {
+      findMany: async () => [{ userId: 'project-member' }],
+    },
+    userAccount: {
+      findMany: async () => [
+        {
+          userName: 'project-member',
+          externalId: 'project-member',
+          displayName: 'Project Member',
+        },
+        {
+          userName: 'requester',
+          externalId: 'requester',
+          displayName: 'Requester',
+        },
+      ],
+    },
+  };
+
+  const result = await buildChatMentionCandidates({
+    room: { id: 'proj-1', type: 'project', allowExternalUsers: false },
+    requesterUserId: 'requester',
+    groupIds: [],
+    groupAccountIds: [],
+    client,
+  });
+
+  assert.equal(chatRoomMemberCalled, false);
+  assert.deepEqual(
+    result.users.map((entry) => entry.userId),
+    ['project-member', 'requester'],
+  );
+});
+
+test('project room candidates include room members when allowExternalUsers is true', async () => {
+  let chatRoomMemberCalled = false;
+  const client = {
+    chatRoomMember: {
+      findMany: async () => {
+        chatRoomMemberCalled = true;
+        return [{ userId: 'external-member' }];
+      },
+    },
+    projectMember: {
+      findMany: async () => [{ userId: 'project-member' }],
+    },
+    userAccount: {
+      findMany: async () => [
+        {
+          userName: 'project-member',
+          externalId: 'project-member',
+          displayName: 'Project Member',
+        },
+        {
+          userName: 'requester',
+          externalId: 'requester',
+          displayName: 'Requester',
+        },
+        {
+          userName: 'external-member',
+          externalId: 'external-member',
+          displayName: 'External Member',
+        },
+      ],
+    },
+  };
+
+  const result = await buildChatMentionCandidates({
+    room: { id: 'proj-1', type: 'project', allowExternalUsers: true },
+    requesterUserId: 'requester',
+    groupIds: [],
+    groupAccountIds: [],
+    client,
+  });
+
+  assert.equal(chatRoomMemberCalled, true);
+  assert.deepEqual(
+    result.users.map((entry) => entry.userId),
+    ['external-member', 'project-member', 'requester'],
+  );
+});

--- a/packages/backend/test/chatRoomsMentionCandidatesProjectRoom.test.js
+++ b/packages/backend/test/chatRoomsMentionCandidatesProjectRoom.test.js
@@ -186,3 +186,52 @@ test('GET /chat-rooms/:roomId/mention-candidates includes room members when proj
     },
   );
 });
+
+test('GET /projects/:projectId/chat-mention-candidates keeps project-only candidates', async () => {
+  let chatRoomMemberCalled = false;
+  await withPrismaStubs(
+    {
+      'chatRoomMember.findMany': async () => {
+        chatRoomMemberCalled = true;
+        return [{ userId: 'external-member' }];
+      },
+      'projectMember.findMany': async () => [{ userId: 'project-member' }],
+      'userAccount.findMany': async () => [
+        {
+          userName: 'requester',
+          externalId: 'requester',
+          displayName: 'Requester',
+        },
+        {
+          userName: 'project-member',
+          externalId: 'project-member',
+          displayName: 'Project Member',
+        },
+        {
+          userName: 'external-member',
+          externalId: 'external-member',
+          displayName: 'External Member',
+        },
+      ],
+    },
+    async () => {
+      await withServer(async (server) => {
+        const res = await server.inject({
+          method: 'GET',
+          url: '/projects/proj-1/chat-mention-candidates',
+          headers: {
+            'x-user-id': 'requester',
+            'x-roles': 'admin',
+          },
+        });
+        assert.equal(res.statusCode, 200, res.body);
+        const body = JSON.parse(res.body);
+        const userIds = Array.isArray(body?.users)
+          ? body.users.map((user) => user.userId).sort()
+          : [];
+        assert.deepEqual(userIds, ['project-member', 'requester']);
+      });
+    },
+  );
+  assert.equal(chatRoomMemberCalled, false);
+});


### PR DESCRIPTION
## 概要
- Issue #1314（Phase B3 / TODO2）の次段として、`mention-candidates` の候補解決ロジックを共通サービス化しました。
- project系/room系のルートは共通サービスへ委譲し、APIレスポンス契約（`{ users, groups, allowAll }`）は維持しています。

## 変更点
- 追加: `packages/backend/src/services/chatMentionCandidates.ts`
  - `buildChatMentionCandidates` を実装
  - room type / allowExternalUsers に応じて `projectMember` と `chatRoomMember` を解決
  - displayName 解決・group候補解決・sort を共通化
- 置換:
  - `packages/backend/src/routes/chat.ts`
    - `GET /projects/:projectId/chat-mention-candidates`
  - `packages/backend/src/routes/chatRooms.ts`
    - `GET /chat-rooms/:roomId/mention-candidates`
- テスト:
  - 追加: `packages/backend/test/chatMentionCandidatesService.test.js`
  - 追加: `packages/backend/test/chatRoomsMentionCandidatesProjectRoom.test.js` に project系経路の配線回帰テスト
- ドキュメント:
  - `docs/requirements/chat-api-unification-inventory.md` に Phase2 先行実装として追記

## テスト
- `npm run build --prefix packages/backend`
- `npm run lint --prefix packages/backend`
- `npm run format:check --prefix packages/backend`
- `npm run test:ci --prefix packages/backend -- test/chatMentionCandidatesService.test.js test/chatRoomsMentionCandidatesProjectRoom.test.js`

Refs #1314
