### PR TITLE
feat: add reference-link backfill script

### DIFF
--- a/docs/requirements/annotations.md
+++ b/docs/requirements/annotations.md
@@ -42,6 +42,11 @@
   `externalUrls` / `internalRefs` を `Annotation(JSON)` と `ReferenceLink` に dual-write する。
   - migration 未適用環境では `ReferenceLink` 書き込みを自動的にスキップし、既存 `Annotation(JSON)` のみで継続できるようにする。
   - read path / response 形式は従来と変えない。
+- バックフィルは `scripts/backfill-reference-links.mjs` で行う。
+  - 既に `ReferenceLink` が存在する target は上書きせず skip する
+  - `--limit-targets` は 1 回の実行で走査する `Annotation` 件数の上限として扱う
+  - `Annotation` の `createdAt/createdBy/updatedAt/updatedBy` を `ReferenceLink` へ引き継ぐ
+  - 既存 `project_chat` は `room_chat` に正規化して投入する
 - `ReferenceLink` 側の `project_chat` 互換データは、read 時に `room_chat` として正規化する。
 
 ## アクセス制御

--- a/packages/backend/src/services/annotationReferences.ts
+++ b/packages/backend/src/services/annotationReferences.ts
@@ -1,7 +1,12 @@
 type AnnotationRecord = {
+  id?: string;
+  targetKind?: string;
+  targetId?: string;
   notes?: string | null;
   externalUrls?: unknown;
   internalRefs?: unknown;
+  createdAt?: Date | null;
+  createdBy?: string | null;
   updatedAt?: Date | null;
   updatedBy?: string | null;
 } | null;
@@ -27,6 +32,28 @@ export type ResolvedAnnotationReferenceState = {
   internalRefs: AnnotationInternalRef[];
   updatedAt: Date | null;
   updatedBy: string | null;
+};
+
+export type ReferenceLinkBackfillOptions = {
+  dryRun?: boolean;
+  batchSize?: number;
+  limitTargets?: number;
+  targetKind?: string;
+  targetId?: string;
+};
+
+export type ReferenceLinkBackfillSummary = {
+  dryRun: boolean;
+  batchSize: number;
+  limitTargets: number | null;
+  scannedTargets: number;
+  candidateTargets: number;
+  candidateLinks: number;
+  createdTargets: number;
+  createdLinks: number;
+  skippedExistingTargets: number;
+  skippedEmptyTargets: number;
+  processedBatches: number;
 };
 
 function normalizeString(value: unknown) {
@@ -126,6 +153,72 @@ function isReferenceLinkTableMissing(error: unknown) {
   );
 }
 
+function normalizeBatchSize(value?: number) {
+  if (!Number.isFinite(value)) return 200;
+  return Math.max(1, Math.min(1000, Math.floor(Number(value))));
+}
+
+function normalizeLimitTargets(value?: number) {
+  if (!Number.isFinite(value)) return null;
+  const normalized = Math.floor(Number(value));
+  return normalized > 0 ? normalized : null;
+}
+
+function buildReferenceLinkData(annotation: NonNullable<AnnotationRecord>) {
+  const targetKind = normalizeString(annotation.targetKind);
+  const targetId = normalizeString(annotation.targetId);
+  if (!targetKind || !targetId) return [];
+  const createdAt = annotation.createdAt ?? annotation.updatedAt ?? new Date();
+  const updatedAt = annotation.updatedAt ?? annotation.createdAt ?? createdAt;
+  const createdBy = annotation.createdBy ?? annotation.updatedBy ?? null;
+  const updatedBy = annotation.updatedBy ?? annotation.createdBy ?? null;
+  const externalUrls = normalizeStoredExternalUrls(annotation.externalUrls);
+  const internalRefs = normalizeStoredInternalRefs(annotation.internalRefs);
+  return [
+    ...externalUrls.map((url, index) => ({
+      targetKind,
+      targetId,
+      linkKind: 'external_url',
+      refKind: '',
+      value: url,
+      label: null,
+      sortOrder: index,
+      createdAt,
+      createdBy,
+      updatedAt,
+      updatedBy,
+    })),
+    ...internalRefs.map((ref, index) => ({
+      targetKind,
+      targetId,
+      linkKind: 'internal_ref',
+      refKind: normalizeInternalRefKind(ref.kind),
+      value: ref.id,
+      label: ref.label ?? null,
+      sortOrder: index,
+      createdAt,
+      createdBy,
+      updatedAt,
+      updatedBy,
+    })),
+  ];
+}
+
+function buildAnnotationBackfillWhere(
+  options: Pick<ReferenceLinkBackfillOptions, 'targetKind' | 'targetId'>,
+  cursor?: { id: string } | null,
+) {
+  const filters: Record<string, unknown>[] = [];
+  const targetKind = normalizeString(options.targetKind);
+  const targetId = normalizeString(options.targetId);
+  if (targetKind) filters.push({ targetKind });
+  if (targetId) filters.push({ targetId });
+  if (cursor) filters.push({ id: { gt: cursor.id } });
+  if (!filters.length) return undefined;
+  if (filters.length === 1) return filters[0];
+  return { AND: filters };
+}
+
 export async function replaceReferenceLinks(
   client: any,
   targetKind: string,
@@ -182,6 +275,131 @@ export async function replaceReferenceLinks(
     if (!isReferenceLinkTableMissing(error)) throw error;
     return false;
   }
+}
+
+export async function backfillReferenceLinksFromAnnotations(
+  client: any,
+  options: ReferenceLinkBackfillOptions = {},
+): Promise<ReferenceLinkBackfillSummary> {
+  if (typeof client.annotation?.findMany !== 'function') {
+    throw new Error('annotation_findMany_not_available');
+  }
+  if (typeof client.referenceLink?.findMany !== 'function') {
+    throw new Error('referenceLink_findMany_not_available');
+  }
+  const dryRun = options.dryRun !== false;
+  if (!dryRun && typeof client.referenceLink?.createMany !== 'function') {
+    throw new Error('referenceLink_createMany_not_available');
+  }
+
+  const batchSize = normalizeBatchSize(options.batchSize);
+  const limitTargets = normalizeLimitTargets(options.limitTargets);
+  const summary: ReferenceLinkBackfillSummary = {
+    dryRun,
+    batchSize,
+    limitTargets,
+    scannedTargets: 0,
+    candidateTargets: 0,
+    candidateLinks: 0,
+    createdTargets: 0,
+    createdLinks: 0,
+    skippedExistingTargets: 0,
+    skippedEmptyTargets: 0,
+    processedBatches: 0,
+  };
+
+  let cursor: { id: string } | null = null;
+
+  while (true) {
+    const remaining =
+      limitTargets === null
+        ? batchSize
+        : Math.min(batchSize, limitTargets - summary.scannedTargets);
+    if (remaining <= 0) break;
+
+    const annotations = (await client.annotation.findMany({
+      where: buildAnnotationBackfillWhere(options, cursor),
+      orderBy: { id: 'asc' },
+      take: remaining,
+      select: {
+        id: true,
+        targetKind: true,
+        targetId: true,
+        externalUrls: true,
+        internalRefs: true,
+        createdAt: true,
+        createdBy: true,
+        updatedAt: true,
+        updatedBy: true,
+      },
+    })) as NonNullable<AnnotationRecord>[];
+
+    if (!annotations.length) break;
+    summary.processedBatches += 1;
+    summary.scannedTargets += annotations.length;
+
+    const targetPairs = annotations.map((annotation) => ({
+      targetKind: normalizeString(annotation.targetKind),
+      targetId: normalizeString(annotation.targetId),
+    }));
+    let existingLinks: Array<{
+      targetKind: string;
+      targetId: string;
+    }> = [];
+    try {
+      existingLinks = await client.referenceLink.findMany({
+        where: {
+          OR: targetPairs,
+          linkKind: { in: ['external_url', 'internal_ref'] },
+        },
+        select: {
+          targetKind: true,
+          targetId: true,
+        },
+      });
+    } catch (error) {
+      if (!isReferenceLinkTableMissing(error)) throw error;
+      throw new Error('referenceLink_table_missing');
+    }
+    const existingKeys = new Set(
+      existingLinks.map((item) => `${item.targetKind}:${item.targetId}`),
+    );
+
+    const rowsToCreate: Array<Record<string, unknown>> = [];
+    let createdTargetsInBatch = 0;
+    for (const annotation of annotations) {
+      const key = `${normalizeString(annotation.targetKind)}:${normalizeString(annotation.targetId)}`;
+      const rows = buildReferenceLinkData(annotation);
+      if (rows.length === 0) {
+        summary.skippedEmptyTargets += 1;
+        continue;
+      }
+      if (existingKeys.has(key)) {
+        summary.skippedExistingTargets += 1;
+        continue;
+      }
+      summary.candidateTargets += 1;
+      summary.candidateLinks += rows.length;
+      rowsToCreate.push(...rows);
+      createdTargetsInBatch += 1;
+    }
+
+    if (!dryRun && rowsToCreate.length > 0) {
+      const result = await client.referenceLink.createMany({
+        data: rowsToCreate,
+        skipDuplicates: true,
+      });
+      summary.createdTargets += createdTargetsInBatch;
+      summary.createdLinks += result.count ?? rowsToCreate.length;
+    }
+
+    const last = annotations[annotations.length - 1];
+    cursor = {
+      id: normalizeString(last.id),
+    };
+  }
+
+  return summary;
 }
 
 function resolveUpdatedMeta(

--- a/packages/backend/test/annotationReferencesBackfill.test.js
+++ b/packages/backend/test/annotationReferencesBackfill.test.js
@@ -1,0 +1,309 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { backfillReferenceLinksFromAnnotations } from '../dist/services/annotationReferences.js';
+
+function createAnnotation({
+  id,
+  targetKind,
+  targetId,
+  externalUrls = [],
+  internalRefs = [],
+  createdAt = new Date('2026-03-01T00:00:00.000Z'),
+  createdBy = 'creator-1',
+  updatedAt = new Date('2026-03-02T00:00:00.000Z'),
+  updatedBy = 'updater-1',
+}) {
+  return {
+    id,
+    targetKind,
+    targetId,
+    externalUrls,
+    internalRefs,
+    createdAt,
+    createdBy,
+    updatedAt,
+    updatedBy,
+  };
+}
+
+function extractCursorGt(where) {
+  if (!where || typeof where !== 'object') return undefined;
+  if (Array.isArray(where.AND)) {
+    for (const item of where.AND) {
+      const cursor = extractCursorGt(item);
+      if (cursor) return cursor;
+    }
+  }
+  return where?.id?.gt;
+}
+
+test('backfillReferenceLinksFromAnnotations: dry-run counts normalized candidates without writing', async () => {
+  const findManyCalls = [];
+  let createManyCalled = false;
+  const client = {
+    annotation: {
+      findMany: async ({ where }) => {
+        findManyCalls.push(where);
+        if (findManyCalls.length === 1) {
+          return [
+            createAnnotation({
+              id: 'ann-1',
+              targetKind: 'invoice',
+              targetId: 'inv-1',
+              externalUrls: [
+                'https://example.com/a',
+                'https://example.com/a',
+                '   ',
+              ],
+              internalRefs: [
+                { kind: 'project_chat', id: 'room-1', label: 'Legacy room' },
+                { kind: 'room_chat', id: 'room-1', label: 'New room label' },
+                { kind: 'chat_message', id: 'msg-1' },
+              ],
+            }),
+            createAnnotation({
+              id: 'ann-2',
+              targetKind: 'invoice',
+              targetId: 'inv-2',
+              externalUrls: [],
+              internalRefs: [],
+            }),
+          ];
+        }
+        return [];
+      },
+    },
+    referenceLink: {
+      findMany: async () => [],
+      createMany: async () => {
+        createManyCalled = true;
+        return { count: 0 };
+      },
+    },
+  };
+
+  const summary = await backfillReferenceLinksFromAnnotations(client, {
+    dryRun: true,
+    batchSize: 10,
+  });
+
+  assert.equal(findManyCalls.length, 2);
+  assert.equal(summary.dryRun, true);
+  assert.equal(summary.scannedTargets, 2);
+  assert.equal(summary.candidateTargets, 1);
+  assert.equal(summary.candidateLinks, 3);
+  assert.equal(summary.createdTargets, 0);
+  assert.equal(summary.createdLinks, 0);
+  assert.equal(summary.skippedEmptyTargets, 1);
+  assert.equal(summary.skippedExistingTargets, 0);
+  assert.equal(summary.processedBatches, 1);
+  assert.equal(createManyCalled, false);
+});
+
+test('backfillReferenceLinksFromAnnotations: omitted dryRun stays in dry-run mode without createMany', async () => {
+  const client = {
+    annotation: {
+      findMany: async () => [
+        createAnnotation({
+          id: 'ann-1',
+          targetKind: 'invoice',
+          targetId: 'inv-1',
+          externalUrls: ['https://example.com/a'],
+        }),
+      ],
+    },
+    referenceLink: {
+      findMany: async () => [],
+    },
+  };
+
+  const summary = await backfillReferenceLinksFromAnnotations(client, {
+    batchSize: 5,
+    limitTargets: 1,
+  });
+
+  assert.equal(summary.dryRun, true);
+  assert.equal(summary.candidateTargets, 1);
+  assert.equal(summary.createdTargets, 0);
+  assert.equal(summary.createdLinks, 0);
+});
+
+test('backfillReferenceLinksFromAnnotations: creates rows only for targets without existing links and preserves metadata', async () => {
+  const createManyCalls = [];
+  const client = {
+    annotation: {
+      findMany: async ({ where }) => {
+        const cursor = extractCursorGt(where);
+        if (!cursor) {
+          return [
+            createAnnotation({
+              id: 'ann-1',
+              targetKind: 'invoice',
+              targetId: 'inv-1',
+              externalUrls: ['https://example.com/a'],
+              internalRefs: [
+                { kind: 'project_chat', id: 'room-1', label: 'Legacy room' },
+              ],
+              createdAt: new Date('2026-03-01T10:00:00.000Z'),
+              createdBy: 'creator-a',
+              updatedAt: new Date('2026-03-02T10:00:00.000Z'),
+              updatedBy: 'updater-a',
+            }),
+            createAnnotation({
+              id: 'ann-2',
+              targetKind: 'invoice',
+              targetId: 'inv-2',
+              externalUrls: ['https://example.com/b'],
+              internalRefs: [],
+              createdAt: new Date('2026-03-01T11:00:00.000Z'),
+              createdBy: 'creator-b',
+              updatedAt: new Date('2026-03-02T11:00:00.000Z'),
+              updatedBy: 'updater-b',
+            }),
+          ];
+        }
+        return [];
+      },
+    },
+    referenceLink: {
+      findMany: async () => [
+        {
+          targetKind: 'invoice',
+          targetId: 'inv-2',
+        },
+      ],
+      createMany: async ({ data, skipDuplicates }) => {
+        createManyCalls.push({ data, skipDuplicates });
+        return { count: data.length };
+      },
+    },
+  };
+
+  const summary = await backfillReferenceLinksFromAnnotations(client, {
+    dryRun: false,
+    batchSize: 10,
+  });
+
+  assert.equal(summary.candidateTargets, 1);
+  assert.equal(summary.candidateLinks, 2);
+  assert.equal(summary.createdTargets, 1);
+  assert.equal(summary.createdLinks, 2);
+  assert.equal(summary.skippedExistingTargets, 1);
+  assert.equal(createManyCalls.length, 1);
+  assert.equal(createManyCalls[0]?.skipDuplicates, true);
+  assert.deepEqual(createManyCalls[0]?.data, [
+    {
+      targetKind: 'invoice',
+      targetId: 'inv-1',
+      linkKind: 'external_url',
+      refKind: '',
+      value: 'https://example.com/a',
+      label: null,
+      sortOrder: 0,
+      createdAt: new Date('2026-03-01T10:00:00.000Z'),
+      createdBy: 'creator-a',
+      updatedAt: new Date('2026-03-02T10:00:00.000Z'),
+      updatedBy: 'updater-a',
+    },
+    {
+      targetKind: 'invoice',
+      targetId: 'inv-1',
+      linkKind: 'internal_ref',
+      refKind: 'room_chat',
+      value: 'room-1',
+      label: 'Legacy room',
+      sortOrder: 0,
+      createdAt: new Date('2026-03-01T10:00:00.000Z'),
+      createdBy: 'creator-a',
+      updatedAt: new Date('2026-03-02T10:00:00.000Z'),
+      updatedBy: 'updater-a',
+    },
+  ]);
+});
+
+test('backfillReferenceLinksFromAnnotations: respects limitTargets across batches', async () => {
+  const createManyCalls = [];
+  const client = {
+    annotation: {
+      findMany: async ({ where, take }) => {
+        const cursor = extractCursorGt(where);
+        if (!cursor) {
+          assert.equal(take, 1);
+          return [
+            createAnnotation({
+              id: 'ann-1',
+              targetKind: 'invoice',
+              targetId: 'inv-1',
+              externalUrls: ['https://example.com/a'],
+            }),
+          ];
+        }
+        throw new Error('unexpected_second_batch');
+      },
+    },
+    referenceLink: {
+      findMany: async () => [],
+      createMany: async ({ data }) => {
+        createManyCalls.push(data);
+        return { count: data.length };
+      },
+    },
+  };
+
+  const summary = await backfillReferenceLinksFromAnnotations(client, {
+    dryRun: false,
+    batchSize: 5,
+    limitTargets: 1,
+  });
+
+  assert.equal(summary.limitTargets, 1);
+  assert.equal(summary.scannedTargets, 1);
+  assert.equal(summary.candidateTargets, 1);
+  assert.equal(summary.createdTargets, 1);
+  assert.equal(createManyCalls.length, 1);
+  assert.equal(createManyCalls[0]?.length, 1);
+});
+
+test('backfillReferenceLinksFromAnnotations: limitTargets caps scanned rows even when early rows are skipped', async () => {
+  const createManyCalls = [];
+  const client = {
+    annotation: {
+      findMany: async ({ take }) => {
+        assert.equal(take, 1);
+        return [
+          createAnnotation({
+            id: 'ann-1',
+            targetKind: 'invoice',
+            targetId: 'inv-1',
+            externalUrls: ['https://example.com/a'],
+          }),
+        ];
+      },
+    },
+    referenceLink: {
+      findMany: async () => [
+        {
+          targetKind: 'invoice',
+          targetId: 'inv-1',
+        },
+      ],
+      createMany: async ({ data }) => {
+        createManyCalls.push(data);
+        return { count: data.length };
+      },
+    },
+  };
+
+  const summary = await backfillReferenceLinksFromAnnotations(client, {
+    dryRun: false,
+    batchSize: 5,
+    limitTargets: 1,
+  });
+
+  assert.equal(summary.scannedTargets, 1);
+  assert.equal(summary.candidateTargets, 0);
+  assert.equal(summary.skippedExistingTargets, 1);
+  assert.equal(summary.createdTargets, 0);
+  assert.equal(createManyCalls.length, 0);
+});

--- a/scripts/backfill-reference-links.mjs
+++ b/scripts/backfill-reference-links.mjs
@@ -1,0 +1,83 @@
+// Backfill ReferenceLink rows from existing Annotation(JSON) data.
+//
+// Usage:
+//   node scripts/backfill-reference-links.mjs
+//   node scripts/backfill-reference-links.mjs --apply
+//   node scripts/backfill-reference-links.mjs --apply --batch-size=100 --limit-targets=500
+//   node scripts/backfill-reference-links.mjs --target-kind=invoice --target-id=inv-001
+//
+// Note:
+//   - Run `npm run build --prefix packages/backend` beforehand.
+//   - This script imports backend dist modules.
+//   - `--limit-targets` caps the number of Annotation rows scanned in one run.
+
+import { prisma } from "../packages/backend/dist/services/db.js";
+import { backfillReferenceLinksFromAnnotations } from "../packages/backend/dist/services/annotationReferences.js";
+
+function parseArgValue(key) {
+  const prefix = `--${key}=`;
+  const hit = process.argv.find((arg) => arg.startsWith(prefix));
+  return hit ? hit.slice(prefix.length) : undefined;
+}
+
+function hasFlag(flag) {
+  return process.argv.includes(flag);
+}
+
+function shouldShowHelp() {
+  return hasFlag("--help") || hasFlag("-h");
+}
+
+function parsePositiveInt(name, value) {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`invalid --${name}: ${value} (expected: positive number)`);
+  }
+  return Math.floor(parsed);
+}
+
+function printHelp() {
+  console.log(
+    [
+      "Usage: node scripts/backfill-reference-links.mjs [--apply] [--batch-size=N] [--limit-targets=N] [--target-kind=KIND] [--target-id=ID]",
+      "",
+      "Examples:",
+      "  node scripts/backfill-reference-links.mjs",
+      "  node scripts/backfill-reference-links.mjs --apply",
+      "  node scripts/backfill-reference-links.mjs --apply --batch-size=100 --limit-targets=500",
+      "  node scripts/backfill-reference-links.mjs --target-kind=invoice --target-id=inv-001",
+    ].join("\n"),
+  );
+}
+
+async function main() {
+  if (shouldShowHelp()) {
+    printHelp();
+    return;
+  }
+
+  const summary = await backfillReferenceLinksFromAnnotations(prisma, {
+    dryRun: !hasFlag("--apply"),
+    batchSize: parsePositiveInt("batch-size", parseArgValue("batch-size")),
+    limitTargets: parsePositiveInt(
+      "limit-targets",
+      parseArgValue("limit-targets"),
+    ),
+    targetKind: parseArgValue("target-kind"),
+    targetId: parseArgValue("target-id"),
+  });
+
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+main()
+  .catch((error) => {
+    console.error(
+      error instanceof Error ? error.message : String(error || "unknown_error"),
+    );
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## 概要
- Annotation(JSON) から ReferenceLink を補完するバックフィル service / CLI を追加
- 既に ReferenceLink が存在する target は上書きせず skip
- Annotation 由来の createdAt/createdBy/updatedAt/updatedBy を引き継ぐ

## 変更内容
- `packages/backend/src/services/annotationReferences.ts`
  - `backfillReferenceLinksFromAnnotations()` を追加
  - `project_chat -> room_chat` 正規化を既存 helper と同じ経路で適用
- `packages/backend/test/annotationReferencesBackfill.test.js`
  - dry-run / apply / limitTargets の回帰を追加
- `scripts/backfill-reference-links.mjs`
  - `--apply --batch-size --limit-targets --target-kind --target-id` を受ける CLI を追加
- `docs/requirements/annotations.md`
  - バックフィル方針と実行手順を追記

## 検証
- `npx prettier --check packages/backend/src/services/annotationReferences.ts packages/backend/test/annotationReferencesBackfill.test.js docs/requirements/annotations.md scripts/backfill-reference-links.mjs`
- `npm run lint --prefix packages/backend`
- `npm run typecheck --prefix packages/backend`
- `npm run build --prefix packages/backend`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres node --test packages/backend/test/annotationReferencesBackfill.test.js packages/backend/test/annotationsChatRefNormalizationRoutes.test.js packages/backend/test/evidenceSnapshotService.test.js`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres node scripts/backfill-reference-links.mjs --help`

Refs: #1317
