### PR TITLE
test(chat): cover room deep link aliases

### DIFF
--- a/packages/frontend/e2e/frontend-dashboard-notification-routing.spec.ts
+++ b/packages/frontend/e2e/frontend-dashboard-notification-routing.spec.ts
@@ -63,7 +63,7 @@ async function ensureOk(res: { ok(): boolean; status(): number; text(): any }) {
 async function prepare(
   page: Page,
   authState: AuthState,
-  options?: { activeSectionId?: string },
+  options?: { activeSectionId?: string; preserveActiveSection?: boolean },
 ) {
   if (page.listenerCount('pageerror') === 0) {
     page.on('pageerror', (error) => {
@@ -81,14 +81,28 @@ async function prepare(
     });
   }
 
-  await page.addInitScript(([state, activeSectionId]) => {
+  await page.addInitScript(([state, config]) => {
     window.localStorage.setItem('erp4_auth', JSON.stringify(state));
+    const activeSectionId =
+      config && typeof config === 'object' ? config.activeSectionId : null;
     if (typeof activeSectionId === 'string' && activeSectionId.length > 0) {
       window.localStorage.setItem('erp4_active_section', activeSectionId);
-    } else {
+      return;
+    }
+    const preserveActiveSection =
+      config &&
+      typeof config === 'object' &&
+      config.preserveActiveSection === true;
+    if (!preserveActiveSection) {
       window.localStorage.removeItem('erp4_active_section');
     }
-  }, [authState, options?.activeSectionId ?? null]);
+  }, [
+    authState,
+    {
+      activeSectionId: options?.activeSectionId ?? null,
+      preserveActiveSection: options?.preserveActiveSection === true,
+    },
+  ]);
   await page.goto(baseUrl);
   await expect(page.getByRole('heading', { name: 'ERP4 MVP PoC' })).toBeVisible(
     {
@@ -669,7 +683,11 @@ test('legacy project-chat stored section migrates to room-chat @extended', async
     groupIds: ['mgmt', 'hr-group'],
   };
 
-  await prepare(page, adminState, { activeSectionId: 'project-chat' });
+  await prepare(page, adminState, { preserveActiveSection: true });
+  await page.evaluate(() => {
+    window.localStorage.setItem('erp4_active_section', 'project-chat');
+  });
+  await page.reload();
   const roomChatHeading = page.locator('main').getByRole('heading', {
     name: 'チャット（全社/部門/private_group/DM）',
     level: 2,


### PR DESCRIPTION
## 概要
- room-first 移行で残っていた deep link / localStorage alias の回帰テストを追加
- `project-chat -> room-chat` migration と `room_chat` deep link を E2E で確認

## 変更点
- `frontend-dashboard-notification-routing.spec.ts` に以下を追加
  - legacy `project-chat` 保存セクションの migration 回帰
  - `room_chat` deep link で対象ルームが選択される回帰
  - deep link 処理後に hash が消去される回帰
- `prepare()` helper を stored active section 指定に対応

## 確認
- `npm run format:check --prefix packages/frontend`
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `E2E_CAPTURE=0 E2E_GREP='project_chat deep link|project-chat stored section|room_chat deep link' ./scripts/e2e-frontend.sh`
