### PR TITLE
Align approval rule admin UI with versioned updates

### DIFF
--- a/packages/frontend/e2e/frontend-smoke-reports-masters-settings.spec.ts
+++ b/packages/frontend/e2e/frontend-smoke-reports-masters-settings.spec.ts
@@ -399,7 +399,9 @@ test('frontend smoke reports masters settings @extended', async ({ page }) => {
     timeout: actionTimeout,
   });
   const createdApprovalRuleText = await createdApprovalRuleCard.textContent();
-  const createdSeriesMatch = createdApprovalRuleText?.match(/series:([^\s/]+)/);
+  const createdSeriesMatch = createdApprovalRuleText?.match(
+    /series:\s*([^\s/]+)/,
+  );
   expect(createdSeriesMatch?.[1]).toBeTruthy();
   await createdApprovalRuleCard
     .getByRole('button', { name: '新版作成' })
@@ -417,7 +419,11 @@ test('frontend smoke reports masters settings @extended', async ({ page }) => {
   ).toBeVisible();
   const seriesRuleCards = approvalBlock
     .locator('.list .card')
-    .filter({ hasText: `series:${createdSeriesMatch?.[1]}` });
+    .filter({
+      hasText: new RegExp(
+        `series:\\s*${createdSeriesMatch?.[1]?.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}`,
+      ),
+    });
   await expect(seriesRuleCards).toHaveCount(2, { timeout: actionTimeout });
   await expect(
     seriesRuleCards.filter({ hasText: 'supersedesRuleId:' }).first(),

--- a/packages/frontend/src/sections/AdminSettings.tsx
+++ b/packages/frontend/src/sections/AdminSettings.tsx
@@ -2224,9 +2224,8 @@ export const AdminSettings: React.FC = () => {
                     }}
                   >
                     <div>
-                      <strong>{rule.flowType}</strong> / series:
-                      {rule.ruleKey ?? rule.id} / v{rule.version ?? 1} / id=
-                      {rule.id}
+                      <strong>{rule.flowType}</strong>
+                      {` / series:${rule.ruleKey ?? rule.id} / v${rule.version ?? 1} / id=${rule.id}`}
                     </div>
                     <div className="row" style={{ gap: 6, flexWrap: 'wrap' }}>
                       <span className="badge">{statusLabel}</span>


### PR DESCRIPTION
## 概要
- 承認ルール管理UIを追記型 versioning 前提に合わせて調整
- 系列(ruleKey)/版(version)/supersedes/effectiveTo を画面表示に追加
- 管理画面E2Eに「作成→新版作成」のシナリオを追加

## 変更内容
- `AdminSettings` の承認ルール編集を「新版作成」UXへ変更
- PATCH 時に server-managed な `version` を送らないよう修正
- 最新版のみ有効化/無効化・新版作成できるように制御
- 系列単位で監査ログをまとめて表示
- Playwright スモークに versioned update の確認を追加

## 確認
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run build --prefix packages/frontend`
- `npm run e2e --prefix packages/frontend -- --list e2e/frontend-smoke-reports-masters-settings.spec.ts`

Closes #1315
