### PR TITLE
test: cover phase3 strict route presets

### DIFF
--- a/packages/backend/test/approvalActionPolicyPreset.test.js
+++ b/packages/backend/test/approvalActionPolicyPreset.test.js
@@ -68,15 +68,21 @@ function approvalInstanceDraft() {
   };
 }
 
-test('POST /approval-instances/:id/act approve: phase2_core preset denies when policy is missing', async () => {
-  await withEnv(
+function withApprovalPolicyEnv(preset, fn) {
+  return withEnv(
     {
       DATABASE_URL: process.env.DATABASE_URL || MIN_DATABASE_URL,
       AUTH_MODE: 'header',
-      ACTION_POLICY_ENFORCEMENT_PRESET: 'phase2_core',
+      ACTION_POLICY_ENFORCEMENT_PRESET: preset,
       ACTION_POLICY_REQUIRED_ACTIONS: '',
     },
-    async () => {
+    fn,
+  );
+}
+
+for (const preset of ['phase2_core', 'phase3_strict']) {
+  test(`POST /approval-instances/:id/act approve: ${preset} preset denies when policy is missing`, async () => {
+    await withApprovalPolicyEnv(preset, async () => {
       await withPrismaStubs(
         {
           'approvalInstance.findUnique': async () => approvalInstanceDraft(),
@@ -99,19 +105,11 @@ test('POST /approval-instances/:id/act approve: phase2_core preset denies when p
           }
         },
       );
-    },
-  );
-});
+    });
+  });
 
-test('POST /approval-instances/:id/act reject: phase2_core preset denies when policy is missing', async () => {
-  await withEnv(
-    {
-      DATABASE_URL: process.env.DATABASE_URL || MIN_DATABASE_URL,
-      AUTH_MODE: 'header',
-      ACTION_POLICY_ENFORCEMENT_PRESET: 'phase2_core',
-      ACTION_POLICY_REQUIRED_ACTIONS: '',
-    },
-    async () => {
+  test(`POST /approval-instances/:id/act reject: ${preset} preset denies when policy is missing`, async () => {
+    await withApprovalPolicyEnv(preset, async () => {
       await withPrismaStubs(
         {
           'approvalInstance.findUnique': async () => approvalInstanceDraft(),
@@ -134,19 +132,11 @@ test('POST /approval-instances/:id/act reject: phase2_core preset denies when po
           }
         },
       );
-    },
-  );
-});
+    });
+  });
 
-test('POST /approval-instances/:id/act approve: policy allow reaches act path (not ACTION_POLICY_DENIED)', async () => {
-  await withEnv(
-    {
-      DATABASE_URL: process.env.DATABASE_URL || MIN_DATABASE_URL,
-      AUTH_MODE: 'header',
-      ACTION_POLICY_ENFORCEMENT_PRESET: 'phase2_core',
-      ACTION_POLICY_REQUIRED_ACTIONS: '',
-    },
-    async () => {
+  test(`POST /approval-instances/:id/act approve: ${preset} policy allow reaches act path (not ACTION_POLICY_DENIED)`, async () => {
+    await withApprovalPolicyEnv(preset, async () => {
       const originalTransaction = prisma.$transaction;
       prisma.$transaction = async () => {
         throw new Error('mock-act-failure');
@@ -191,19 +181,11 @@ test('POST /approval-instances/:id/act approve: policy allow reaches act path (n
       } finally {
         prisma.$transaction = originalTransaction;
       }
-    },
-  );
-});
+    });
+  });
 
-test('POST /approval-instances/:id/act reject: policy allow reaches act path (not ACTION_POLICY_DENIED)', async () => {
-  await withEnv(
-    {
-      DATABASE_URL: process.env.DATABASE_URL || MIN_DATABASE_URL,
-      AUTH_MODE: 'header',
-      ACTION_POLICY_ENFORCEMENT_PRESET: 'phase2_core',
-      ACTION_POLICY_REQUIRED_ACTIONS: '',
-    },
-    async () => {
+  test(`POST /approval-instances/:id/act reject: ${preset} policy allow reaches act path (not ACTION_POLICY_DENIED)`, async () => {
+    await withApprovalPolicyEnv(preset, async () => {
       const originalTransaction = prisma.$transaction;
       prisma.$transaction = async () => {
         throw new Error('mock-act-failure');
@@ -248,9 +230,9 @@ test('POST /approval-instances/:id/act reject: policy allow reaches act path (no
       } finally {
         prisma.$transaction = originalTransaction;
       }
-    },
-  );
-});
+    });
+  });
+}
 
 test('POST /approval-instances/:id/act approve: reason required policy returns REASON_REQUIRED', async () => {
   await withEnv(

--- a/packages/backend/test/invoicePolicyEnforcementPreset.test.js
+++ b/packages/backend/test/invoicePolicyEnforcementPreset.test.js
@@ -73,163 +73,165 @@ function invoiceDraft() {
   };
 }
 
-function withInvoicePolicyEnv(fn) {
+function withInvoicePolicyEnv(preset, fn) {
   return withEnv(
     {
       DATABASE_URL: process.env.DATABASE_URL || MIN_DATABASE_URL,
       AUTH_MODE: 'header',
-      ACTION_POLICY_ENFORCEMENT_PRESET: 'phase2_core',
+      ACTION_POLICY_ENFORCEMENT_PRESET: preset,
       ACTION_POLICY_REQUIRED_ACTIONS: '',
     },
     fn,
   );
 }
 
-test('POST /invoices/:id/submit: phase2_core required action denies when policy is missing', async () => {
-  await withInvoicePolicyEnv(async () => {
-    let transactionCalled = 0;
-    await withPrismaStubs(
-      {
-        'invoice.findUnique': async () => invoiceDraft(),
-        'actionPolicy.findMany': async () => [],
-        $transaction: async () => {
-          transactionCalled += 1;
-          throw new Error('unexpected transaction in deny path');
+for (const preset of ['phase2_core', 'phase3_strict']) {
+  test(`POST /invoices/:id/submit: ${preset} required action denies when policy is missing`, async () => {
+    await withInvoicePolicyEnv(preset, async () => {
+      let transactionCalled = 0;
+      await withPrismaStubs(
+        {
+          'invoice.findUnique': async () => invoiceDraft(),
+          'actionPolicy.findMany': async () => [],
+          $transaction: async () => {
+            transactionCalled += 1;
+            throw new Error('unexpected transaction in deny path');
+          },
         },
-      },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'POST',
-            url: '/invoices/inv-001/submit',
-            headers: adminHeaders(),
-            payload: {},
-          });
-          assert.equal(res.statusCode, 403, res.body);
-          const payload = JSON.parse(res.body);
-          assert.equal(payload?.error?.code, 'ACTION_POLICY_DENIED');
-          assert.equal(transactionCalled, 0);
-        } finally {
-          await server.close();
-        }
-      },
-    );
+        async () => {
+          const server = await buildServer({ logger: false });
+          try {
+            const res = await server.inject({
+              method: 'POST',
+              url: '/invoices/inv-001/submit',
+              headers: adminHeaders(),
+              payload: {},
+            });
+            assert.equal(res.statusCode, 403, res.body);
+            const payload = JSON.parse(res.body);
+            assert.equal(payload?.error?.code, 'ACTION_POLICY_DENIED');
+            assert.equal(transactionCalled, 0);
+          } finally {
+            await server.close();
+          }
+        },
+      );
+    });
   });
-});
 
-test('POST /invoices/:id/submit: policy allow reaches downstream submit path (not ACTION_POLICY_DENIED)', async () => {
-  await withInvoicePolicyEnv(async () => {
-    let transactionCalled = 0;
-    let updateCalled = 0;
-    const tx = {
-      invoice: {
-        update: async ({ where, data }) => {
-          updateCalled += 1;
-          return {
-            id: where.id,
+  test(`POST /invoices/:id/submit: ${preset} policy allow reaches downstream submit path (not ACTION_POLICY_DENIED)`, async () => {
+    await withInvoicePolicyEnv(preset, async () => {
+      let transactionCalled = 0;
+      let updateCalled = 0;
+      const tx = {
+        invoice: {
+          update: async ({ where, data }) => {
+            updateCalled += 1;
+            return {
+              id: where.id,
+              status: data.status,
+              projectId: 'proj-001',
+            };
+          },
+        },
+        project: {
+          findUnique: async () => null,
+        },
+        approvalRule: {
+          findMany: async () => [
+            {
+              id: 'rule-invoice-submit',
+              flowType: 'invoice',
+              ruleKey: 'invoice-default',
+              version: 1,
+              isActive: true,
+              conditions: {},
+              steps: [{ approverUserId: 'admin-user', stepOrder: 1 }],
+            },
+          ],
+        },
+        approvalInstance: {
+          findFirst: async () => null,
+          create: async ({ data }) => ({
+            id: 'approval-001',
+            flowType: data.flowType,
+            targetTable: data.targetTable,
+            targetId: data.targetId,
+            projectId: data.projectId,
             status: data.status,
-            projectId: 'proj-001',
-          };
+            currentStep: data.currentStep,
+            ruleId: data.ruleId,
+            createdBy: data.createdBy,
+            stagePolicy: data.stagePolicy ?? null,
+            steps: (data.steps?.create ?? []).map((step, index) => ({
+              id: `step-${index + 1}`,
+              ...step,
+            })),
+          }),
         },
-      },
-      project: {
-        findUnique: async () => null,
-      },
-      approvalRule: {
-        findMany: async () => [
-          {
-            id: 'rule-invoice-submit',
-            flowType: 'invoice',
-            ruleKey: 'invoice-default',
-            version: 1,
-            isActive: true,
-            conditions: {},
-            steps: [{ approverUserId: 'admin-user', stepOrder: 1 }],
-          },
-        ],
-      },
-      approvalInstance: {
-        findFirst: async () => null,
-        create: async ({ data }) => ({
-          id: 'approval-001',
-          flowType: data.flowType,
-          targetTable: data.targetTable,
-          targetId: data.targetId,
-          projectId: data.projectId,
-          status: data.status,
-          currentStep: data.currentStep,
-          ruleId: data.ruleId,
-          createdBy: data.createdBy,
-          stagePolicy: data.stagePolicy ?? null,
-          steps: (data.steps?.create ?? []).map((step, index) => ({
-            id: `step-${index + 1}`,
-            ...step,
-          })),
-        }),
-      },
-      evidenceSnapshot: {
-        findFirst: async () => null,
-        create: async ({ data }) => ({
-          id: 'snapshot-001',
-          approvalInstanceId: data.approvalInstanceId,
-          targetTable: data.targetTable,
-          targetId: data.targetId,
-          version: data.version,
-        }),
-      },
-      annotation: {
-        findUnique: async () => null,
-      },
-      referenceLink: {
-        findMany: async () => [],
-      },
-      chatMessage: {
-        findMany: async () => [],
-      },
-    };
+        evidenceSnapshot: {
+          findFirst: async () => null,
+          create: async ({ data }) => ({
+            id: 'snapshot-001',
+            approvalInstanceId: data.approvalInstanceId,
+            targetTable: data.targetTable,
+            targetId: data.targetId,
+            version: data.version,
+          }),
+        },
+        annotation: {
+          findUnique: async () => null,
+        },
+        referenceLink: {
+          findMany: async () => [],
+        },
+        chatMessage: {
+          findMany: async () => [],
+        },
+      };
 
-    await withPrismaStubs(
-      {
-        'invoice.findUnique': async () => invoiceDraft(),
-        'actionPolicy.findMany': async () => [
-          {
-            id: 'policy-invoice-submit-allow',
-            flowType: 'invoice',
-            actionKey: 'submit',
-            priority: 100,
-            isEnabled: true,
-            subjects: null,
-            stateConstraints: null,
-            requireReason: false,
-            guards: null,
+      await withPrismaStubs(
+        {
+          'invoice.findUnique': async () => invoiceDraft(),
+          'actionPolicy.findMany': async () => [
+            {
+              id: 'policy-invoice-submit-allow',
+              flowType: 'invoice',
+              actionKey: 'submit',
+              priority: 100,
+              isEnabled: true,
+              subjects: null,
+              stateConstraints: null,
+              requireReason: false,
+              guards: null,
+            },
+          ],
+          $transaction: async (callback) => {
+            transactionCalled += 1;
+            return callback(tx);
           },
-        ],
-        $transaction: async (callback) => {
-          transactionCalled += 1;
-          return callback(tx);
+          'auditLog.create': async () => ({ id: 'audit-001' }),
         },
-        'auditLog.create': async () => ({ id: 'audit-001' }),
-      },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'POST',
-            url: '/invoices/inv-001/submit',
-            headers: adminHeaders(),
-            payload: {},
-          });
-          assert.equal(res.statusCode, 200, res.body);
-          const payload = JSON.parse(res.body);
-          assert.equal(payload?.id, 'inv-001');
-          assert.equal(payload?.status, 'pending_qa');
-          assert.equal(updateCalled, 1);
-          assert.equal(transactionCalled, 1);
-        } finally {
-          await server.close();
-        }
-      },
-    );
+        async () => {
+          const server = await buildServer({ logger: false });
+          try {
+            const res = await server.inject({
+              method: 'POST',
+              url: '/invoices/inv-001/submit',
+              headers: adminHeaders(),
+              payload: {},
+            });
+            assert.equal(res.statusCode, 200, res.body);
+            const payload = JSON.parse(res.body);
+            assert.equal(payload?.id, 'inv-001');
+            assert.equal(payload?.status, 'pending_qa');
+            assert.equal(updateCalled, 1);
+            assert.equal(transactionCalled, 1);
+          } finally {
+            await server.close();
+          }
+        },
+      );
+    });
   });
-});
+}

--- a/packages/backend/test/sendPolicyEnforcementPreset.test.js
+++ b/packages/backend/test/sendPolicyEnforcementPreset.test.js
@@ -92,16 +92,22 @@ function approvalInstanceApproved() {
   };
 }
 
-test('POST /invoices/:id/send: phase2_core preset denies when policy is missing', async () => {
-  await withEnv(
+function withSendPolicyEnv(preset, fn) {
+  return withEnv(
     {
       DATABASE_URL: process.env.DATABASE_URL || MIN_DATABASE_URL,
       AUTH_MODE: 'header',
-      ACTION_POLICY_ENFORCEMENT_PRESET: 'phase2_core',
+      ACTION_POLICY_ENFORCEMENT_PRESET: preset,
       ACTION_POLICY_REQUIRED_ACTIONS: '',
       APPROVAL_EVIDENCE_REQUIRED_ACTIONS: '',
     },
-    async () => {
+    fn,
+  );
+}
+
+for (const preset of ['phase2_core', 'phase3_strict']) {
+  test(`POST /invoices/:id/send: ${preset} preset denies when policy is missing`, async () => {
+    await withSendPolicyEnv(preset, async () => {
       await withPrismaStubs(
         {
           'invoice.findUnique': async () => invoiceDraft(),
@@ -123,55 +129,11 @@ test('POST /invoices/:id/send: phase2_core preset denies when policy is missing'
           }
         },
       );
-    },
-  );
-});
+    });
+  });
 
-test('POST /invoices/:id/send: preset off keeps legacy fallback behavior', async () => {
-  await withEnv(
-    {
-      DATABASE_URL: process.env.DATABASE_URL || MIN_DATABASE_URL,
-      AUTH_MODE: 'header',
-      ACTION_POLICY_ENFORCEMENT_PRESET: 'off',
-      ACTION_POLICY_REQUIRED_ACTIONS: '',
-      APPROVAL_EVIDENCE_REQUIRED_ACTIONS: '',
-    },
-    async () => {
-      await withPrismaStubs(
-        {
-          'invoice.findUnique': async () => invoiceDraft(),
-          'actionPolicy.findMany': async () => [],
-        },
-        async () => {
-          const server = await buildServer({ logger: false });
-          try {
-            const res = await server.inject({
-              method: 'POST',
-              url: '/invoices/inv-001/send?templateId=missing-template',
-              headers: adminHeaders(),
-            });
-            assert.equal(res.statusCode, 404, res.body);
-            const payload = JSON.parse(res.body);
-            assert.equal(payload?.error?.code, 'template_not_found');
-          } finally {
-            await server.close();
-          }
-        },
-      );
-    },
-  );
-});
-
-test('POST /invoices/:id/send: phase2_core requires approval+evidence after policy allow', async () => {
-  await withEnv(
-    {
-      DATABASE_URL: process.env.DATABASE_URL || MIN_DATABASE_URL,
-      AUTH_MODE: 'header',
-      ACTION_POLICY_ENFORCEMENT_PRESET: 'phase2_core',
-      ACTION_POLICY_REQUIRED_ACTIONS: '',
-      APPROVAL_EVIDENCE_REQUIRED_ACTIONS: '',
-    },
-    async () => {
+  test(`POST /invoices/:id/send: ${preset} requires approval+evidence after policy allow`, async () => {
+    await withSendPolicyEnv(preset, async () => {
       await withPrismaStubs(
         {
           'invoice.findUnique': async () => invoiceDraft(),
@@ -206,20 +168,11 @@ test('POST /invoices/:id/send: phase2_core requires approval+evidence after poli
           }
         },
       );
-    },
-  );
-});
+    });
+  });
 
-test('POST /invoices/:id/send: phase2_core returns EVIDENCE_REQUIRED when approval exists without snapshot', async () => {
-  await withEnv(
-    {
-      DATABASE_URL: process.env.DATABASE_URL || MIN_DATABASE_URL,
-      AUTH_MODE: 'header',
-      ACTION_POLICY_ENFORCEMENT_PRESET: 'phase2_core',
-      ACTION_POLICY_REQUIRED_ACTIONS: '',
-      APPROVAL_EVIDENCE_REQUIRED_ACTIONS: '',
-    },
-    async () => {
+  test(`POST /invoices/:id/send: ${preset} returns EVIDENCE_REQUIRED when approval exists without snapshot`, async () => {
+    await withSendPolicyEnv(preset, async () => {
       await withPrismaStubs(
         {
           'invoice.findUnique': async () => invoiceDraft(),
@@ -250,6 +203,41 @@ test('POST /invoices/:id/send: phase2_core returns EVIDENCE_REQUIRED when approv
             assert.equal(res.statusCode, 403, res.body);
             const payload = JSON.parse(res.body);
             assert.equal(payload?.error?.code, 'EVIDENCE_REQUIRED');
+          } finally {
+            await server.close();
+          }
+        },
+      );
+    });
+  });
+}
+
+test('POST /invoices/:id/send: preset off keeps legacy fallback behavior', async () => {
+  await withEnv(
+    {
+      DATABASE_URL: process.env.DATABASE_URL || MIN_DATABASE_URL,
+      AUTH_MODE: 'header',
+      ACTION_POLICY_ENFORCEMENT_PRESET: 'off',
+      ACTION_POLICY_REQUIRED_ACTIONS: '',
+      APPROVAL_EVIDENCE_REQUIRED_ACTIONS: '',
+    },
+    async () => {
+      await withPrismaStubs(
+        {
+          'invoice.findUnique': async () => invoiceDraft(),
+          'actionPolicy.findMany': async () => [],
+        },
+        async () => {
+          const server = await buildServer({ logger: false });
+          try {
+            const res = await server.inject({
+              method: 'POST',
+              url: '/invoices/inv-001/send?templateId=missing-template',
+              headers: adminHeaders(),
+            });
+            assert.equal(res.statusCode, 404, res.body);
+            const payload = JSON.parse(res.body);
+            assert.equal(payload?.error?.code, 'template_not_found');
           } finally {
             await server.close();
           }
@@ -303,7 +291,10 @@ test('POST /invoices/:id/send: e2e header override can enable evidence gate when
             assert.equal(res.statusCode, 403, res.body);
             const payload = JSON.parse(res.body);
             assert.equal(payload?.error?.code, 'EVIDENCE_REQUIRED');
-            assert.equal(payload?.error?.details?.approvalInstanceId, 'approval-001');
+            assert.equal(
+              payload?.error?.details?.approvalInstanceId,
+              'approval-001',
+            );
           } finally {
             await server.close();
           }
@@ -383,7 +374,10 @@ test('POST /invoices/:id/send: reason override writes action_policy_override aud
           overrideAudit.metadata._request.id.length > 0,
       );
       assert.equal(overrideAudit?.metadata?._request?.source, 'api');
-      assert.equal(overrideAudit?.metadata?._auth?.principalUserId, 'admin-user');
+      assert.equal(
+        overrideAudit?.metadata?._auth?.principalUserId,
+        'admin-user',
+      );
       assert.equal(overrideAudit?.metadata?._auth?.actorUserId, 'admin-user');
     },
   );


### PR DESCRIPTION
## 概要
- `phase3_strict` でも高リスク route preset が `phase2_core` と同じ期待動作を満たすことを backend route test で追加確認
- 承認 act / invoice submit / invoice send について、policy 未定義時拒否と policy 定義時の downstream 到達を自動化

## 変更内容
- `packages/backend/test/approvalActionPolicyPreset.test.js`
  - `approve` / `reject` の deny / allow を `phase3_strict` でも追加検証
- `packages/backend/test/invoicePolicyEnforcementPreset.test.js`
  - `submit` の deny / allow を `phase3_strict` でも追加検証
- `packages/backend/test/sendPolicyEnforcementPreset.test.js`
  - `send` の deny / `APPROVAL_REQUIRED` / `EVIDENCE_REQUIRED` を `phase3_strict` でも追加検証

## 確認
- `npx prettier --check packages/backend/test/approvalActionPolicyPreset.test.js packages/backend/test/invoicePolicyEnforcementPreset.test.js packages/backend/test/sendPolicyEnforcementPreset.test.js`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres node --test packages/backend/test/approvalActionPolicyPreset.test.js packages/backend/test/invoicePolicyEnforcementPreset.test.js packages/backend/test/sendPolicyEnforcementPreset.test.js`

Refs: #1312 #1308
