### PR TITLE
feat(approval): add B2 fallback audit logging

### DIFF
--- a/packages/backend/src/services/approval.ts
+++ b/packages/backend/src/services/approval.ts
@@ -1,6 +1,7 @@
+import type { Prisma } from '@prisma/client';
 import { DocStatusValue } from '../types.js';
 import { prisma } from './db.js';
-import { logAudit, type AuditContext } from './audit.js';
+import { buildAuditMetadata, logAudit, type AuditContext } from './audit.js';
 import { createEvidenceSnapshotForApproval } from './evidenceSnapshot.js';
 import { logExpenseStateTransition } from './expenseStateTransitionLog.js';
 import { isExpenseQaChecklistComplete } from './expenseQaChecklist.js';
@@ -242,8 +243,23 @@ async function resolveRule(
   };
 }
 
-function approvalFallbackPayloadHints(payload: Record<string, unknown>) {
-  const pick = (key: string) => payload[key] ?? null;
+function toAuditJsonPrimitive(value: unknown): Prisma.InputJsonValue {
+  if (value === null || value === undefined) return 'null';
+  if (typeof value === 'string' || typeof value === 'boolean') return value;
+  if (typeof value === 'number') {
+    if (Number.isFinite(value)) return value;
+    return String(value);
+  }
+  if (typeof value === 'bigint') return value.toString();
+  if (value instanceof Date) return value.toISOString();
+  return String(value);
+}
+
+function approvalFallbackPayloadHints(
+  payload: Record<string, unknown>,
+): Prisma.InputJsonObject {
+  const pick = (key: string): Prisma.InputJsonValue =>
+    toAuditJsonPrimitive(payload[key]);
   return {
     amount: pick('amount'),
     totalAmount: pick('totalAmount'),
@@ -283,14 +299,19 @@ async function logApprovalRuleFallbackIfNeeded(options: {
     source: 'system',
     reasonCode: options.fallbackReasons[0],
     metadata,
-  } as const;
+  };
+  const normalizedMetadata = buildAuditMetadata(baseData);
+  const auditData = {
+    ...baseData,
+    metadata: normalizedMetadata,
+  };
   try {
     if (options.client && options.client !== prisma) {
       if (typeof options.client.auditLog?.create !== 'function') return;
-      await options.client.auditLog.create({ data: baseData });
+      await options.client.auditLog.create({ data: auditData });
       return;
     }
-    await logAudit(baseData);
+    await prisma.auditLog.create({ data: auditData });
   } catch (err) {
     console.error('[approval fallback audit failed]', err);
   }
@@ -315,7 +336,7 @@ async function createApprovalWithClient(
     targetTable,
     targetId,
   });
-  if (existing) return existing;
+  if (existing) return { instance: existing, created: false };
 
   const normalizedSteps = steps.map((s, idx) => ({
     ...s,
@@ -353,7 +374,7 @@ async function createApprovalWithClient(
       },
       include: { steps: true },
     });
-    return instance;
+    return { instance, created: true };
   } catch (err) {
     if (!isPrismaUniqueError(err)) {
       throw err;
@@ -364,7 +385,7 @@ async function createApprovalWithClient(
       targetTable,
       targetId,
     });
-    if (fallback) return fallback;
+    if (fallback) return { instance: fallback, created: false };
     throw err;
   }
 }
@@ -381,7 +402,7 @@ export async function createApproval(
   ruleVersion?: number,
   ruleSnapshot?: Record<string, unknown> | null,
 ) {
-  return prisma.$transaction(async (tx: any) =>
+  const result = await prisma.$transaction(async (tx: any) =>
     createApprovalWithClient(
       tx,
       flowType,
@@ -396,6 +417,7 @@ export async function createApproval(
       ruleSnapshot,
     ),
   );
+  return result.instance;
 }
 
 export async function createApprovalFor(
@@ -440,22 +462,25 @@ export async function createApprovalFor(
   if (!rule) {
     fallbackReasons.push('rule_id_auto_used');
   }
-  let approval;
+  let approvalResult;
   if (client === prisma) {
-    approval = await createApproval(
-      flowType,
-      targetTable,
-      targetId,
-      steps,
-      rule?.id || 'auto',
-      options.createdBy,
-      projectId,
-      stagePolicy,
-      ruleVersion,
-      ruleSnapshot,
+    approvalResult = await prisma.$transaction(async (tx: any) =>
+      createApprovalWithClient(
+        tx,
+        flowType,
+        targetTable,
+        targetId,
+        steps,
+        rule?.id || 'auto',
+        options.createdBy,
+        projectId,
+        stagePolicy,
+        ruleVersion,
+        ruleSnapshot,
+      ),
     );
   } else {
-    approval = await createApprovalWithClient(
+    approvalResult = await createApprovalWithClient(
       client,
       flowType,
       targetTable,
@@ -469,17 +494,20 @@ export async function createApprovalFor(
       ruleSnapshot,
     );
   }
-  await logApprovalRuleFallbackIfNeeded({
-    client,
-    flowType,
-    targetTable,
-    targetId,
-    approvalInstanceId: approval.id,
-    ruleId: rule?.id ?? null,
-    fallbackReasons,
-    payload: enrichedPayload,
-    createdBy: options.createdBy,
-  });
+  const approval = approvalResult.instance;
+  if (approvalResult.created) {
+    await logApprovalRuleFallbackIfNeeded({
+      client,
+      flowType,
+      targetTable,
+      targetId,
+      approvalInstanceId: approval.id,
+      ruleId: rule?.id ?? null,
+      fallbackReasons,
+      payload: enrichedPayload,
+      createdBy: options.createdBy,
+    });
+  }
   return approval;
 }
 

--- a/packages/backend/test/approvalRuleSelection.test.js
+++ b/packages/backend/test/approvalRuleSelection.test.js
@@ -242,6 +242,52 @@ test('createApprovalFor: logs fallback reasons when no active rule is found', as
   ]);
 });
 
+test('createApprovalFor: writes normalized fallback metadata in tx path', async () => {
+  const auditLogs = [];
+  const fakeClient = {
+    approvalRule: {
+      findMany: async () => [],
+    },
+    project: { findUnique: async () => null },
+    approvalInstance: {
+      findFirst: async () => null,
+      create: async () => ({
+        id: 'a-fallback-normalized',
+        status: 'pending_qa',
+        currentStep: 1,
+        steps: [],
+      }),
+    },
+    auditLog: {
+      create: async ({ data }) => {
+        auditLogs.push(data);
+        return { id: 'audit-normalized' };
+      },
+    },
+  };
+
+  await createApprovalFor(
+    'invoice',
+    'invoices',
+    'inv-normalized',
+    {
+      amount: BigInt(10),
+      totalAmount: Number.POSITIVE_INFINITY,
+      projectType: new Date('2026-01-01T00:00:00.000Z'),
+    },
+    { client: fakeClient, createdBy: 'u1' },
+  );
+
+  assert.equal(auditLogs.length, 1);
+  assert.equal(auditLogs[0].metadata._request.source, 'system');
+  assert.equal(auditLogs[0].metadata.payloadHints.amount, '10');
+  assert.equal(auditLogs[0].metadata.payloadHints.totalAmount, 'Infinity');
+  assert.equal(
+    auditLogs[0].metadata.payloadHints.projectType,
+    '2026-01-01T00:00:00.000Z',
+  );
+});
+
 test('createApprovalFor: logs fallback reason when first rule is used without condition match', async () => {
   const auditLogs = [];
   const fakeClient = {
@@ -329,6 +375,54 @@ test('createApprovalFor: logs fallback reason when selected rule has invalid ste
   assert.deepEqual(auditLogs[0].metadata.fallbackReasons, [
     'rule_invalid_steps',
   ]);
+});
+
+test('createApprovalFor: does not log fallback when open approval already exists', async () => {
+  const auditLogs = [];
+  let createCalled = false;
+  const fakeClient = {
+    approvalRule: {
+      findMany: async () => [],
+    },
+    approvalInstance: {
+      findFirst: async () => ({
+        id: 'a-existing',
+        flowType: 'invoice',
+        targetTable: 'invoices',
+        targetId: 'inv-existing',
+        status: 'pending_qa',
+        currentStep: 1,
+        steps: [],
+      }),
+      create: async () => {
+        createCalled = true;
+        return {
+          id: 'a-created',
+          status: 'pending_qa',
+          currentStep: 1,
+          steps: [],
+        };
+      },
+    },
+    auditLog: {
+      create: async ({ data }) => {
+        auditLogs.push(data);
+        return { id: 'audit-duplicate' };
+      },
+    },
+  };
+
+  const approval = await createApprovalFor(
+    'invoice',
+    'invoices',
+    'inv-existing',
+    { amount: 50 },
+    { client: fakeClient, createdBy: 'u1' },
+  );
+
+  assert.equal(createCalled, false);
+  assert.equal(approval.id, 'a-existing');
+  assert.equal(auditLogs.length, 0);
 });
 
 test('createApprovalFor: stage order derives currentStep/status from the smallest stepOrder', async () => {


### PR DESCRIPTION
## 概要
- Issue #1316 (B2) の初手として、承認ルール未解決時のフォールバック経路を監査可能にしました
- 挙動は変えず、どの理由で fallback したかを `AuditLog` に記録します

## 変更点
- `createApprovalFor` に fallback 理由収集を追加
  - `rule_not_found`
  - `rule_condition_unmatched_first_rule`
  - `rule_invalid_steps`
  - `rule_id_auto_used`
- fallback 発生時に `approval_rule_fallback_used` を監査ログへ出力
  - 理由配列、対象 flow/target、採用 rule、payload の要約を metadata に保持
  - トランザクション client（`tx.auditLog.create`）がある場合は同一トランザクション内で記録
- テスト追加
  - fallback 理由ごとの監査ログ出力を `approvalRuleSelection.test.js` に追加

## 互換性
- 承認フローの結果（採用ルール/ステップ計算）は従来通り
- 監査ログ追加のみ（挙動変更なし）

## テスト
- `DATABASE_URL='postgresql://postgres:postgres@127.0.0.1:5432/erp4' npm run test --prefix packages/backend`
- `npm run lint --prefix packages/backend`
- `npm run typecheck --prefix packages/backend`
- `npm run format:check --prefix packages/backend`

Refs #1316
Refs #1308
