### PR TITLE
docs(approval): inventory current rule versioning behavior for B1

### DIFF
--- a/docs/requirements/approval-rule-versioning-inventory.md
+++ b/docs/requirements/approval-rule-versioning-inventory.md
@@ -16,7 +16,8 @@
 - `POST /approval-rules`
 - `PATCH /approval-rules/:id`
 - `GET /approval-instances`
-- `POST /approval-instances/:id/action`
+- `POST /approval-instances/:id/act`
+- `POST /approval-instances/:id/cancel`
 
 補足:
 
@@ -36,9 +37,9 @@
 ### 3.2 ApprovalInstance
 
 - 主キー: `id`
-- 主要列: `flowType`, `targetTable`, `targetId`, `status`, `currentStepNo`
+- 主要列: `flowType`, `targetTable`, `targetId`, `status`, `currentStep`, `projectId`
 - 参照: `ruleId`（必須、`ApprovalRule.id` への FK）
-- 保持情報: `stagePolicy`, `completedAt`, `createdAt`
+- 保持情報: `stagePolicy`, `createdAt`
 - 子要素: `ApprovalStep[]`
 
 ### 3.3 参照整合


### PR DESCRIPTION
## 概要
- Issue #1315 (B1) の TODO0「現状把握」を進めるため、ApprovalRule の現行実装棚卸ドキュメントを追加
- CRUD/API、適用ロジック、DBスキーマ、instance参照保持、versioningギャップを整理

## 変更点
- 追加: `docs/requirements/approval-rule-versioning-inventory.md`
  - 現行 API (`GET/POST/PATCH /approval-rules`, `GET /approval-instances`, `POST /approval-instances/:id/action`)
  - 現行 Prisma モデル（ApprovalRule / ApprovalInstance / FK 制約）
  - ルール選択・instance生成・承認進行の流れ
  - B1観点の主要ギャップ（上書き更新、version運用不足、instance固定情報不足など）
  - TODO1 以降へ接続する次アクション

## テスト
- `npx prettier --check docs/requirements/approval-rule-versioning-inventory.md`

Refs #1315
