### PR TITLE
test: cover vendor invoice edit action policy presets

### DIFF
--- a/packages/backend/test/vendorInvoiceUpdatePolicyEnforcementPreset.test.js
+++ b/packages/backend/test/vendorInvoiceUpdatePolicyEnforcementPreset.test.js
@@ -1,10 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { buildServer } from '../dist/server.js';
-import { prisma } from '../dist/services/db.js';
-
 const MIN_DATABASE_URL = 'postgresql://user:pass@localhost:5432/postgres';
+
+process.env.DATABASE_URL ||= MIN_DATABASE_URL;
+
+const { buildServer } = await import('../dist/server.js');
+const { prisma } = await import('../dist/services/db.js');
 
 function withPrismaStubs(stubs, fn) {
   const restores = [];


### PR DESCRIPTION
## 概要
- `PUT /vendor-invoices/:id/allocations` / `PUT /vendor-invoices/:id/lines` の `phase2_core` preset route test を追加
- policy 未定義時の `ACTION_POLICY_DENIED` と、allow policy 定義時に downstream update path へ到達することを確認

## テスト
- `npx prettier --check packages/backend/test/vendorInvoiceUpdatePolicyEnforcementPreset.test.js`
- `npm run build --prefix packages/backend`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres node --test packages/backend/test/vendorInvoiceUpdatePolicyEnforcementPreset.test.js`

## 関連
- refs #1312