### PR TITLE
fix: deny unmatched approval rule fallback in strict mode

### DIFF
--- a/docs/requirements/approval-default-rule-fallback-inventory.md
+++ b/docs/requirements/approval-default-rule-fallback-inventory.md
@@ -87,6 +87,7 @@
 
 ## 8. 実装メモ（2026-03-06）
 
-- `APPROVAL_RULE_FALLBACK_MODE=strict` では、`rule_not_found` / `rule_invalid_steps` を
-  `computeApprovalSteps` にフォールバックさせず `approval_rule_required` で拒否する。
+- `APPROVAL_RULE_FALLBACK_MODE=strict` では、`rule_not_found` / `rule_invalid_steps` /
+  `rule_condition_unmatched_first_rule` を `computeApprovalSteps` や先頭ルール採用へ
+  フォールバックさせず `approval_rule_required` で拒否する。
 - ただし既存の open approval instance がある場合は、strict でも idempotency を優先して既存 instance を返す。

--- a/packages/backend/src/services/approval.ts
+++ b/packages/backend/src/services/approval.ts
@@ -337,7 +337,10 @@ function shouldDenyImplicitApprovalFallback(
 ) {
   if (fallbackMode !== 'strict') return false;
   return fallbackReasons.some(
-    (reason) => reason === 'rule_not_found' || reason === 'rule_invalid_steps',
+    (reason) =>
+      reason === 'rule_not_found' ||
+      reason === 'rule_invalid_steps' ||
+      reason === 'rule_condition_unmatched_first_rule',
   );
 }
 

--- a/packages/backend/test/approvalRuleSelection.test.js
+++ b/packages/backend/test/approvalRuleSelection.test.js
@@ -516,6 +516,66 @@ test('createApprovalFor: strict mode rejects implicit fallback when selected rul
   assert.equal(createCalled, false);
 });
 
+test('createApprovalFor: strict mode rejects implicit fallback when no rule condition matches', async () => {
+  const prevMode = process.env.APPROVAL_RULE_FALLBACK_MODE;
+  process.env.APPROVAL_RULE_FALLBACK_MODE = 'strict';
+  let createCalled = false;
+  try {
+    const fakeClient = {
+      approvalRule: {
+        findMany: async () => [
+          {
+            id: 'r-strict-unmatched',
+            flowType: 'invoice',
+            conditions: { amountMin: 999999 },
+            steps: [{ approverGroupId: 'mgmt', stepOrder: 1 }],
+          },
+        ],
+      },
+      approvalInstance: {
+        findFirst: async () => null,
+        create: async () => {
+          createCalled = true;
+          return {
+            id: 'unexpected',
+            status: 'pending_qa',
+            currentStep: 1,
+            steps: [],
+          };
+        },
+      },
+    };
+
+    await assert.rejects(
+      () =>
+        createApprovalFor(
+          'invoice',
+          'invoices',
+          'inv-strict-unmatched',
+          { amount: 120000 },
+          { client: fakeClient, createdBy: 'u1' },
+        ),
+      (err) => {
+        assert.equal(err?.code, 'approval_rule_required');
+        assert.equal(err?.httpStatus, 409);
+        assert.equal(err?.details?.fallbackMode, 'strict');
+        assert.deepEqual(err?.details?.fallbackReasons, [
+          'rule_condition_unmatched_first_rule',
+        ]);
+        return true;
+      },
+    );
+  } finally {
+    if (prevMode === undefined) {
+      delete process.env.APPROVAL_RULE_FALLBACK_MODE;
+    } else {
+      process.env.APPROVAL_RULE_FALLBACK_MODE = prevMode;
+    }
+  }
+
+  assert.equal(createCalled, false);
+});
+
 test('createApprovalFor: strict mode still returns an existing open approval instance', async () => {
   const prevMode = process.env.APPROVAL_RULE_FALLBACK_MODE;
   process.env.APPROVAL_RULE_FALLBACK_MODE = 'strict';


### PR DESCRIPTION
## 概要
- `APPROVAL_RULE_FALLBACK_MODE=strict` で、条件不一致時の `rules[0]` 採用も implicit fallback として拒否
- `approvalRuleSelection` に strict モードの回帰テストを追加
- `docs/requirements/approval-default-rule-fallback-inventory.md` を現行挙動に同期

## テスト
- `npm run format:check --prefix packages/backend`
- `npm run build --prefix packages/backend`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres node --test packages/backend/test/approvalRuleSelection.test.js`

## 関連
- refs #1316
