### PR TITLE
docs: sync action-policy failsafe coverage status

### DIFF
--- a/docs/requirements/action-policy-failsafe-inventory.md
+++ b/docs/requirements/action-policy-failsafe-inventory.md
@@ -107,11 +107,9 @@ node scripts/report-action-policy-required-action-gaps.mjs --format=text
 - `node scripts/report-action-policy-required-action-gaps.mjs --format=text` の結果:
   - `missing_static_callsites: 0`
   - `stale_required_actions: 0`
-  - `dynamic_callsites: 1`
-- 残る dynamic callsite は `packages/backend/src/routes/approvalRules.ts:790`
-  - `flowTypeExpr=instance.flowType`
-  - `actionKeyExpr=body.action`
-- したがって、`phase2_core` の required actions は static route callsite を全て被覆済みで、残差は承認アクション共通 route の動的評価だけである。
+  - `dynamic_callsites: 0`
+- `scripts/report-action-policy-callsites.mjs` は承認アクション共通 route を `*:approve` / `*:reject` に静的展開する。
+- したがって、`phase2_core` の required actions は現行の static route callsite を全て被覆済みである。
 
 ### 4.1.1 route preset テストの被覆
 


### PR DESCRIPTION
## 概要
- `action-policy-failsafe-inventory` の coverage 状況を現行実装に同期
- `dynamic_callsites: 0` 反映と、承認アクション共通 route の静的展開を追記

## 変更内容
- `docs/requirements/action-policy-failsafe-inventory.md`
  - report 結果を `dynamic_callsites: 0` に更新
  - `approvalRules.ts` の共通 route が `*:approve` / `*:reject` に静的展開済みである旨を追記

## 検証
- `npx prettier --check docs/requirements/action-policy-failsafe-inventory.md`

Refs: #1312
