### PR TITLE
test: cover expense action policy preset mutations

### DIFF
--- a/packages/backend/test/expensePolicyEnforcementPreset.test.js
+++ b/packages/backend/test/expensePolicyEnforcementPreset.test.js
@@ -68,7 +68,7 @@ function adminHeaders() {
 function expenseDraft(overrides = {}) {
   return {
     id: 'exp-001',
-    userId: '',
+    userId: 'user-001',
     projectId: 'proj-001',
     amount: 12000,
     currency: 'JPY',
@@ -230,6 +230,9 @@ test('POST /expenses/:id/submit: policy allow reaches downstream submit path (no
         'expenseStateTransitionLog.create': async () => ({
           id: 'transition-001',
         }),
+        'userNotificationPreference.findMany': async () => [],
+        'appNotification.findMany': async () => [],
+        'appNotification.createMany': async () => ({ count: 0 }),
         'actionPolicy.findMany': async () => allowPolicy('submit'),
         $transaction: async (callback) => {
           transactionCalled += 1;
@@ -315,6 +318,8 @@ test('POST /expenses/:id/mark-paid: policy allow reaches downstream update path 
         'expenseStateTransitionLog.create': async () => ({
           id: 'transition-002',
         }),
+        'userNotificationPreference.findMany': async () => [],
+        'appNotification.findFirst': async () => ({ id: 'notif-existing' }),
         'auditLog.create': async () => ({ id: 'audit-002' }),
       },
       async () => {


### PR DESCRIPTION
## 概要
- `POST /expenses/:id/submit` / `mark-paid` / `unmark-paid` の `phase2_core` preset route test を追加
- 各 route で policy 未定義時の `ACTION_POLICY_DENIED` と、allow 定義時に downstream mutation path へ到達することを確認

## テスト
- `npx prettier --check packages/backend/test/expensePolicyEnforcementPreset.test.js`
- `npm run build --prefix packages/backend`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres node --test packages/backend/test/expensePolicyEnforcementPreset.test.js`

## 関連
- refs #1312
