### PR TITLE
test: add legacy project_chat deep link normalization e2e

### DIFF
--- a/packages/frontend/e2e/frontend-smoke-workflow-evidence.spec.ts
+++ b/packages/frontend/e2e/frontend-smoke-workflow-evidence.spec.ts
@@ -286,6 +286,14 @@ test('frontend smoke workflow evidence chat references @extended', async ({
     expenseAnnotationDrawer.locator('.badge', { hasText: 'room_chat' }),
   ).toBeVisible({ timeout: actionTimeout });
   await expenseAnnotationDrawer
+    .getByLabel('手動追加（deep link / kind:id）')
+    .fill(`/#/open?kind=project_chat&id=${projectId}`);
+  await expenseAnnotationDrawer
+    .getByRole('button', { name: '追加' })
+    .last()
+    .click();
+  await expect(roomChatReference).toHaveCount(1, { timeout: actionTimeout });
+  await expenseAnnotationDrawer
     .getByRole('button', { name: '参照状態を確認' })
     .click();
   await expect(expenseAnnotationDrawer.getByText('参照可能')).toBeVisible({


### PR DESCRIPTION
## 概要
- 注釈の手動追加で `project_chat:${projectId}` に加えて `/#/open?kind=project_chat&id=...` も `room_chat` に正規化される E2E を追加
- 同一 room 参照が重複追加されないことを確認

## テスト
- `npm run format:check --prefix packages/frontend -- packages/frontend/e2e/frontend-smoke-workflow-evidence.spec.ts`
- `npm run typecheck --prefix packages/frontend`
- `npm run build --prefix packages/frontend`
- `E2E_CAPTURE=0 E2E_GREP='frontend smoke workflow evidence chat references' ./scripts/e2e-frontend.sh`

## 関連
- refs #1314