### PR TITLE
docs(approval): map hardcoded fallback paths for B2

### DIFF
--- a/docs/requirements/approval-default-rule-fallback-inventory.md
+++ b/docs/requirements/approval-default-rule-fallback-inventory.md
@@ -15,7 +15,7 @@
 - estimate:submit
 - invoice:submit
 - purchase_order:submit
-- vendor_invoice:submit（`/vendor-invoices/:id/submit`, `/approve` alias）
+- vendor_invoice:submit（`/approve` 既存, `/vendor-invoices/:id/submit` はその alias。後方互換のため `/approve` を残置）
 - expense:submit
 - leave:submit（`requiresApproval=true` の場合）
 - time:edit（承認影響がある変更時）
@@ -49,8 +49,9 @@
 
 ### 3.5 ruleId の暫定固定値依存
 
-- ルール未解決時に `ruleId='auto'` / `'manual'` を使う経路がある。
-- `ApprovalInstance.ruleId` は必須 FK のため、実データとの整合が運用依存になる。
+- `createApprovalFor` では、ルール未解決時に `rule?.id || 'auto'` として `ruleId='auto'` をフォールバックに使う。
+- 一方 `createApproval` / `createApprovalWithClient` はデフォルト `ruleId='manual'` を持ち、手動作成用途の経路として残っている。
+- `ApprovalInstance.ruleId` は必須 FK のため、`auto` / `manual` の実体管理が運用依存になりやすい。
 
 ## 4. B2観点の主要論点
 


### PR DESCRIPTION
## 概要
- Issue #1316 (B2) の TODO0（棚卸）として、承認ルール未整備時フォールバックの現状をドキュメント化
- コードベース上の fallback 経路と論点を整理し、TODO1（既定ルール設計）への入力を明確化

## 変更点
- 追加: `docs/requirements/approval-default-rule-fallback-inventory.md`
  - 対象フロー（estimate/invoice/purchase_order/vendor_invoice/expense/leave/time）
  - フォールバック経路（ルール0件、ルール不備、ハードコード段生成、先頭ルール採用、ruleId固定値依存）
  - B2観点の主要論点と推奨
  - 次アクション（TODO1 への入力）

## テスト
- `npx prettier --check docs/requirements/approval-default-rule-fallback-inventory.md`

Refs #1316
