### PR TITLE
refactor(chat): reuse active project room guard for ack preview

### DIFF
--- a/docs/requirements/chat-api-unification-inventory.md
+++ b/docs/requirements/chat-api-unification-inventory.md
@@ -127,6 +127,6 @@
 3. **Phase 2（backend統合）**: project path を alias 化し、roomロジックへ委譲
    - 先行実装: unread/read の集計・既読更新ロジックを `chatReadState` サービスへ共通化
    - 先行実装: mention-candidates の候補解決ロジックを `chatMentionCandidates` サービスへ共通化
-   - 追補実装: project系 `chat-unread` / `chat-read` / `chat-ack-candidates` の room 解決を `resolveActiveProjectRoom` に統一
+   - 追補実装: project系 `chat-unread` / `chat-read` / `chat-ack-candidates` / `chat-ack-requests/preview` の room 解決を `resolveActiveProjectRoom` に統一
 4. **Phase 3（frontend統合）**: `ProjectChat` 呼び出しを room API へ段階移行
 5. **Phase 4（deprecate）**: 旧project系経路の無通信確認後に削除

--- a/packages/backend/src/routes/chat.ts
+++ b/packages/backend/src/routes/chat.ts
@@ -820,27 +820,12 @@ export async function registerChatRoutes(app: FastifyInstance) {
         });
       }
 
-      if (!(await ensureProjectRoom(projectId, userId))) {
-        return reply.status(404).send({
-          error: { code: 'NOT_FOUND', message: 'Project not found' },
-        });
-      }
-      const room = await prisma.chatRoom.findUnique({
-        where: { id: projectId },
-        select: {
-          id: true,
-          type: true,
-          groupId: true,
-          viewerGroupIds: true,
-          deletedAt: true,
-          allowExternalUsers: true,
-        },
+      const room = await resolveActiveProjectRoom({
+        projectId,
+        userId,
+        reply,
       });
-      if (!room || room.deletedAt) {
-        return reply.status(404).send({
-          error: { code: 'NOT_FOUND', message: 'Room not found' },
-        });
-      }
+      if (!room) return reply;
 
       const preview = await previewChatAckRecipients({
         room,

--- a/packages/backend/test/projectChatLegacyRoomResolution.test.js
+++ b/packages/backend/test/projectChatLegacyRoomResolution.test.js
@@ -149,6 +149,27 @@ test('GET /projects/:projectId/chat-ack-candidates returns 404 when project does
   );
 });
 
+test('POST /projects/:projectId/chat-ack-requests/preview returns 404 when project does not exist', async () => {
+  await withPrismaStubs(
+    {
+      'chatSetting.findUnique': async () => null,
+      'chatRoom.findUnique': async () => null,
+      'project.findUnique': async () => null,
+    },
+    async () => {
+      await withServer(async (server) => {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/projects/project-missing/chat-ack-requests/preview',
+          headers: adminHeaders(),
+          payload: { requiredUserIds: ['u-1'] },
+        });
+        assertNotFound(res, 'Project not found');
+      });
+    },
+  );
+});
+
 test('GET /projects/:projectId/chat-unread returns 404 when project room is deleted', async () => {
   await withPrismaStubs(
     {
@@ -178,6 +199,26 @@ test('POST /projects/:projectId/chat-read returns 404 when project room is delet
           method: 'POST',
           url: '/projects/p1/chat-read',
           headers: adminHeaders(),
+        });
+        assertNotFound(res, 'Room not found');
+      });
+    },
+  );
+});
+
+test('POST /projects/:projectId/chat-ack-requests/preview returns 404 when project room is deleted', async () => {
+  await withPrismaStubs(
+    {
+      'chatSetting.findUnique': async () => null,
+      'chatRoom.findUnique': async () => deletedProjectRoom('p1'),
+    },
+    async () => {
+      await withServer(async (server) => {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/projects/p1/chat-ack-requests/preview',
+          headers: adminHeaders(),
+          payload: { requiredUserIds: ['u-1'] },
         });
         assertNotFound(res, 'Room not found');
       });


### PR DESCRIPTION
## 概要
- Issue #1314 (Phase B3 / TODO2) の次段として、`POST /projects/:projectId/chat-ack-requests/preview` の room 解決を `resolveActiveProjectRoom` に統一しました。
- 既に統一済みの `chat-unread` / `chat-read` / `chat-ack-candidates` と同じ 404 挙動（Project/Room not found）に揃えています。

## 変更点
- `packages/backend/src/routes/chat.ts`
  - `POST /projects/:projectId/chat-ack-requests/preview` を `resolveActiveProjectRoom` 経由に変更
  - `ensureProjectRoom + chatRoom.findUnique` の重複コードを削減
- `packages/backend/test/projectChatLegacyRoomResolution.test.js`
  - `chat-ack-requests/preview` の 404 回帰テストを追加
    - project 不在時: `Project not found`
    - room deleted 時: `Room not found`
  - `chatSetting.findUnique` をスタブし、DB依存を除去
- `docs/requirements/chat-api-unification-inventory.md`
  - Phase2 追補実装に `chat-ack-requests/preview` を反映

## テスト
- `npm run format:check --prefix packages/backend`
- `npm run lint --prefix packages/backend`
- `npm run build --prefix packages/backend`
- `npm run test:ci --prefix packages/backend -- test/projectChatLegacyRoomResolution.test.js`

Refs #1314
