### PR TITLE
feat: prefer normalized refs in annotation updates

### DIFF
--- a/docs/requirements/annotations.md
+++ b/docs/requirements/annotations.md
@@ -39,7 +39,8 @@
     - 承認証跡スナップショット生成
     - 休暇申請 submit 時の証跡有無判定
 - `PATCH /annotations/:kind/:id` は、`notes` を `Annotation` に保持しつつ、
-  `externalUrls` / `internalRefs` を `Annotation(JSON)` と `ReferenceLink` に dual-write する。
+  `externalUrls` / `internalRefs` の更新時は `ReferenceLink` を正本として同期する。
+  - `ReferenceLink` 書き込みに成功した更新では、`Annotation.externalUrls/internalRefs` は empty shadow に縮退する。
   - migration 未適用環境では `ReferenceLink` 書き込みを自動的にスキップし、既存 `Annotation(JSON)` のみで継続できるようにする。
   - read path / response 形式は従来と変えない。
 - バックフィルは `scripts/backfill-reference-links.mjs` で行う。

--- a/packages/backend/src/routes/annotations.ts
+++ b/packages/backend/src/routes/annotations.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@prisma/client';
 import { FastifyInstance } from 'fastify';
 import {
+  isReferenceLinkTableAvailable,
   loadResolvedAnnotationReferenceState,
   replaceReferenceLinks,
 } from '../services/annotationReferences.js';
@@ -217,6 +218,16 @@ function normalizeInternalRefs(value: unknown): InternalRef[] {
     refs.push(label ? { kind, id, label } : { kind, id });
   }
   return refs;
+}
+
+function coerceResolvedInternalRefs(
+  value: { kind: string; id: string; label?: string }[],
+): InternalRef[] {
+  return value.map((ref) =>
+    ref.label
+      ? { kind: ref.kind as InternalRefKind, id: ref.id, label: ref.label }
+      : { kind: ref.kind as InternalRefKind, id: ref.id },
+  );
 }
 
 function normalizeNotes(
@@ -574,6 +585,8 @@ export async function registerAnnotationRoutes(app: FastifyInstance) {
       }
 
       const actorRole = resolveActorRole(roles);
+      const referenceLinkTableAvailable =
+        await isReferenceLinkTableAvailable(prisma);
 
       const sumLength = (values: string[]) =>
         values.reduce((acc, item) => acc + item.length, 0);
@@ -585,17 +598,23 @@ export async function registerAnnotationRoutes(app: FastifyInstance) {
           const current = await tx.annotation.findUnique({
             where: { targetKind_targetId: { targetKind: kind, targetId: id } },
           });
+          const currentState = await loadResolvedAnnotationReferenceState(
+            tx,
+            kind,
+            id,
+            current,
+          );
 
           const mergedNotes =
-            nextNotes !== undefined ? nextNotes : (current?.notes ?? null);
+            nextNotes !== undefined ? nextNotes : currentState.notes;
           const mergedExternalUrls =
             nextExternalUrls !== undefined
               ? nextExternalUrls
-              : normalizeJsonArray<string>(current?.externalUrls);
+              : currentState.externalUrls;
           const mergedInternalRefs =
             nextInternalRefs !== undefined
               ? nextInternalRefs
-              : normalizeJsonArray<InternalRef>(current?.internalRefs);
+              : coerceResolvedInternalRefs(currentState.internalRefs);
 
           if (
             mergedNotes !== null &&
@@ -604,9 +623,9 @@ export async function registerAnnotationRoutes(app: FastifyInstance) {
             throw new Error('NOTES_TOO_LONG');
           }
 
-          const beforeUrls = normalizeJsonArray<string>(current?.externalUrls);
-          const beforeRefs = normalizeJsonArray<InternalRef>(
-            current?.internalRefs,
+          const beforeUrls = currentState.externalUrls;
+          const beforeRefs = coerceResolvedInternalRefs(
+            currentState.internalRefs,
           );
           const urlsChanged =
             JSON.stringify(mergedExternalUrls) !== JSON.stringify(beforeUrls);
@@ -614,19 +633,34 @@ export async function registerAnnotationRoutes(app: FastifyInstance) {
             JSON.stringify(mergedInternalRefs) !== JSON.stringify(beforeRefs);
 
           const noEffectiveChange =
-            mergedNotes === (current?.notes ?? null) &&
-            !urlsChanged &&
-            !refsChanged;
+            mergedNotes === currentState.notes && !urlsChanged && !refsChanged;
           if (noEffectiveChange && !reasonCode) {
             return {
               didWrite: false as const,
-              current,
-              mergedNotes,
+              currentState,
+            };
+          }
+
+          let shadowExternalUrls = normalizeJsonArray<string>(
+            current?.externalUrls,
+          );
+          let shadowInternalRefs = normalizeJsonArray<InternalRef>(
+            current?.internalRefs,
+          );
+          if ((urlsChanged || refsChanged) && referenceLinkTableAvailable) {
+            const synced = await replaceReferenceLinks(
+              tx,
+              kind,
+              id,
               mergedExternalUrls,
               mergedInternalRefs,
-              urlsChanged,
-              refsChanged,
-            };
+              userId,
+            );
+            shadowExternalUrls = synced ? [] : mergedExternalUrls;
+            shadowInternalRefs = synced ? [] : mergedInternalRefs;
+          } else if (urlsChanged || refsChanged) {
+            shadowExternalUrls = mergedExternalUrls;
+            shadowInternalRefs = mergedInternalRefs;
           }
 
           const updated = await tx.annotation.upsert({
@@ -636,18 +670,18 @@ export async function registerAnnotationRoutes(app: FastifyInstance) {
               targetId: id,
               notes: mergedNotes,
               externalUrls:
-                mergedExternalUrls as unknown as Prisma.InputJsonValue,
+                shadowExternalUrls as unknown as Prisma.InputJsonValue,
               internalRefs:
-                mergedInternalRefs as unknown as Prisma.InputJsonValue,
+                shadowInternalRefs as unknown as Prisma.InputJsonValue,
               createdBy: userId,
               updatedBy: userId,
             },
             update: {
               notes: mergedNotes,
               externalUrls:
-                mergedExternalUrls as unknown as Prisma.InputJsonValue,
+                shadowExternalUrls as unknown as Prisma.InputJsonValue,
               internalRefs:
-                mergedInternalRefs as unknown as Prisma.InputJsonValue,
+                shadowInternalRefs as unknown as Prisma.InputJsonValue,
               updatedBy: userId,
             },
           });
@@ -671,12 +705,11 @@ export async function registerAnnotationRoutes(app: FastifyInstance) {
           return {
             didWrite: true as const,
             current,
+            currentState,
             updated,
             mergedNotes,
             mergedExternalUrls,
             mergedInternalRefs,
-            urlsChanged,
-            refsChanged,
           };
         })
         .catch((err) => {
@@ -695,27 +728,19 @@ export async function registerAnnotationRoutes(app: FastifyInstance) {
         return {
           targetKind: kind,
           targetId: id,
-          notes: result.current?.notes ?? null,
-          externalUrls: normalizeJsonArray<string>(
-            result.current?.externalUrls,
-          ),
-          internalRefs: normalizeJsonArray<InternalRef>(
-            result.current?.internalRefs,
-          ),
-          updatedAt: result.current?.updatedAt ?? null,
-          updatedBy: result.current?.updatedBy ?? null,
+          notes: result.currentState.notes,
+          externalUrls: result.currentState.externalUrls,
+          internalRefs: result.currentState.internalRefs,
+          updatedAt: result.currentState.updatedAt,
+          updatedBy: result.currentState.updatedBy,
         };
       }
 
       const beforeNotesLen = (result.current?.notes ?? '').length;
       const afterNotesLen = (result.mergedNotes ?? '').length;
-      const beforeUrls = normalizeJsonArray<string>(
-        result.current?.externalUrls,
-      );
+      const beforeUrls = result.currentState.externalUrls;
       const afterUrls = result.mergedExternalUrls;
-      const beforeRefs = normalizeJsonArray<InternalRef>(
-        result.current?.internalRefs,
-      );
+      const beforeRefs = result.currentState.internalRefs;
       const afterRefs = result.mergedInternalRefs;
 
       await logAudit({
@@ -747,25 +772,12 @@ export async function registerAnnotationRoutes(app: FastifyInstance) {
         ...auditContextFromRequest(req),
       });
 
-      if (result.urlsChanged || result.refsChanged) {
-        await replaceReferenceLinks(
-          prisma,
-          kind,
-          id,
-          result.mergedExternalUrls,
-          result.mergedInternalRefs,
-          userId,
-        );
-      }
-
       return {
         targetKind: kind,
         targetId: id,
         notes: result.updated.notes ?? null,
-        externalUrls: normalizeJsonArray<string>(result.updated.externalUrls),
-        internalRefs: normalizeJsonArray<InternalRef>(
-          result.updated.internalRefs,
-        ),
+        externalUrls: result.mergedExternalUrls,
+        internalRefs: result.mergedInternalRefs,
         updatedAt: result.updated.updatedAt,
         updatedBy: result.updated.updatedBy ?? null,
       };

--- a/packages/backend/src/services/annotationReferences.ts
+++ b/packages/backend/src/services/annotationReferences.ts
@@ -277,6 +277,20 @@ export async function replaceReferenceLinks(
   }
 }
 
+export async function isReferenceLinkTableAvailable(client: any) {
+  if (typeof client.referenceLink?.findMany !== 'function') return false;
+  try {
+    await client.referenceLink.findMany({
+      take: 1,
+      select: { id: true },
+    });
+    return true;
+  } catch (error) {
+    if (!isReferenceLinkTableMissing(error)) throw error;
+    return false;
+  }
+}
+
 export async function backfillReferenceLinksFromAnnotations(
   client: any,
   options: ReferenceLinkBackfillOptions = {},
@@ -423,17 +437,20 @@ export async function loadResolvedAnnotationReferenceState(
   client: any,
   targetKind: string,
   targetId: string,
+  annotationOverride?: AnnotationRecord,
 ): Promise<ResolvedAnnotationReferenceState> {
-  const annotation = (await client.annotation?.findUnique?.({
-    where: { targetKind_targetId: { targetKind, targetId } },
-    select: {
-      notes: true,
-      externalUrls: true,
-      internalRefs: true,
-      updatedAt: true,
-      updatedBy: true,
-    },
-  })) as AnnotationRecord;
+  const annotation =
+    annotationOverride ??
+    ((await client.annotation?.findUnique?.({
+      where: { targetKind_targetId: { targetKind, targetId } },
+      select: {
+        notes: true,
+        externalUrls: true,
+        internalRefs: true,
+        updatedAt: true,
+        updatedBy: true,
+      },
+    })) as AnnotationRecord);
 
   let referenceLinks: ReferenceLinkRecord[] = [];
   if (typeof client.referenceLink?.findMany === 'function') {

--- a/packages/backend/test/annotationsChatRefNormalizationRoutes.test.js
+++ b/packages/backend/test/annotationsChatRefNormalizationRoutes.test.js
@@ -93,6 +93,7 @@ test('PATCH /annotations/:kind/:id normalizes project_chat refs into room_chat',
           }),
           'annotationSetting.findUnique': async () => null,
           'annotation.findUnique': async () => null,
+          'referenceLink.findMany': async () => [],
           'annotation.upsert': async ({ create, update }) => {
             upserts.push({ create, update });
             return {
@@ -101,7 +102,7 @@ test('PATCH /annotations/:kind/:id normalizes project_chat refs into room_chat',
               targetId: 'inv-001',
               notes: null,
               externalUrls: [],
-              internalRefs: create.internalRefs,
+              internalRefs: [],
               updatedAt: new Date('2026-03-06T00:00:00Z'),
               updatedBy: 'admin-user',
             };
@@ -162,13 +163,7 @@ test('PATCH /annotations/:kind/:id normalizes project_chat refs into room_chat',
       );
 
       assert.equal(upserts.length, 1);
-      assert.deepEqual(upserts[0]?.create?.internalRefs, [
-        {
-          kind: 'room_chat',
-          id: 'room-001',
-          label: 'Legacy project room',
-        },
-      ]);
+      assert.deepEqual(upserts[0]?.create?.internalRefs, []);
       assert.equal(annotationLogs.length, 1);
       assert.deepEqual(annotationLogs[0]?.internalRefs, [
         {
@@ -183,13 +178,14 @@ test('PATCH /annotations/:kind/:id normalizes project_chat refs into room_chat',
   );
 });
 
-test('PATCH /annotations/:kind/:id dual-writes normalized links into reference_links', async () => {
+test('PATCH /annotations/:kind/:id syncs normalized links into reference_links and shrinks annotation shadow', async () => {
   await withEnv(
     {
       DATABASE_URL: process.env.DATABASE_URL || MIN_DATABASE_URL,
       AUTH_MODE: 'header',
     },
     async () => {
+      const upserts = [];
       const referenceDeletes = [];
       const referenceCreates = [];
       await withPrismaStubs(
@@ -213,16 +209,20 @@ test('PATCH /annotations/:kind/:id dual-writes normalized links into reference_l
             updatedAt: new Date('2026-03-06T00:00:00Z'),
             updatedBy: 'author-1',
           }),
-          'annotation.upsert': async ({ create, update }) => ({
-            id: 'annotation-10',
-            targetKind: 'invoice',
-            targetId: 'inv-010',
-            notes: update.notes ?? create.notes ?? null,
-            externalUrls: update.externalUrls ?? create.externalUrls ?? [],
-            internalRefs: update.internalRefs ?? create.internalRefs ?? [],
-            updatedAt: new Date('2026-03-07T00:00:00Z'),
-            updatedBy: 'admin-user',
-          }),
+          'referenceLink.findMany': async () => [],
+          'annotation.upsert': async ({ create, update }) => {
+            upserts.push({ create, update });
+            return {
+              id: 'annotation-10',
+              targetKind: 'invoice',
+              targetId: 'inv-010',
+              notes: update.notes ?? create.notes ?? null,
+              externalUrls: [],
+              internalRefs: [],
+              updatedAt: new Date('2026-03-07T00:00:00Z'),
+              updatedBy: 'admin-user',
+            };
+          },
           'annotationLog.create': async () => ({ id: 'annotation-log-1' }),
           'referenceLink.deleteMany': async ({ where }) => {
             referenceDeletes.push(where);
@@ -264,12 +264,28 @@ test('PATCH /annotations/:kind/:id dual-writes normalized links into reference_l
               },
             });
             assert.equal(res.statusCode, 200, res.body);
+            const payload = JSON.parse(res.body);
+            assert.deepEqual(payload.externalUrls, [
+              'https://example.com/a',
+              'https://example.com/b',
+            ]);
+            assert.deepEqual(payload.internalRefs, [
+              {
+                kind: 'room_chat',
+                id: 'room-010',
+                label: 'Legacy room',
+              },
+              { kind: 'chat_message', id: 'msg-010', label: 'Message 10' },
+            ]);
           } finally {
             await server.close();
           }
         },
       );
 
+      assert.equal(upserts.length, 1);
+      assert.deepEqual(upserts[0]?.update?.externalUrls, []);
+      assert.deepEqual(upserts[0]?.update?.internalRefs, []);
       assert.deepEqual(referenceDeletes, [
         {
           targetKind: 'invoice',
@@ -345,6 +361,11 @@ test('PATCH /annotations/:kind/:id continues when ReferenceLink table is not ava
           }),
           'annotationSetting.findUnique': async () => null,
           'annotation.findUnique': async () => null,
+          'referenceLink.findMany': async () => {
+            const error = new Error('relation "ReferenceLink" does not exist');
+            error.code = 'P2021';
+            throw error;
+          },
           'annotation.upsert': async ({ create }) => ({
             id: 'annotation-11',
             targetKind: 'invoice',
@@ -411,6 +432,7 @@ test('PATCH /annotations/:kind/:id clears ReferenceLink rows when refs are remov
     async () => {
       const referenceDeletes = [];
       let createManyCalled = false;
+      const upserts = [];
       await withPrismaStubs(
         {
           'invoice.findUnique': async () => ({
@@ -432,16 +454,20 @@ test('PATCH /annotations/:kind/:id clears ReferenceLink rows when refs are remov
             updatedAt: new Date('2026-03-06T00:00:00Z'),
             updatedBy: 'author-1',
           }),
-          'annotation.upsert': async ({ update, create }) => ({
-            id: 'annotation-12',
-            targetKind: 'invoice',
-            targetId: 'inv-012',
-            notes: update.notes ?? create.notes ?? null,
-            externalUrls: update.externalUrls ?? create.externalUrls ?? [],
-            internalRefs: update.internalRefs ?? create.internalRefs ?? [],
-            updatedAt: new Date('2026-03-07T00:00:00Z'),
-            updatedBy: 'admin-user',
-          }),
+          'referenceLink.findMany': async () => [],
+          'annotation.upsert': async ({ update, create }) => {
+            upserts.push({ update, create });
+            return {
+              id: 'annotation-12',
+              targetKind: 'invoice',
+              targetId: 'inv-012',
+              notes: update.notes ?? create.notes ?? null,
+              externalUrls: [],
+              internalRefs: [],
+              updatedAt: new Date('2026-03-07T00:00:00Z'),
+              updatedBy: 'admin-user',
+            };
+          },
           'annotationLog.create': async () => ({ id: 'annotation-log-1' }),
           'referenceLink.deleteMany': async ({ where }) => {
             referenceDeletes.push(where);
@@ -485,6 +511,9 @@ test('PATCH /annotations/:kind/:id clears ReferenceLink rows when refs are remov
           linkKind: { in: ['external_url', 'internal_ref'] },
         },
       ]);
+      assert.equal(upserts.length, 1);
+      assert.deepEqual(upserts[0]?.update?.externalUrls, []);
+      assert.deepEqual(upserts[0]?.update?.internalRefs, []);
       assert.equal(createManyCalled, false);
     },
   );
@@ -515,13 +544,29 @@ test('PATCH /annotations/:kind/:id skips ReferenceLink sync when there is no eff
             targetKind: 'invoice',
             targetId: 'inv-013',
             notes: 'same',
-            externalUrls: ['https://example.com/a'],
-            internalRefs: [
-              { kind: 'room_chat', id: 'room-013', label: 'Room 13' },
-            ],
+            externalUrls: [],
+            internalRefs: [],
             updatedAt: new Date('2026-03-06T00:00:00Z'),
             updatedBy: 'author-1',
           }),
+          'referenceLink.findMany': async () => [
+            {
+              linkKind: 'external_url',
+              refKind: '',
+              value: 'https://example.com/a',
+              label: null,
+              updatedAt: new Date('2026-03-07T00:00:00Z'),
+              updatedBy: 'author-2',
+            },
+            {
+              linkKind: 'internal_ref',
+              refKind: 'room_chat',
+              value: 'room-013',
+              label: 'Room 13',
+              updatedAt: new Date('2026-03-07T00:00:00Z'),
+              updatedBy: 'author-2',
+            },
+          ],
           'annotation.upsert': async () => {
             annotationUpsertCalled = true;
             throw new Error('annotation.upsert should not be called');
@@ -566,6 +611,7 @@ test('PATCH /annotations/:kind/:id skips ReferenceLink sync when there is no eff
             assert.deepEqual(payload.internalRefs, [
               { kind: 'room_chat', id: 'room-013', label: 'Room 13' },
             ]);
+            assert.equal(payload.updatedBy, 'author-2');
           } finally {
             await server.close();
           }
@@ -587,6 +633,7 @@ test('PATCH /annotations/:kind/:id does not rewrite ReferenceLink rows for notes
       AUTH_MODE: 'header',
     },
     async () => {
+      const upserts = [];
       let referenceDeleteCalled = false;
       let referenceCreateCalled = false;
       await withPrismaStubs(
@@ -603,23 +650,42 @@ test('PATCH /annotations/:kind/:id does not rewrite ReferenceLink rows for notes
             targetKind: 'invoice',
             targetId: 'inv-014',
             notes: 'before',
-            externalUrls: ['https://example.com/a'],
-            internalRefs: [
-              { kind: 'room_chat', id: 'room-014', label: 'Room 14' },
-            ],
+            externalUrls: [],
+            internalRefs: [],
             updatedAt: new Date('2026-03-06T00:00:00Z'),
             updatedBy: 'author-1',
           }),
-          'annotation.upsert': async ({ update, create }) => ({
-            id: 'annotation-14',
-            targetKind: 'invoice',
-            targetId: 'inv-014',
-            notes: update.notes ?? create.notes ?? null,
-            externalUrls: update.externalUrls ?? create.externalUrls ?? [],
-            internalRefs: update.internalRefs ?? create.internalRefs ?? [],
-            updatedAt: new Date('2026-03-07T00:00:00Z'),
-            updatedBy: 'admin-user',
-          }),
+          'referenceLink.findMany': async () => [
+            {
+              linkKind: 'external_url',
+              refKind: '',
+              value: 'https://example.com/a',
+              label: null,
+              updatedAt: new Date('2026-03-07T00:00:00Z'),
+              updatedBy: 'author-2',
+            },
+            {
+              linkKind: 'internal_ref',
+              refKind: 'room_chat',
+              value: 'room-014',
+              label: 'Room 14',
+              updatedAt: new Date('2026-03-07T00:00:00Z'),
+              updatedBy: 'author-2',
+            },
+          ],
+          'annotation.upsert': async ({ update, create }) => {
+            upserts.push({ update, create });
+            return {
+              id: 'annotation-14',
+              targetKind: 'invoice',
+              targetId: 'inv-014',
+              notes: update.notes ?? create.notes ?? null,
+              externalUrls: update.externalUrls ?? create.externalUrls ?? [],
+              internalRefs: update.internalRefs ?? create.internalRefs ?? [],
+              updatedAt: new Date('2026-03-07T00:00:00Z'),
+              updatedBy: 'admin-user',
+            };
+          },
           'annotationLog.create': async () => ({ id: 'annotation-log-1' }),
           'referenceLink.deleteMany': async () => {
             referenceDeleteCalled = true;
@@ -660,6 +726,9 @@ test('PATCH /annotations/:kind/:id does not rewrite ReferenceLink rows for notes
         },
       );
 
+      assert.equal(upserts.length, 1);
+      assert.deepEqual(upserts[0]?.update?.externalUrls, []);
+      assert.deepEqual(upserts[0]?.update?.internalRefs, []);
       assert.equal(referenceDeleteCalled, false);
       assert.equal(referenceCreateCalled, false);
     },


### PR DESCRIPTION
## 概要
- `PATCH /annotations/:kind/:id` の判断基準を `ReferenceLink` ベースへ寄せる
- refs 更新時に `ReferenceLink` を正本として同期し、`Annotation` の shadow JSON を縮退する
- migration 未適用時の JSON fallback は維持する

## 変更内容
- `packages/backend/src/routes/annotations.ts`
  - no-op 判定・差分監査・返却 payload の参照元を resolved state に変更
  - refs 更新時は `replaceReferenceLinks()` を transaction 内で先に実行
  - `ReferenceLink` 同期に成功した場合、`Annotation.externalUrls/internalRefs` は empty shadow として保存
  - `ReferenceLink` が未利用/未適用なら従来どおり JSON を保存
- `packages/backend/test/annotationsChatRefNormalizationRoutes.test.js`
  - stale JSON + 最新 `ReferenceLink` を前提にした no-op / notes-only / update の回帰を追加
  - shadow 縮退と fallback 維持を確認
- `docs/requirements/annotations.md`
  - write path を `ReferenceLink` 正本へ寄せた仕様を反映

## 検証
- `npx prettier --check packages/backend/src/routes/annotations.ts packages/backend/test/annotationsChatRefNormalizationRoutes.test.js docs/requirements/annotations.md`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres npm run prisma:generate --prefix packages/backend`
- `npm run lint --prefix packages/backend`
- `npm run typecheck --prefix packages/backend`
- `npm run build --prefix packages/backend`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres node --test packages/backend/test/annotationsChatRefNormalizationRoutes.test.js packages/backend/test/evidenceSnapshotService.test.js packages/backend/test/leaveTypeRoutes.test.js packages/backend/test/annotationReferencesBackfill.test.js`

Refs: #1317
