### PR TITLE
test: cover vendor invoice submit action policy preset

### DIFF
--- a/packages/backend/test/vendorInvoiceSubmitPolicyEnforcementPreset.test.js
+++ b/packages/backend/test/vendorInvoiceSubmitPolicyEnforcementPreset.test.js
@@ -1,10 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { buildServer } from '../dist/server.js';
-import { prisma } from '../dist/services/db.js';
-
 const MIN_DATABASE_URL = 'postgresql://user:pass@localhost:5432/postgres';
+
+process.env.DATABASE_URL ||= MIN_DATABASE_URL;
+
+const { buildServer } = await import('../dist/server.js');
+const { prisma } = await import('../dist/services/db.js');
 
 function withPrismaStubs(stubs, fn) {
   const restores = [];
@@ -65,7 +67,7 @@ function adminHeaders() {
   };
 }
 
-function vendorInvoiceDraft() {
+function vendorInvoiceReceived() {
   return {
     id: 'vi-001',
     status: 'received',
@@ -90,7 +92,7 @@ test('POST /vendor-invoices/:id/submit: phase2_core required action denies when 
     let transactionCalled = 0;
     await withPrismaStubs(
       {
-        'vendorInvoice.findUnique': async () => vendorInvoiceDraft(),
+        'vendorInvoice.findUnique': async () => vendorInvoiceReceived(),
         'actionPolicy.findMany': async () => [],
         $transaction: async () => {
           transactionCalled += 1;
@@ -191,7 +193,7 @@ test('POST /vendor-invoices/:id/submit: policy allow reaches downstream submit p
 
     await withPrismaStubs(
       {
-        'vendorInvoice.findUnique': async () => vendorInvoiceDraft(),
+        'vendorInvoice.findUnique': async () => vendorInvoiceReceived(),
         'actionPolicy.findMany': async () => [
           {
             id: 'policy-vendor-invoice-submit-allow',


### PR DESCRIPTION
## 概要
- `POST /vendor-invoices/:id/submit` の `phase2_core` preset route test を追加
- policy 未定義時の `ACTION_POLICY_DENIED` と、allow policy 定義時に downstream submit path へ到達することを確認

## テスト
- `npx prettier --check packages/backend/test/vendorInvoiceSubmitPolicyEnforcementPreset.test.js`
- `npm run build --prefix packages/backend`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres node --test packages/backend/test/vendorInvoiceSubmitPolicyEnforcementPreset.test.js`

## 関連
- refs #1312