### PR TITLE
feat(annotations): normalize legacy project chat refs

### DIFF
--- a/docs/requirements/annotations.md
+++ b/docs/requirements/annotations.md
@@ -48,6 +48,7 @@
   - `kind` は許可リストのみ
   - `id` 必須
   - 同一 `kind:id` は重複排除
+  - legacy な `project_chat` は保存時に `room_chat` へ正規化する
 - `notes`
   - 文字数上限は設定値で制限
 

--- a/packages/backend/src/routes/annotations.ts
+++ b/packages/backend/src/routes/annotations.ts
@@ -88,6 +88,11 @@ const ALLOWED_INTERNAL_REF_KINDS = new Set<InternalRefKind>([
   'chat_message',
 ]);
 
+function normalizeInternalRefKind(kind: InternalRefKind) {
+  if (kind === 'project_chat') return 'room_chat' as const;
+  return kind;
+}
+
 function normalizeString(value: unknown) {
   return typeof value === 'string' ? value.trim() : '';
 }
@@ -190,14 +195,15 @@ function normalizeInternalRefs(value: unknown): InternalRef[] {
     if (!entry || typeof entry !== 'object') {
       throw new Error('INVALID_INTERNAL_REF');
     }
-    const kind = normalizeString((entry as any).kind) as InternalRefKind;
+    const rawKind = normalizeString((entry as any).kind) as InternalRefKind;
     const id = normalizeString((entry as any).id);
     const labelRaw = (entry as any).label;
     const label =
       typeof labelRaw === 'string' && labelRaw.trim() ? labelRaw.trim() : '';
-    if (!kind || !ALLOWED_INTERNAL_REF_KINDS.has(kind)) {
+    if (!rawKind || !ALLOWED_INTERNAL_REF_KINDS.has(rawKind)) {
       throw new Error('INVALID_INTERNAL_REF_KIND');
     }
+    const kind = normalizeInternalRefKind(rawKind);
     if (!id) {
       throw new Error('INVALID_INTERNAL_REF_ID');
     }

--- a/packages/backend/test/annotationsChatRefNormalizationRoutes.test.js
+++ b/packages/backend/test/annotationsChatRefNormalizationRoutes.test.js
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildServer } from '../dist/server.js';
+import { prisma } from '../dist/services/db.js';
+
+const MIN_DATABASE_URL = 'postgresql://user:pass@localhost:5432/postgres';
+
+function withPrismaStubs(stubs, fn) {
+  const restores = [];
+  for (const [path, stub] of Object.entries(stubs)) {
+    const parts = path.split('.');
+    let target;
+    let method;
+    if (parts.length === 1) {
+      const rootMethod = parts[0];
+      if (!rootMethod || !rootMethod.startsWith('$')) {
+        throw new Error(`invalid stub path: ${path}`);
+      }
+      target = prisma;
+      method = rootMethod;
+    } else if (parts.length === 2) {
+      const [model, member] = parts;
+      if (!model || !member) {
+        throw new Error(`invalid stub path: ${path}`);
+      }
+      target = prisma[model];
+      method = member;
+    } else {
+      throw new Error(`invalid stub path: ${path}`);
+    }
+    if (!target || typeof target[method] !== 'function') {
+      throw new Error(`invalid stub target: ${path}`);
+    }
+    const original = target[method];
+    target[method] = stub;
+    restores.push(() => {
+      target[method] = original;
+    });
+  }
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => {
+      for (const restore of restores.reverse()) restore();
+    });
+}
+
+function withEnv(overrides, fn) {
+  const previous = new Map();
+  for (const key of Object.keys(overrides)) {
+    previous.set(key, process.env[key]);
+    const value = overrides[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => {
+      for (const [key, value] of previous.entries()) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    });
+}
+
+function createTransactionStub() {
+  return async (callback) => callback(prisma);
+}
+
+test('PATCH /annotations/:kind/:id normalizes project_chat refs into room_chat', async () => {
+  await withEnv(
+    {
+      DATABASE_URL: process.env.DATABASE_URL || MIN_DATABASE_URL,
+      AUTH_MODE: 'header',
+    },
+    async () => {
+      const upserts = [];
+      const annotationLogs = [];
+      const auditEntries = [];
+      await withPrismaStubs(
+        {
+          'invoice.findUnique': async () => ({
+            id: 'inv-001',
+            projectId: 'proj-001',
+            status: 'draft',
+            deletedAt: null,
+          }),
+          'annotationSetting.findUnique': async () => null,
+          'annotation.findUnique': async () => null,
+          'annotation.upsert': async ({ create, update }) => {
+            upserts.push({ create, update });
+            return {
+              id: 'annotation-1',
+              targetKind: 'invoice',
+              targetId: 'inv-001',
+              notes: null,
+              externalUrls: [],
+              internalRefs: create.internalRefs,
+              updatedAt: new Date('2026-03-06T00:00:00Z'),
+              updatedBy: 'admin-user',
+            };
+          },
+          'annotationLog.create': async ({ data }) => {
+            annotationLogs.push(data);
+            return { id: `annotation-log-${annotationLogs.length}` };
+          },
+          'auditLog.create': async ({ data }) => {
+            auditEntries.push(data);
+            return { id: `audit-${auditEntries.length}` };
+          },
+          $transaction: createTransactionStub(),
+        },
+        async () => {
+          const server = await buildServer({ logger: false });
+          try {
+            const res = await server.inject({
+              method: 'PATCH',
+              url: '/annotations/invoice/inv-001',
+              headers: {
+                'x-user-id': 'admin-user',
+                'x-roles': 'admin,mgmt',
+                'content-type': 'application/json',
+              },
+              payload: {
+                notes: null,
+                externalUrls: [],
+                internalRefs: [
+                  {
+                    kind: 'project_chat',
+                    id: 'room-001',
+                    label: 'Legacy project room',
+                  },
+                  {
+                    kind: 'room_chat',
+                    id: 'room-001',
+                    label: 'Canonical room',
+                  },
+                ],
+              },
+            });
+            assert.equal(res.statusCode, 200, res.body);
+            const payload = JSON.parse(res.body);
+            assert.deepEqual(payload.internalRefs, [
+              {
+                kind: 'room_chat',
+                id: 'room-001',
+                label: 'Legacy project room',
+              },
+            ]);
+          } finally {
+            await server.close();
+          }
+        },
+      );
+
+      assert.equal(upserts.length, 1);
+      assert.deepEqual(upserts[0]?.create?.internalRefs, [
+        {
+          kind: 'room_chat',
+          id: 'room-001',
+          label: 'Legacy project room',
+        },
+      ]);
+      assert.equal(annotationLogs.length, 1);
+      assert.deepEqual(annotationLogs[0]?.internalRefs, [
+        {
+          kind: 'room_chat',
+          id: 'room-001',
+          label: 'Legacy project room',
+        },
+      ]);
+      assert.equal(auditEntries.length, 1);
+      assert.equal(auditEntries[0]?.action, 'annotations_updated');
+    },
+  );
+});


### PR DESCRIPTION
## 概要
- 注釈の内部参照で legacy `project_chat` を保存時に `room_chat` へ正規化
- room-first 移行後に新規書き込みで legacy kind を増やさないようにする
- route test と仕様書を追加

## 変更点
- backend: `normalizeInternalRefs()` で `project_chat -> room_chat` を canonicalize
- backend test: 重複する `project_chat` / `room_chat` 入力が `room_chat` 1件に畳み込まれることを確認
- docs: 注釈仕様に正規化方針を追記

## 確認
- `npm run format:check --prefix packages/backend`
- `npm run lint --prefix packages/backend`
- `npm run typecheck --prefix packages/backend`
- `npm run build --prefix packages/backend`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres node --test packages/backend/test/annotationsChatRefNormalizationRoutes.test.js`
