### PR TITLE
refactor(chat): reuse active project room guard for chat summary

### DIFF
--- a/docs/requirements/chat-api-unification-inventory.md
+++ b/docs/requirements/chat-api-unification-inventory.md
@@ -127,6 +127,6 @@
 3. **Phase 2（backend統合）**: project path を alias 化し、roomロジックへ委譲
    - 先行実装: unread/read の集計・既読更新ロジックを `chatReadState` サービスへ共通化
    - 先行実装: mention-candidates の候補解決ロジックを `chatMentionCandidates` サービスへ共通化
-   - 追補実装: project系 `chat-unread` / `chat-read` / `chat-ack-candidates` / `chat-ack-requests/preview` の room 解決を `resolveActiveProjectRoom` に統一
+   - 追補実装: project系 `chat-unread` / `chat-read` / `chat-ack-candidates` / `chat-ack-requests/preview` / `chat-summary` の room 解決を `resolveActiveProjectRoom` に統一
 4. **Phase 3（frontend統合）**: `ProjectChat` 呼び出しを room API へ段階移行
 5. **Phase 4（deprecate）**: 旧project系経路の無通信確認後に削除

--- a/packages/backend/src/routes/chat.ts
+++ b/packages/backend/src/routes/chat.ts
@@ -463,6 +463,12 @@ export async function registerChatRoutes(app: FastifyInstance) {
           },
         });
       }
+      const room = await resolveActiveProjectRoom({
+        projectId,
+        userId: req.user?.userId || null,
+        reply,
+      });
+      if (!room) return reply;
 
       const createdAt =
         since && until
@@ -475,7 +481,7 @@ export async function registerChatRoutes(app: FastifyInstance) {
 
       const items = await prisma.chatMessage.findMany({
         where: {
-          roomId: projectId,
+          roomId: room.id,
           deletedAt: null,
           createdAt,
         },
@@ -529,7 +535,7 @@ export async function registerChatRoutes(app: FastifyInstance) {
 
       const summaryLines = [
         '（スタブ要約: 集計ベース）',
-        `- projectId: ${projectId}`,
+        `- projectId: ${room.id}`,
         `- 取得件数: ${items.length}件`,
         `- 投稿者数: ${users.size}名`,
         `- @all: ${mentionAllCount}件`,
@@ -546,7 +552,7 @@ export async function registerChatRoutes(app: FastifyInstance) {
         action: 'chat_summary_generated',
         targetTable: 'chat_messages',
         metadata: {
-          projectId,
+          projectId: room.id,
           limit: take,
           since: body.since || null,
           until: body.until || null,
@@ -561,7 +567,7 @@ export async function registerChatRoutes(app: FastifyInstance) {
           ? summaryLines.join('\n')
           : '対象メッセージがありません',
         stats: {
-          projectId,
+          projectId: room.id,
           messageCount: items.length,
           userCount: users.size,
           mentionAllCount,

--- a/packages/backend/test/projectChatLegacyRoomResolution.test.js
+++ b/packages/backend/test/projectChatLegacyRoomResolution.test.js
@@ -111,6 +111,26 @@ test('GET /projects/:projectId/chat-unread returns 404 when project does not exi
   );
 });
 
+test('POST /projects/:projectId/chat-summary returns 404 when project does not exist', async () => {
+  await withPrismaStubs(
+    {
+      'chatRoom.findUnique': async () => null,
+      'project.findUnique': async () => null,
+    },
+    async () => {
+      await withServer(async (server) => {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/projects/project-missing/chat-summary',
+          headers: adminHeaders(),
+          payload: {},
+        });
+        assertNotFound(res, 'Project not found');
+      });
+    },
+  );
+});
+
 test('POST /projects/:projectId/chat-read returns 404 when project does not exist', async () => {
   await withPrismaStubs(
     {
@@ -181,6 +201,25 @@ test('GET /projects/:projectId/chat-unread returns 404 when project room is dele
           method: 'GET',
           url: '/projects/p1/chat-unread',
           headers: adminHeaders(),
+        });
+        assertNotFound(res, 'Room not found');
+      });
+    },
+  );
+});
+
+test('POST /projects/:projectId/chat-summary returns 404 when project room is deleted', async () => {
+  await withPrismaStubs(
+    {
+      'chatRoom.findUnique': async () => deletedProjectRoom('p1'),
+    },
+    async () => {
+      await withServer(async (server) => {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/projects/p1/chat-summary',
+          headers: adminHeaders(),
+          payload: {},
         });
         assertNotFound(res, 'Room not found');
       });


### PR DESCRIPTION
## 概要
- Issue #1314 (Phase B3 / TODO2) の次段として、`POST /projects/:projectId/chat-summary` の room 解決を `resolveActiveProjectRoom` に統一しました。
- 既に統一済みの project系チャットAPIと同じ 404 挙動（Project/Room not found）に揃えています。

## 変更点
- `packages/backend/src/routes/chat.ts`
  - `POST /projects/:projectId/chat-summary` を `resolveActiveProjectRoom` 経由に変更
  - summary 集計対象の `roomId` と監査ログ `projectId` を `room.id` ベースに統一
- `packages/backend/test/projectChatLegacyRoomResolution.test.js`
  - `chat-summary` の 404 回帰テストを追加
    - project 不在時: `Project not found`
    - room deleted 時: `Room not found`
- `docs/requirements/chat-api-unification-inventory.md`
  - Phase2 追補実装に `chat-summary` を反映

## テスト
- `npm run format:check --prefix packages/backend`
- `npm run lint --prefix packages/backend`
- `npm run build --prefix packages/backend`
- `npm run test:ci --prefix packages/backend -- test/projectChatLegacyRoomResolution.test.js`

Refs #1314
