### PR TITLE
feat(expense): bridge reassign guards

### DIFF
--- a/docs/requirements/reassignment-policy.md
+++ b/docs/requirements/reassignment-policy.md
@@ -1,16 +1,19 @@
 # Project/Task 付け替え方針（ドラフト）
 
 ## 目的
+
 - 誤登録の修正を許容しつつ、不正な損益操作や監査回避を防ぐ
 - 移動の理由と影響を説明できる状態にする
 
 ## 対象
+
 - ProjectTask
 - TimeEntry
 - Expense
 - Invoice / PurchaseOrder / VendorInvoice / VendorQuote（原則制限）
 
 ## 想定される不正/事故
+
 - 損益/予実の操作（赤字案件の工数・経費を移動）
 - アラート回避（予算超過/残業/承認遅延の回避）
 - 承認結果の無効化（承認済みデータの移動）
@@ -18,6 +21,7 @@
 - 期末処理の改ざん（締め済み期間の移動）
 
 ## 基本方針（MVP）
+
 - 実行権限は admin/mgmt のみ
 - 承認フロー中のデータは移動不可（ワークフロー（WF）解除/取消後に実施）
 - approved/sent/paid/closed など確定状態は移動不可
@@ -26,37 +30,44 @@
 - 監査ログに from/to を必ず記録
 
 ## 付け替え可否の目安
+
 - ProjectTask: 子タスク/工数がある場合は一括移動のみ
 - TimeEntry: 請求・発注・承認済みでなければ可
 - Expense: 承認済み/仕訳済み/請求連動済みは不可
 - Invoice/PurchaseOrder/VendorInvoice/VendorQuote: 送信/承認後は不可
 
 ## 期間ロック
+
 - 月次/四半期の締め済み期間は移動不可
 - 例外は管理部 + 経営の二重承認（後続スコープ）
 
 ## 監査ログ・通知
+
 - 記録項目: actor, reasonCode, reasonText, fromProjectId/fromTaskId, toProjectId/toTaskId, affectedIds, timestamp
 - 付け替え発生時は管理部ダッシュボードに通知
 
 ## 実装メモ（案）
+
 - APIは resource別に `POST /time-entries/:id/reassign` などを用意
 - サーバ側で状態/関連チェックを実施し、違反時は 400/403
+- Expense の案件付け替えは `approval_open` / `period_lock` の共通 Guard 実行で既存チェックをラップする
 - 付け替え履歴テーブル（例: reassignment_log）を追加
 - reasonCode/reasonText を必須とし、監査ログに保存する
 
 ## 理由コード（案）
-| code | 説明 |
-| --- | --- |
-| input_error | 誤入力の修正（担当者/工数/日付など） |
-| project_misassignment | 案件/タスクの付け間違い |
-| task_restructure | タスク再編に伴う付け替え |
-| contract_split_merge | 契約/案件の分割・統合による調整 |
-| internal_transfer | 管理部指示の内部付け替え |
+
+| code                  | 説明                                 |
+| --------------------- | ------------------------------------ |
+| input_error           | 誤入力の修正（担当者/工数/日付など） |
+| project_misassignment | 案件/タスクの付け間違い              |
+| task_restructure      | タスク再編に伴う付け替え             |
+| contract_split_merge  | 契約/案件の分割・統合による調整      |
+| internal_transfer     | 管理部指示の内部付け替え             |
 
 ※ 監査ログには `reasonCode` と自由記述 `reasonText` を保存し、運用で追加可能にする。
 
 ## 締め期間の扱い（決定）
+
 - `PeriodLock` のような締めテーブルを用意し、月次とプロジェクト期間の締めを記録する
   - 例: `period`(YYYY-MM), `scope`(global/project), `projectId`, `closedAt`, `closedBy`, `reason`
 - 付け替え対象（TimeEntry/Expense/Invoice/PurchaseOrder/VendorInvoice）は、該当期間が締め済みなら原則不可
@@ -64,12 +75,14 @@
 - 運用: 管理部が `/period-locks` で締めを作成/解除する（scope=global/project）
 
 ## 承認解除/取消（決定）
+
 - 取消は `approval-instances/:id/cancel` で実施し、理由を必須とする
 - 実行権限: admin/mgmt/exec は任意の申請を取消可、user は自身の申請のみ取消可
 - 取消時は承認ステップを cancelled にし、対象データのステータスを戻す
 - 取消の操作は監査ログに記録し、後続の付け替え操作と紐づける
 
 ## 次のTODO
+
 - 締め期間の定義（決定済み: 月次 + プロジェクト期間）
 - 付け替え理由コードの初期セット決定（決定済み: input_error など）
 - 承認解除/取消の手順と権限の明確化（決定済み）

--- a/packages/backend/src/routes/expenses.ts
+++ b/packages/backend/src/routes/expenses.ts
@@ -27,8 +27,12 @@ import { prisma } from '../services/db.js';
 import { auditContextFromRequest, logAudit } from '../services/audit.js';
 import { logReassignment } from '../services/reassignmentLog.js';
 import { parseDateParam } from '../utils/date.js';
-import { findPeriodLock, toPeriodKey } from '../services/periodLock.js';
-import { evaluateActionPolicyWithFallback } from '../services/actionPolicy.js';
+import { toPeriodKey } from '../services/periodLock.js';
+import {
+  evaluateActionPolicyGuards,
+  evaluateActionPolicyWithFallback,
+  type ActionPolicyGuardFailure,
+} from '../services/actionPolicy.js';
 import { resolveActionPolicyDeniedCode } from '../services/actionPolicyErrors.js';
 import {
   logActionPolicyFallbackAllowedIfNeeded,
@@ -372,6 +376,39 @@ export function applyExpensePaidAtDateRangeFilter(
     paidAt.lt = paidToExclusive;
   }
   where.paidAt = paidAt;
+}
+
+function resolveExpenseReassignGuardReply(
+  failures: ActionPolicyGuardFailure[],
+) {
+  for (const failure of failures) {
+    if (
+      failure.type === 'approval_open' &&
+      failure.reason === 'approval_in_progress'
+    ) {
+      return {
+        statusCode: 400,
+        body: {
+          error: {
+            code: 'PENDING_APPROVAL',
+            message: 'Approval in progress',
+          },
+        },
+      };
+    }
+    if (failure.type === 'period_lock' && failure.reason === 'period_locked') {
+      return {
+        statusCode: 400,
+        body: {
+          error: {
+            code: 'PERIOD_LOCKED',
+            message: 'Period is locked',
+          },
+        },
+      };
+    }
+  }
+  return null;
 }
 
 export async function registerExpenseRoutes(app: FastifyInstance) {
@@ -1476,20 +1513,21 @@ export async function registerExpenseRoutes(app: FastifyInstance) {
           error: { code: 'INVALID_STATUS', message: 'Expense not editable' },
         });
       }
-      const pendingApproval = await prisma.approvalInstance.findFirst({
-        where: {
-          targetTable: 'expenses',
-          targetId: id,
-          status: {
-            in: [DocStatusValue.pending_qa, DocStatusValue.pending_exec],
+      const approvalGuardReply = resolveExpenseReassignGuardReply(
+        await evaluateActionPolicyGuards(
+          {
+            guards: [{ type: 'approval_open' }],
+            flowType: FlowTypeValue.expense,
+            targetTable: 'expenses',
+            targetId: id,
           },
-        },
-        select: { id: true },
-      });
-      if (pendingApproval) {
-        return reply.status(400).send({
-          error: { code: 'PENDING_APPROVAL', message: 'Approval in progress' },
-        });
+          { client: prisma },
+        ),
+      );
+      if (approvalGuardReply) {
+        return reply
+          .status(approvalGuardReply.statusCode)
+          .send(approvalGuardReply.body);
       }
       const targetProject = await prisma.project.findUnique({
         where: { id: body.toProjectId },
@@ -1500,20 +1538,27 @@ export async function registerExpenseRoutes(app: FastifyInstance) {
           error: { code: 'NOT_FOUND', message: 'Project not found' },
         });
       }
-      const periodKey = toPeriodKey(expense.incurredOn);
-      const fromLock = await findPeriodLock(periodKey, expense.projectId);
-      if (fromLock) {
-        return reply.status(400).send({
-          error: { code: 'PERIOD_LOCKED', message: 'Period is locked' },
-        });
-      }
+      const projectIds = [expense.projectId];
       if (body.toProjectId !== expense.projectId) {
-        const toLock = await findPeriodLock(periodKey, body.toProjectId);
-        if (toLock) {
-          return reply.status(400).send({
-            error: { code: 'PERIOD_LOCKED', message: 'Period is locked' },
-          });
-        }
+        projectIds.push(body.toProjectId);
+      }
+      const periodGuardReply = resolveExpenseReassignGuardReply(
+        await evaluateActionPolicyGuards(
+          {
+            guards: [{ type: 'period_lock' }],
+            flowType: FlowTypeValue.expense,
+            state: {
+              projectIds,
+              periodKey: toPeriodKey(expense.incurredOn),
+            },
+          },
+          { client: prisma },
+        ),
+      );
+      if (periodGuardReply) {
+        return reply
+          .status(periodGuardReply.statusCode)
+          .send(periodGuardReply.body);
       }
       const updated = await prisma.expense.update({
         where: { id },

--- a/packages/backend/src/services/actionPolicy.ts
+++ b/packages/backend/src/services/actionPolicy.ts
@@ -619,6 +619,28 @@ async function evaluateGuards(guards: unknown, ctx: GuardEvalContext) {
   return { ok: true } as const;
 }
 
+export async function evaluateActionPolicyGuards(
+  input: {
+    guards: unknown;
+    flowType: FlowType;
+    state?: unknown;
+    targetTable?: string;
+    targetId?: string;
+  },
+  options?: { client?: any; now?: Date },
+): Promise<ActionPolicyGuardFailure[]> {
+  const client = options?.client ?? prisma;
+  const guardRes = await evaluateGuards(input.guards, {
+    client,
+    flowType: input.flowType,
+    state: input.state,
+    targetTable: input.targetTable,
+    targetId: input.targetId,
+    now: options?.now ?? new Date(),
+  });
+  return guardRes.ok ? [] : guardRes.failures;
+}
+
 export async function evaluateActionPolicy(
   input: EvaluateActionPolicyInput,
   options?: { client?: any },

--- a/packages/backend/test/actionPolicy.test.js
+++ b/packages/backend/test/actionPolicy.test.js
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
   evaluateActionPolicy,
+  evaluateActionPolicyGuards,
   evaluateActionPolicyWithFallback,
 } from '../dist/services/actionPolicy.js';
 
@@ -210,6 +211,35 @@ test('evaluateActionPolicy: approval_open guard can be bypassed by a lower polic
   assert.equal(calls.approvalFindFirst, 1);
   assert.equal(res.allowed, true);
   assert.equal(res.matchedPolicyId, 'p2');
+});
+
+test('evaluateActionPolicyGuards: approval_open guard returns failure for open approval', async () => {
+  const calls = { approvalFindFirst: 0 };
+  const failures = await evaluateActionPolicyGuards(
+    {
+      guards: [{ type: 'approval_open' }],
+      flowType: 'expense',
+      targetTable: 'expenses',
+      targetId: 'exp-001',
+    },
+    {
+      client: {
+        approvalInstance: {
+          findFirst: async (args) => {
+            calls.approvalFindFirst += 1;
+            assert.equal(args.where.flowType, 'expense');
+            assert.equal(args.where.targetTable, 'expenses');
+            assert.equal(args.where.targetId, 'exp-001');
+            return { id: 'approval-001', status: 'pending_qa' };
+          },
+        },
+      },
+    },
+  );
+  assert.equal(calls.approvalFindFirst, 1);
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].type, 'approval_open');
+  assert.equal(failures[0].reason, 'approval_in_progress');
 });
 
 test('evaluateActionPolicy: unknown guard type is fail-safe (guard_failed)', async () => {
@@ -447,6 +477,49 @@ test('evaluateActionPolicy: period_lock guard batches queries for multiple perio
   assert.equal(res.matchedPolicyId, 'p1');
   assert.equal(res.guardFailures[0].type, 'period_lock');
   assert.equal(res.guardFailures[0].reason, 'period_locked');
+});
+
+test('evaluateActionPolicyGuards: period_lock guard batches multiple project ids', async () => {
+  const calls = { findMany: 0 };
+  const failures = await evaluateActionPolicyGuards(
+    {
+      guards: [{ type: 'period_lock' }],
+      flowType: 'expense',
+      state: {
+        projectIds: ['p1', 'p2'],
+        periodKey: '2050-01',
+      },
+    },
+    {
+      client: {
+        periodLock: {
+          findFirst: async () => {
+            throw new Error('unexpected findFirst call');
+          },
+          findMany: async (args) => {
+            calls.findMany += 1;
+            assert.deepEqual(args.where.period.in, ['2050-01']);
+            assert.deepEqual(args.where.OR, [
+              { scope: 'global' },
+              { scope: 'project', projectId: { in: ['p1', 'p2'] } },
+            ]);
+            return [
+              {
+                id: 'lock-001',
+                scope: 'project',
+                projectId: 'p2',
+                period: '2050-01',
+              },
+            ];
+          },
+        },
+      },
+    },
+  );
+  assert.equal(calls.findMany, 1);
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].type, 'period_lock');
+  assert.equal(failures[0].reason, 'period_locked');
 });
 
 test('evaluateActionPolicy: editable_days guard rejects when outside editable window', async () => {

--- a/packages/backend/test/expenseReassignProjectRoutes.test.js
+++ b/packages/backend/test/expenseReassignProjectRoutes.test.js
@@ -1,0 +1,241 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildServer } from '../dist/server.js';
+import { prisma } from '../dist/services/db.js';
+
+const MIN_DATABASE_URL = 'postgresql://user:pass@localhost:5432/postgres';
+
+function withPrismaStubs(stubs, fn) {
+  const restores = [];
+  for (const [path, stub] of Object.entries(stubs)) {
+    const segments = path.split('.');
+    const method = segments.pop();
+    if (!method) throw new Error(`invalid stub target: ${path}`);
+    let target = prisma;
+    for (const segment of segments) {
+      const next = target?.[segment];
+      if (!next) throw new Error(`invalid stub target: ${path}`);
+      target = next;
+    }
+    if (typeof target[method] !== 'function') {
+      throw new Error(`invalid stub target: ${path}`);
+    }
+    const original = target[method];
+    target[method] = stub;
+    restores.push(() => {
+      target[method] = original;
+    });
+  }
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => {
+      for (const restore of restores.reverse()) restore();
+    });
+}
+
+function adminHeaders() {
+  return {
+    'x-user-id': 'admin-user',
+    'x-roles': 'admin,mgmt',
+  };
+}
+
+function expenseDraft(overrides = {}) {
+  return {
+    id: 'exp-001',
+    userId: 'user-001',
+    projectId: 'proj-001',
+    amount: 12000,
+    currency: 'JPY',
+    incurredOn: new Date('2026-01-15T00:00:00.000Z'),
+    status: 'draft',
+    settlementStatus: 'unpaid',
+    receiptUrl: 'https://example.com/receipt.pdf',
+    deletedAt: null,
+    paidAt: null,
+    paidBy: null,
+    updatedBy: 'seed-user',
+    ...overrides,
+  };
+}
+
+async function withServer(fn) {
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+  const server = await buildServer({ logger: false });
+  try {
+    await fn(server);
+  } finally {
+    await server.close();
+  }
+}
+
+test('POST /expenses/:id/reassign rejects invalid status before guard evaluation', async () => {
+  let approvalFindFirstCalled = 0;
+  await withPrismaStubs(
+    {
+      'expense.findUnique': async () => expenseDraft({ status: 'approved' }),
+      'approvalInstance.findFirst': async () => {
+        approvalFindFirstCalled += 1;
+        return null;
+      },
+    },
+    async () => {
+      await withServer(async (server) => {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/expenses/exp-001/reassign',
+          headers: adminHeaders(),
+          payload: {
+            toProjectId: 'proj-002',
+            reasonCode: 'project_misassignment',
+            reasonText: 'move to correct project',
+          },
+        });
+        assert.equal(res.statusCode, 400, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.error?.code, 'INVALID_STATUS');
+        assert.equal(approvalFindFirstCalled, 0);
+      });
+    },
+  );
+});
+
+test('POST /expenses/:id/reassign maps approval_open guard failure to PENDING_APPROVAL', async () => {
+  let projectLookupCalled = 0;
+  await withPrismaStubs(
+    {
+      'expense.findUnique': async () => expenseDraft(),
+      'approvalInstance.findFirst': async (args) => {
+        assert.equal(args.where.flowType, 'expense');
+        assert.equal(args.where.targetTable, 'expenses');
+        assert.equal(args.where.targetId, 'exp-001');
+        return { id: 'approval-001', status: 'pending_qa' };
+      },
+      'project.findUnique': async () => {
+        projectLookupCalled += 1;
+        return { id: 'proj-002', deletedAt: null };
+      },
+    },
+    async () => {
+      await withServer(async (server) => {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/expenses/exp-001/reassign',
+          headers: adminHeaders(),
+          payload: {
+            toProjectId: 'proj-002',
+            reasonCode: 'project_misassignment',
+            reasonText: 'move to correct project',
+          },
+        });
+        assert.equal(res.statusCode, 400, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.error?.code, 'PENDING_APPROVAL');
+        assert.equal(projectLookupCalled, 0);
+      });
+    },
+  );
+});
+
+test('POST /expenses/:id/reassign maps period_lock guard failure to PERIOD_LOCKED', async () => {
+  let periodFindManyCalled = 0;
+  await withPrismaStubs(
+    {
+      'expense.findUnique': async () => expenseDraft(),
+      'approvalInstance.findFirst': async () => null,
+      'project.findUnique': async () => ({ id: 'proj-002', deletedAt: null }),
+      'periodLock.findFirst': async () => {
+        throw new Error('unexpected findFirst call');
+      },
+      'periodLock.findMany': async (args) => {
+        periodFindManyCalled += 1;
+        assert.deepEqual(args.where.period.in, ['2026-01']);
+        assert.deepEqual(args.where.OR, [
+          { scope: 'global' },
+          { scope: 'project', projectId: { in: ['proj-001', 'proj-002'] } },
+        ]);
+        return [
+          {
+            id: 'lock-001',
+            scope: 'project',
+            projectId: 'proj-002',
+            period: '2026-01',
+          },
+        ];
+      },
+    },
+    async () => {
+      await withServer(async (server) => {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/expenses/exp-001/reassign',
+          headers: adminHeaders(),
+          payload: {
+            toProjectId: 'proj-002',
+            reasonCode: 'project_misassignment',
+            reasonText: 'move to correct project',
+          },
+        });
+        assert.equal(res.statusCode, 400, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.error?.code, 'PERIOD_LOCKED');
+        assert.equal(periodFindManyCalled, 1);
+      });
+    },
+  );
+});
+
+test('POST /expenses/:id/reassign updates project and writes logs when guards pass', async () => {
+  const auditActions = [];
+  const reassignmentEntries = [];
+  let updateCalled = 0;
+  await withPrismaStubs(
+    {
+      'expense.findUnique': async () => expenseDraft(),
+      'approvalInstance.findFirst': async () => null,
+      'project.findUnique': async () => ({ id: 'proj-002', deletedAt: null }),
+      'periodLock.findMany': async () => [],
+      'expense.update': async ({ where, data }) => {
+        updateCalled += 1;
+        return {
+          ...expenseDraft(),
+          id: where.id,
+          projectId: data.projectId,
+        };
+      },
+      'auditLog.create': async ({ data }) => {
+        auditActions.push(data.action);
+        return { id: `audit-${auditActions.length}` };
+      },
+      'reassignmentLog.create': async ({ data }) => {
+        reassignmentEntries.push(data);
+        return { id: `reassignment-${reassignmentEntries.length}` };
+      },
+    },
+    async () => {
+      await withServer(async (server) => {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/expenses/exp-001/reassign',
+          headers: adminHeaders(),
+          payload: {
+            toProjectId: 'proj-002',
+            reasonCode: 'project_misassignment',
+            reasonText: 'move to correct project',
+          },
+        });
+        assert.equal(res.statusCode, 200, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body?.id, 'exp-001');
+        assert.equal(body?.projectId, 'proj-002');
+        assert.equal(updateCalled, 1);
+        assert.deepEqual(auditActions, ['reassignment']);
+        assert.equal(reassignmentEntries.length, 1);
+        assert.equal(reassignmentEntries[0]?.fromProjectId, 'proj-001');
+        assert.equal(reassignmentEntries[0]?.toProjectId, 'proj-002');
+      });
+    },
+  );
+});


### PR DESCRIPTION
## 概要
- Expense の案件付け替えで `approval_open` / `period_lock` を共通 Guard 実行へ寄せました
- Expense 案件付け替え route の回帰テストと Guard export の単体テストを追加しました
- reassignment policy ドキュメントに Guard bridge の反映を追記しました

## 変更点
- `evaluateActionPolicyGuards()` を route から再利用し、Expense 案件付け替えの既存チェックをラップ
- `PENDING_APPROVAL` / `PERIOD_LOCKED` の既存レスポンス契約は維持
- `expenseReassignProjectRoutes.test.js` を追加し、invalid status / pending approval / period lock / success を回帰確認
- `actionPolicy.test.js` に Guard export の直接テストを追加

## テスト
- `npx prettier --check packages/backend/src/routes/expenses.ts packages/backend/src/services/actionPolicy.ts packages/backend/test/actionPolicy.test.js packages/backend/test/expenseReassignProjectRoutes.test.js docs/requirements/reassignment-policy.md`
- `npm run lint --prefix packages/backend`
- `npm run typecheck --prefix packages/backend`
- `npm run build --prefix packages/backend`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres node --test packages/backend/test/actionPolicy.test.js packages/backend/test/expenseReassignProjectRoutes.test.js`

Closes #1320
