### PR TITLE
test(chat): add room-priority ProjectChat e2e coverage

### DIFF
--- a/docs/requirements/chat-api-unification-inventory.md
+++ b/docs/requirements/chat-api-unification-inventory.md
@@ -139,6 +139,6 @@
    - 追補実装: project系 `chat-messages` / `chat-summary` / `chat-mention-candidates` / `chat-ack-candidates` / `chat-unread` / `chat-read` / `chat-ack-requests/preview` / `chat-ack-requests` の room 解決を `resolveActiveProjectRoom` に統一
 4. **Phase 3（frontend統合）**: `ProjectChat` 呼び出しを room API へ段階移行
    - 実装済み: room API 優先 + project API フォールバック
-   - 実装済み: E2Eで room優先経路 / fallback経路を追加検証
+   - 実装済み: E2Eで room優先経路を追加検証
    - 残課題: fallback利用率が 0 になった段階で frontend 側 fallback を除去
 5. **Phase 4（deprecate）**: 旧project系経路の無通信確認後に削除

--- a/packages/frontend/e2e/frontend-smoke-chat-ack-targets.spec.ts
+++ b/packages/frontend/e2e/frontend-smoke-chat-ack-targets.spec.ts
@@ -105,7 +105,7 @@ test('frontend project chat uses room API after project room resolution @extende
   const id = runId();
   const message = `E2E room-first path ${id}`;
   const projectId = authState.projectIds[0];
-  const projectPattern = new RegExp(`/projects/${projectId}/chat-`);
+  const projectChatRoutePattern = `**/projects/${projectId}/chat-*`;
   const blockedProjectUrls: string[] = [];
 
   await prepare(page);
@@ -121,7 +121,7 @@ test('frontend project chat uses room API after project room resolution @extende
     timeout: actionTimeout,
   });
 
-  await page.route('**/projects/*/chat-*', async (route) => {
+  await page.route(projectChatRoutePattern, async (route) => {
     blockedProjectUrls.push(route.request().url());
     await route.abort();
   });
@@ -133,12 +133,10 @@ test('frontend project chat uses room API after project room resolution @extende
     await expect(messageItem).toHaveCount(1, { timeout: actionTimeout });
     await expect(messageItem).toBeVisible({ timeout: actionTimeout });
   } finally {
-    await page.unroute('**/projects/*/chat-*');
+    await page.unroute(projectChatRoutePattern);
   }
 
-  expect(blockedProjectUrls.filter((url) => projectPattern.test(url))).toEqual(
-    [],
-  );
+  expect(blockedProjectUrls).toEqual([]);
 });
 
 test('frontend smoke project chat ack targets (user/group/role) @extended', async ({


### PR DESCRIPTION
## 概要
- Issue #1314 (Phase B3) の継続として、`ProjectChat` の room API 優先経路を E2E で明示的に検証
- `docs/requirements/chat-api-unification-inventory.md` を現行実装（room優先 + projectフォールバック）に同期

## 変更点
- `packages/frontend/e2e/frontend-smoke-chat-ack-targets.spec.ts`
  - 新規E2E: `frontend project chat uses room API after project room resolution`
  - project系 chat API (`/projects/*/chat-*`) を route abort し、room解決後の投稿が成功することを検証
  - 重複していた section open 処理を `openProjectChatSection` に集約
- `docs/requirements/chat-api-unification-inventory.md`
  - 3.1/3.2 を実装同期（ProjectChat は room優先、未解決時のみ projectフォールバック）
  - Phase 3 の進捗/残課題を更新

## テスト
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run build --prefix packages/frontend`
- `E2E_GREP="frontend project chat uses room API after project room resolution" E2E_CAPTURE=0 ./scripts/e2e-frontend.sh`

Refs #1314
