### PR TITLE
test: cover vendor invoice edit action policy presets

### DIFF
--- a/packages/backend/test/vendorInvoiceEditPolicyEnforcementPreset.test.js
+++ b/packages/backend/test/vendorInvoiceEditPolicyEnforcementPreset.test.js
@@ -1,10 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { buildServer } from '../dist/server.js';
-import { prisma } from '../dist/services/db.js';
-
 const MIN_DATABASE_URL = 'postgresql://user:pass@localhost:5432/postgres';
+
+process.env.DATABASE_URL ||= MIN_DATABASE_URL;
+
+const { buildServer } = await import('../dist/server.js');
+const { prisma } = await import('../dist/services/db.js');
 
 function withPrismaStubs(stubs, fn) {
   const restores = [];


### PR DESCRIPTION
## Summary
- add phase2_core preset coverage for vendor invoice allocations update
- add phase2_core preset coverage for vendor invoice lines update
- verify deny and allow paths reach the expected downstream behavior

## Testing
- npx prettier --check packages/backend/test/vendorInvoiceEditPolicyEnforcementPreset.test.js
- npm run build --prefix packages/backend
- DATABASE_URL=postgresql://user:pass@localhost:5432/postgres node --test packages/backend/test/vendorInvoiceEditPolicyEnforcementPreset.test.js