### PR TITLE
fix(approval): deny implicit strict-mode fallback

### DIFF
--- a/docs/requirements/approval-default-rule-fallback-inventory.md
+++ b/docs/requirements/approval-default-rule-fallback-inventory.md
@@ -84,3 +84,9 @@
   - `packages/backend/src/services/approval.ts`
 - demo seed の ApprovalRule も空stepsを廃止し、既定ルール形へ更新
   - `scripts/seed-demo.sql`
+
+## 8. 実装メモ（2026-03-06）
+
+- `APPROVAL_RULE_FALLBACK_MODE=strict` では、`rule_not_found` / `rule_invalid_steps` を
+  `computeApprovalSteps` にフォールバックさせず `approval_rule_required` で拒否する。
+- ただし既存の open approval instance がある場合は、strict でも idempotency を優先して既存 instance を返す。

--- a/packages/backend/src/services/approval.ts
+++ b/packages/backend/src/services/approval.ts
@@ -3,6 +3,7 @@ import type { Prisma } from '@prisma/client';
 import { DocStatusValue } from '../types.js';
 import { prisma } from './db.js';
 import { buildAuditMetadata, logAudit, type AuditContext } from './audit.js';
+import { AppError } from './errors.js';
 import { createEvidenceSnapshotForApproval } from './evidenceSnapshot.js';
 import { logExpenseStateTransition } from './expenseStateTransitionLog.js';
 import { isExpenseQaChecklistComplete } from './expenseQaChecklist.js';
@@ -330,6 +331,16 @@ function approvalFallbackPayloadHints(
   };
 }
 
+function shouldDenyImplicitApprovalFallback(
+  fallbackMode: ApprovalRuleFallbackMode,
+  fallbackReasons: string[],
+) {
+  if (fallbackMode !== 'strict') return false;
+  return fallbackReasons.some(
+    (reason) => reason === 'rule_not_found' || reason === 'rule_invalid_steps',
+  );
+}
+
 async function logApprovalRuleFallbackIfNeeded(options: {
   client: any;
   flowType: string;
@@ -507,6 +518,31 @@ export async function createApprovalFor(
   const normalized = normalizeRuleStepsWithPolicy(rule?.steps);
   if (rule && !normalized) {
     fallbackReasons.push('rule_invalid_steps');
+  }
+  if (shouldDenyImplicitApprovalFallback(fallbackMode, fallbackReasons)) {
+    const existing = await findOpenApprovalInstance({
+      client,
+      flowType,
+      targetTable,
+      targetId,
+    });
+    if (existing) {
+      return existing;
+    }
+    throw new AppError({
+      code: 'approval_rule_required',
+      message:
+        'Active approval rule is required before submission in strict mode',
+      httpStatus: 409,
+      category: 'conflict',
+      details: {
+        flowType,
+        targetTable,
+        targetId,
+        fallbackMode,
+        fallbackReasons,
+      },
+    });
   }
   const steps =
     normalized?.steps ||

--- a/packages/backend/test/approvalRuleSelection.test.js
+++ b/packages/backend/test/approvalRuleSelection.test.js
@@ -407,6 +407,166 @@ test('createApprovalFor: db_default_only mode skips in-code default rule seeding
   ]);
 });
 
+test('createApprovalFor: strict mode rejects implicit fallback when no rule is found', async () => {
+  const prevMode = process.env.APPROVAL_RULE_FALLBACK_MODE;
+  process.env.APPROVAL_RULE_FALLBACK_MODE = 'strict';
+  let createCalled = false;
+  try {
+    const fakeClient = {
+      approvalRule: {
+        findMany: async () => [],
+      },
+      approvalInstance: {
+        findFirst: async () => null,
+        create: async () => {
+          createCalled = true;
+          return {
+            id: 'unexpected',
+            status: 'pending_qa',
+            currentStep: 1,
+            steps: [],
+          };
+        },
+      },
+    };
+
+    await assert.rejects(
+      () =>
+        createApprovalFor(
+          'invoice',
+          'invoices',
+          'inv-strict-no-rule',
+          { amount: 120000 },
+          { client: fakeClient, createdBy: 'u1' },
+        ),
+      (err) => {
+        assert.equal(err?.code, 'approval_rule_required');
+        assert.equal(err?.httpStatus, 409);
+        assert.equal(err?.details?.fallbackMode, 'strict');
+        assert.deepEqual(err?.details?.fallbackReasons, ['rule_not_found']);
+        return true;
+      },
+    );
+  } finally {
+    if (prevMode === undefined) {
+      delete process.env.APPROVAL_RULE_FALLBACK_MODE;
+    } else {
+      process.env.APPROVAL_RULE_FALLBACK_MODE = prevMode;
+    }
+  }
+
+  assert.equal(createCalled, false);
+});
+
+test('createApprovalFor: strict mode rejects implicit fallback when selected rule has invalid steps', async () => {
+  const prevMode = process.env.APPROVAL_RULE_FALLBACK_MODE;
+  process.env.APPROVAL_RULE_FALLBACK_MODE = 'strict';
+  let createCalled = false;
+  try {
+    const fakeClient = {
+      approvalRule: {
+        findMany: async () => [
+          {
+            id: 'r-strict-invalid',
+            flowType: 'invoice',
+            conditions: {},
+            steps: { invalid: true },
+          },
+        ],
+      },
+      approvalInstance: {
+        findFirst: async () => null,
+        create: async () => {
+          createCalled = true;
+          return {
+            id: 'unexpected',
+            status: 'pending_qa',
+            currentStep: 1,
+            steps: [],
+          };
+        },
+      },
+    };
+
+    await assert.rejects(
+      () =>
+        createApprovalFor(
+          'invoice',
+          'invoices',
+          'inv-strict-invalid-steps',
+          { amount: 120000 },
+          { client: fakeClient, createdBy: 'u1' },
+        ),
+      (err) => {
+        assert.equal(err?.code, 'approval_rule_required');
+        assert.equal(err?.httpStatus, 409);
+        assert.equal(err?.details?.fallbackMode, 'strict');
+        assert.deepEqual(err?.details?.fallbackReasons, ['rule_invalid_steps']);
+        return true;
+      },
+    );
+  } finally {
+    if (prevMode === undefined) {
+      delete process.env.APPROVAL_RULE_FALLBACK_MODE;
+    } else {
+      process.env.APPROVAL_RULE_FALLBACK_MODE = prevMode;
+    }
+  }
+
+  assert.equal(createCalled, false);
+});
+
+test('createApprovalFor: strict mode still returns an existing open approval instance', async () => {
+  const prevMode = process.env.APPROVAL_RULE_FALLBACK_MODE;
+  process.env.APPROVAL_RULE_FALLBACK_MODE = 'strict';
+  let createCalled = false;
+  const existing = {
+    id: 'a-strict-existing',
+    flowType: 'invoice',
+    targetTable: 'invoices',
+    targetId: 'inv-strict-existing',
+    status: 'pending_qa',
+    currentStep: 1,
+    steps: [],
+  };
+  try {
+    const fakeClient = {
+      approvalRule: {
+        findMany: async () => [],
+      },
+      approvalInstance: {
+        findFirst: async () => existing,
+        create: async () => {
+          createCalled = true;
+          return {
+            id: 'unexpected',
+            status: 'pending_qa',
+            currentStep: 1,
+            steps: [],
+          };
+        },
+      },
+    };
+
+    const approval = await createApprovalFor(
+      'invoice',
+      'invoices',
+      'inv-strict-existing',
+      { amount: 120000 },
+      { client: fakeClient, createdBy: 'u1' },
+    );
+    assert.equal(approval.id, existing.id);
+  } finally {
+    if (prevMode === undefined) {
+      delete process.env.APPROVAL_RULE_FALLBACK_MODE;
+    } else {
+      process.env.APPROVAL_RULE_FALLBACK_MODE = prevMode;
+    }
+  }
+
+  assert.equal(createCalled, false);
+});
+
 test('createApprovalFor: writes normalized fallback metadata in tx path', async () => {
   const auditLogs = [];
   const fakeClient = {


### PR DESCRIPTION
## 概要
- `APPROVAL_RULE_FALLBACK_MODE=strict` で `rule_not_found` / `rule_invalid_steps` をコード側の暗黙 fallback へ流さず拒否するよう変更
- ただし既存 open approval instance がある場合は idempotency を優先して既存 instance を返す
- 関連要件メモと unit test を追加

## 背景
- #1316 の残作業として、`strict` を既定運用できる状態へ近づけるため `auto/manual` 相当の暗黙 fallback を strict mode では禁止する必要がありました。
- 現状は `db_default_only` / `strict` でも、ルール未解決時に `computeApprovalSteps` へ流れて承認が成立していました。

## 変更内容
- `packages/backend/src/services/approval.ts`
  - strict mode かつ `rule_not_found` / `rule_invalid_steps` の場合は `approval_rule_required` (`409`) を送出
  - ただし既存 open approval instance があれば再作成せず返却
- `packages/backend/test/approvalRuleSelection.test.js`
  - strict mode の拒否ケース 2件と既存 instance 優先ケースを追加
- `docs/requirements/approval-default-rule-fallback-inventory.md`
  - strict mode 拒否の挙動を実装メモへ追記

## 検証
- `npm run lint --prefix packages/backend`
- `npm run build --prefix packages/backend`
- `npm run format:check --prefix packages/backend`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres node --test packages/backend/test/approvalRuleSelection.test.js packages/backend/test/approvalIdempotency.test.js`

## 影響
- strict mode の承認起票
- ApprovalRule 未整備/不備時のエラー挙動
