### PR TITLE
test: extend phase3 strict expense and po presets

### DIFF
--- a/packages/backend/test/expensePolicyEnforcementPreset.test.js
+++ b/packages/backend/test/expensePolicyEnforcementPreset.test.js
@@ -84,12 +84,12 @@ function expenseDraft(overrides = {}) {
   };
 }
 
-function withExpensePolicyEnv(fn) {
+function withExpensePolicyEnv(preset, fn) {
   return withEnv(
     {
       DATABASE_URL: process.env.DATABASE_URL || MIN_DATABASE_URL,
       AUTH_MODE: 'header',
-      ACTION_POLICY_ENFORCEMENT_PRESET: 'phase2_core',
+      ACTION_POLICY_ENFORCEMENT_PRESET: preset,
       ACTION_POLICY_REQUIRED_ACTIONS: '',
     },
     fn,
@@ -112,326 +112,328 @@ function allowPolicy(actionKey) {
   ];
 }
 
-test('POST /expenses/:id/submit: phase2_core required action denies when policy is missing', async () => {
-  await withExpensePolicyEnv(async () => {
-    let transactionCalled = 0;
-    await withPrismaStubs(
-      {
-        'expense.findUnique': async () => expenseDraft(),
-        'project.findUnique': async () => ({
-          budgetCost: 100000,
-          currency: 'JPY',
-        }),
-        'expense.aggregate': async () => ({ _sum: { amount: 0 } }),
-        'actionPolicy.findMany': async () => [],
-        $transaction: async () => {
-          transactionCalled += 1;
-          throw new Error('unexpected transaction in deny path');
-        },
-      },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'POST',
-            url: '/expenses/exp-001/submit',
-            headers: adminHeaders(),
-            payload: {},
-          });
-          assert.equal(res.statusCode, 403, res.body);
-          const payload = JSON.parse(res.body);
-          assert.equal(payload?.error?.code, 'ACTION_POLICY_DENIED');
-          assert.equal(transactionCalled, 0);
-        } finally {
-          await server.close();
-        }
-      },
-    );
-  });
-});
-
-test('POST /expenses/:id/submit: policy allow reaches downstream submit path (not ACTION_POLICY_DENIED)', async () => {
-  await withExpensePolicyEnv(async () => {
-    let transactionCalled = 0;
-    let updateCalled = 0;
-    const tx = {
-      expense: {
-        update: async ({ where, data }) => {
-          updateCalled += 1;
-          return {
-            id: where.id,
-            status: data.status,
-            settlementStatus: 'unpaid',
-            projectId: 'proj-001',
-          };
-        },
-      },
-      project: {
-        findUnique: async () => null,
-      },
-      approvalRule: {
-        findMany: async () => [
-          {
-            id: 'rule-expense-submit',
-            flowType: 'expense',
-            ruleKey: 'expense-default',
-            version: 1,
-            isActive: true,
-            conditions: {},
-            steps: [{ approverUserId: 'admin-user', stepOrder: 1 }],
+for (const preset of ['phase2_core', 'phase3_strict']) {
+  test(`POST /expenses/:id/submit: ${preset} required action denies when policy is missing`, async () => {
+    await withExpensePolicyEnv(preset, async () => {
+      let transactionCalled = 0;
+      await withPrismaStubs(
+        {
+          'expense.findUnique': async () => expenseDraft(),
+          'project.findUnique': async () => ({
+            budgetCost: 100000,
+            currency: 'JPY',
+          }),
+          'expense.aggregate': async () => ({ _sum: { amount: 0 } }),
+          'actionPolicy.findMany': async () => [],
+          $transaction: async () => {
+            transactionCalled += 1;
+            throw new Error('unexpected transaction in deny path');
           },
-        ],
-      },
-      approvalInstance: {
-        findFirst: async () => null,
-        create: async ({ data }) => ({
-          id: 'approval-001',
-          flowType: data.flowType,
-          targetTable: data.targetTable,
-          targetId: data.targetId,
-          projectId: data.projectId,
-          status: data.status,
-          currentStep: data.currentStep,
-          ruleId: data.ruleId,
-          createdBy: data.createdBy,
-          stagePolicy: data.stagePolicy ?? null,
-          steps: (data.steps?.create ?? []).map((step, index) => ({
-            id: `step-${index + 1}`,
-            ...step,
-          })),
-        }),
-      },
-      evidenceSnapshot: {
-        findFirst: async () => null,
-        create: async ({ data }) => ({
-          id: 'snapshot-001',
-          approvalInstanceId: data.approvalInstanceId,
-          targetTable: data.targetTable,
-          targetId: data.targetId,
-          version: data.version,
-        }),
-      },
-      annotation: {
-        findUnique: async () => null,
-      },
-      referenceLink: {
-        findMany: async () => [],
-      },
-      chatMessage: {
-        findMany: async () => [],
-      },
-    };
-
-    await withPrismaStubs(
-      {
-        'expense.findUnique': async () => expenseDraft(),
-        'project.findUnique': async () => ({
-          budgetCost: 100000,
-          currency: 'JPY',
-        }),
-        'expense.aggregate': async () => ({ _sum: { amount: 0 } }),
-        'expenseStateTransitionLog.create': async () => ({
-          id: 'transition-001',
-        }),
-        'userNotificationPreference.findMany': async () => [],
-        'appNotification.findMany': async () => [],
-        'appNotification.createMany': async () => ({ count: 0 }),
-        'actionPolicy.findMany': async () => allowPolicy('submit'),
-        $transaction: async (callback) => {
-          transactionCalled += 1;
-          return callback(tx);
         },
-        'auditLog.create': async () => ({ id: 'audit-001' }),
-      },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'POST',
-            url: '/expenses/exp-001/submit',
-            headers: adminHeaders(),
-            payload: {},
-          });
-          assert.equal(res.statusCode, 200, res.body);
-          const payload = JSON.parse(res.body);
-          assert.equal(payload?.id, 'exp-001');
-          assert.equal(payload?.status, 'pending_qa');
-          assert.equal(updateCalled, 1);
-          assert.equal(transactionCalled, 1);
-        } finally {
-          await server.close();
-        }
-      },
-    );
-  });
-});
-
-test('POST /expenses/:id/mark-paid: phase2_core required action denies when policy is missing', async () => {
-  await withExpensePolicyEnv(async () => {
-    let updateCalled = 0;
-    await withPrismaStubs(
-      {
-        'expense.findUnique': async () =>
-          expenseDraft({ status: 'approved', settlementStatus: 'unpaid' }),
-        'actionPolicy.findMany': async () => [],
-        'expense.update': async () => {
-          updateCalled += 1;
-          return { id: 'exp-001' };
+        async () => {
+          const server = await buildServer({ logger: false });
+          try {
+            const res = await server.inject({
+              method: 'POST',
+              url: '/expenses/exp-001/submit',
+              headers: adminHeaders(),
+              payload: {},
+            });
+            assert.equal(res.statusCode, 403, res.body);
+            const payload = JSON.parse(res.body);
+            assert.equal(payload?.error?.code, 'ACTION_POLICY_DENIED');
+            assert.equal(transactionCalled, 0);
+          } finally {
+            await server.close();
+          }
         },
-      },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'POST',
-            url: '/expenses/exp-001/mark-paid',
-            headers: adminHeaders(),
-            payload: {},
-          });
-          assert.equal(res.statusCode, 403, res.body);
-          const payload = JSON.parse(res.body);
-          assert.equal(payload?.error?.code, 'ACTION_POLICY_DENIED');
-          assert.equal(updateCalled, 0);
-        } finally {
-          await server.close();
-        }
-      },
-    );
+      );
+    });
   });
-});
 
-test('POST /expenses/:id/mark-paid: policy allow reaches downstream update path (not ACTION_POLICY_DENIED)', async () => {
-  await withExpensePolicyEnv(async () => {
-    let updateCalled = 0;
-    await withPrismaStubs(
-      {
-        'expense.findUnique': async () =>
-          expenseDraft({ status: 'approved', settlementStatus: 'unpaid' }),
-        'actionPolicy.findMany': async () => allowPolicy('mark_paid'),
-        'expense.update': async ({ where, data }) => {
-          updateCalled += 1;
-          return {
-            id: where.id,
-            status: 'approved',
-            settlementStatus: data.settlementStatus,
-            paidAt: data.paidAt,
-            paidBy: data.paidBy,
-          };
+  test(`POST /expenses/:id/submit: ${preset} policy allow reaches downstream submit path (not ACTION_POLICY_DENIED)`, async () => {
+    await withExpensePolicyEnv(preset, async () => {
+      let transactionCalled = 0;
+      let updateCalled = 0;
+      const tx = {
+        expense: {
+          update: async ({ where, data }) => {
+            updateCalled += 1;
+            return {
+              id: where.id,
+              status: data.status,
+              settlementStatus: 'unpaid',
+              projectId: 'proj-001',
+            };
+          },
         },
-        'expenseStateTransitionLog.create': async () => ({
-          id: 'transition-002',
-        }),
-        'userNotificationPreference.findMany': async () => [],
-        'appNotification.findFirst': async () => ({ id: 'notif-existing' }),
-        'auditLog.create': async () => ({ id: 'audit-002' }),
-      },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'POST',
-            url: '/expenses/exp-001/mark-paid',
-            headers: adminHeaders(),
-            payload: {},
-          });
-          assert.equal(res.statusCode, 200, res.body);
-          const payload = JSON.parse(res.body);
-          assert.equal(payload?.id, 'exp-001');
-          assert.equal(payload?.settlementStatus, 'paid');
-          assert.equal(updateCalled, 1);
-        } finally {
-          await server.close();
-        }
-      },
-    );
-  });
-});
-
-test('POST /expenses/:id/unmark-paid: phase2_core required action denies when policy is missing', async () => {
-  await withExpensePolicyEnv(async () => {
-    let updateCalled = 0;
-    await withPrismaStubs(
-      {
-        'expense.findUnique': async () =>
-          expenseDraft({
-            status: 'approved',
-            settlementStatus: 'paid',
-            paidAt: new Date('2026-01-20T00:00:00.000Z'),
-            paidBy: 'admin-user',
+        project: {
+          findUnique: async () => null,
+        },
+        approvalRule: {
+          findMany: async () => [
+            {
+              id: 'rule-expense-submit',
+              flowType: 'expense',
+              ruleKey: 'expense-default',
+              version: 1,
+              isActive: true,
+              conditions: {},
+              steps: [{ approverUserId: 'admin-user', stepOrder: 1 }],
+            },
+          ],
+        },
+        approvalInstance: {
+          findFirst: async () => null,
+          create: async ({ data }) => ({
+            id: 'approval-001',
+            flowType: data.flowType,
+            targetTable: data.targetTable,
+            targetId: data.targetId,
+            projectId: data.projectId,
+            status: data.status,
+            currentStep: data.currentStep,
+            ruleId: data.ruleId,
+            createdBy: data.createdBy,
+            stagePolicy: data.stagePolicy ?? null,
+            steps: (data.steps?.create ?? []).map((step, index) => ({
+              id: `step-${index + 1}`,
+              ...step,
+            })),
           }),
-        'actionPolicy.findMany': async () => [],
-        'expense.update': async () => {
-          updateCalled += 1;
-          return { id: 'exp-001' };
         },
-      },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'POST',
-            url: '/expenses/exp-001/unmark-paid',
-            headers: adminHeaders(),
-            payload: { reasonText: 'fix settlement' },
-          });
-          assert.equal(res.statusCode, 403, res.body);
-          const payload = JSON.parse(res.body);
-          assert.equal(payload?.error?.code, 'ACTION_POLICY_DENIED');
-          assert.equal(updateCalled, 0);
-        } finally {
-          await server.close();
-        }
-      },
-    );
-  });
-});
-
-test('POST /expenses/:id/unmark-paid: policy allow reaches downstream update path (not ACTION_POLICY_DENIED)', async () => {
-  await withExpensePolicyEnv(async () => {
-    let updateCalled = 0;
-    await withPrismaStubs(
-      {
-        'expense.findUnique': async () =>
-          expenseDraft({
-            status: 'approved',
-            settlementStatus: 'paid',
-            paidAt: new Date('2026-01-20T00:00:00.000Z'),
-            paidBy: 'admin-user',
+        evidenceSnapshot: {
+          findFirst: async () => null,
+          create: async ({ data }) => ({
+            id: 'snapshot-001',
+            approvalInstanceId: data.approvalInstanceId,
+            targetTable: data.targetTable,
+            targetId: data.targetId,
+            version: data.version,
           }),
-        'actionPolicy.findMany': async () => allowPolicy('unmark_paid'),
-        'expense.update': async ({ where, data }) => {
-          updateCalled += 1;
-          return {
-            id: where.id,
-            status: 'approved',
-            settlementStatus: data.settlementStatus,
-            paidAt: data.paidAt,
-            paidBy: data.paidBy,
-          };
         },
-        'expenseStateTransitionLog.create': async () => ({
-          id: 'transition-003',
-        }),
-        'auditLog.create': async () => ({ id: 'audit-003' }),
-      },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'POST',
-            url: '/expenses/exp-001/unmark-paid',
-            headers: adminHeaders(),
-            payload: { reasonText: 'fix settlement' },
-          });
-          assert.equal(res.statusCode, 200, res.body);
-          const payload = JSON.parse(res.body);
-          assert.equal(payload?.id, 'exp-001');
-          assert.equal(payload?.settlementStatus, 'unpaid');
-          assert.equal(updateCalled, 1);
-        } finally {
-          await server.close();
-        }
-      },
-    );
+        annotation: {
+          findUnique: async () => null,
+        },
+        referenceLink: {
+          findMany: async () => [],
+        },
+        chatMessage: {
+          findMany: async () => [],
+        },
+      };
+
+      await withPrismaStubs(
+        {
+          'expense.findUnique': async () => expenseDraft(),
+          'project.findUnique': async () => ({
+            budgetCost: 100000,
+            currency: 'JPY',
+          }),
+          'expense.aggregate': async () => ({ _sum: { amount: 0 } }),
+          'expenseStateTransitionLog.create': async () => ({
+            id: 'transition-001',
+          }),
+          'userNotificationPreference.findMany': async () => [],
+          'appNotification.findMany': async () => [],
+          'appNotification.createMany': async () => ({ count: 0 }),
+          'actionPolicy.findMany': async () => allowPolicy('submit'),
+          $transaction: async (callback) => {
+            transactionCalled += 1;
+            return callback(tx);
+          },
+          'auditLog.create': async () => ({ id: 'audit-001' }),
+        },
+        async () => {
+          const server = await buildServer({ logger: false });
+          try {
+            const res = await server.inject({
+              method: 'POST',
+              url: '/expenses/exp-001/submit',
+              headers: adminHeaders(),
+              payload: {},
+            });
+            assert.equal(res.statusCode, 200, res.body);
+            const payload = JSON.parse(res.body);
+            assert.equal(payload?.id, 'exp-001');
+            assert.equal(payload?.status, 'pending_qa');
+            assert.equal(updateCalled, 1);
+            assert.equal(transactionCalled, 1);
+          } finally {
+            await server.close();
+          }
+        },
+      );
+    });
   });
-});
+
+  test(`POST /expenses/:id/mark-paid: ${preset} required action denies when policy is missing`, async () => {
+    await withExpensePolicyEnv(preset, async () => {
+      let updateCalled = 0;
+      await withPrismaStubs(
+        {
+          'expense.findUnique': async () =>
+            expenseDraft({ status: 'approved', settlementStatus: 'unpaid' }),
+          'actionPolicy.findMany': async () => [],
+          'expense.update': async () => {
+            updateCalled += 1;
+            return { id: 'exp-001' };
+          },
+        },
+        async () => {
+          const server = await buildServer({ logger: false });
+          try {
+            const res = await server.inject({
+              method: 'POST',
+              url: '/expenses/exp-001/mark-paid',
+              headers: adminHeaders(),
+              payload: {},
+            });
+            assert.equal(res.statusCode, 403, res.body);
+            const payload = JSON.parse(res.body);
+            assert.equal(payload?.error?.code, 'ACTION_POLICY_DENIED');
+            assert.equal(updateCalled, 0);
+          } finally {
+            await server.close();
+          }
+        },
+      );
+    });
+  });
+
+  test(`POST /expenses/:id/mark-paid: ${preset} policy allow reaches downstream update path (not ACTION_POLICY_DENIED)`, async () => {
+    await withExpensePolicyEnv(preset, async () => {
+      let updateCalled = 0;
+      await withPrismaStubs(
+        {
+          'expense.findUnique': async () =>
+            expenseDraft({ status: 'approved', settlementStatus: 'unpaid' }),
+          'actionPolicy.findMany': async () => allowPolicy('mark_paid'),
+          'expense.update': async ({ where, data }) => {
+            updateCalled += 1;
+            return {
+              id: where.id,
+              status: 'approved',
+              settlementStatus: data.settlementStatus,
+              paidAt: data.paidAt,
+              paidBy: data.paidBy,
+            };
+          },
+          'expenseStateTransitionLog.create': async () => ({
+            id: 'transition-002',
+          }),
+          'userNotificationPreference.findMany': async () => [],
+          'appNotification.findFirst': async () => ({ id: 'notif-existing' }),
+          'auditLog.create': async () => ({ id: 'audit-002' }),
+        },
+        async () => {
+          const server = await buildServer({ logger: false });
+          try {
+            const res = await server.inject({
+              method: 'POST',
+              url: '/expenses/exp-001/mark-paid',
+              headers: adminHeaders(),
+              payload: {},
+            });
+            assert.equal(res.statusCode, 200, res.body);
+            const payload = JSON.parse(res.body);
+            assert.equal(payload?.id, 'exp-001');
+            assert.equal(payload?.settlementStatus, 'paid');
+            assert.equal(updateCalled, 1);
+          } finally {
+            await server.close();
+          }
+        },
+      );
+    });
+  });
+
+  test(`POST /expenses/:id/unmark-paid: ${preset} required action denies when policy is missing`, async () => {
+    await withExpensePolicyEnv(preset, async () => {
+      let updateCalled = 0;
+      await withPrismaStubs(
+        {
+          'expense.findUnique': async () =>
+            expenseDraft({
+              status: 'approved',
+              settlementStatus: 'paid',
+              paidAt: new Date('2026-01-20T00:00:00.000Z'),
+              paidBy: 'admin-user',
+            }),
+          'actionPolicy.findMany': async () => [],
+          'expense.update': async () => {
+            updateCalled += 1;
+            return { id: 'exp-001' };
+          },
+        },
+        async () => {
+          const server = await buildServer({ logger: false });
+          try {
+            const res = await server.inject({
+              method: 'POST',
+              url: '/expenses/exp-001/unmark-paid',
+              headers: adminHeaders(),
+              payload: { reasonText: 'fix settlement' },
+            });
+            assert.equal(res.statusCode, 403, res.body);
+            const payload = JSON.parse(res.body);
+            assert.equal(payload?.error?.code, 'ACTION_POLICY_DENIED');
+            assert.equal(updateCalled, 0);
+          } finally {
+            await server.close();
+          }
+        },
+      );
+    });
+  });
+
+  test(`POST /expenses/:id/unmark-paid: ${preset} policy allow reaches downstream update path (not ACTION_POLICY_DENIED)`, async () => {
+    await withExpensePolicyEnv(preset, async () => {
+      let updateCalled = 0;
+      await withPrismaStubs(
+        {
+          'expense.findUnique': async () =>
+            expenseDraft({
+              status: 'approved',
+              settlementStatus: 'paid',
+              paidAt: new Date('2026-01-20T00:00:00.000Z'),
+              paidBy: 'admin-user',
+            }),
+          'actionPolicy.findMany': async () => allowPolicy('unmark_paid'),
+          'expense.update': async ({ where, data }) => {
+            updateCalled += 1;
+            return {
+              id: where.id,
+              status: 'approved',
+              settlementStatus: data.settlementStatus,
+              paidAt: data.paidAt,
+              paidBy: data.paidBy,
+            };
+          },
+          'expenseStateTransitionLog.create': async () => ({
+            id: 'transition-003',
+          }),
+          'auditLog.create': async () => ({ id: 'audit-003' }),
+        },
+        async () => {
+          const server = await buildServer({ logger: false });
+          try {
+            const res = await server.inject({
+              method: 'POST',
+              url: '/expenses/exp-001/unmark-paid',
+              headers: adminHeaders(),
+              payload: { reasonText: 'fix settlement' },
+            });
+            assert.equal(res.statusCode, 200, res.body);
+            const payload = JSON.parse(res.body);
+            assert.equal(payload?.id, 'exp-001');
+            assert.equal(payload?.settlementStatus, 'unpaid');
+            assert.equal(updateCalled, 1);
+          } finally {
+            await server.close();
+          }
+        },
+      );
+    });
+  });
+}

--- a/packages/backend/test/purchaseOrderPolicyEnforcementPreset.test.js
+++ b/packages/backend/test/purchaseOrderPolicyEnforcementPreset.test.js
@@ -73,163 +73,165 @@ function purchaseOrderDraft() {
   };
 }
 
-function withPurchaseOrderPolicyEnv(fn) {
+function withPurchaseOrderPolicyEnv(preset, fn) {
   return withEnv(
     {
       DATABASE_URL: process.env.DATABASE_URL || MIN_DATABASE_URL,
       AUTH_MODE: 'header',
-      ACTION_POLICY_ENFORCEMENT_PRESET: 'phase2_core',
+      ACTION_POLICY_ENFORCEMENT_PRESET: preset,
       ACTION_POLICY_REQUIRED_ACTIONS: '',
     },
     fn,
   );
 }
 
-test('POST /purchase-orders/:id/submit: phase2_core required action denies when policy is missing', async () => {
-  await withPurchaseOrderPolicyEnv(async () => {
-    let transactionCalled = 0;
-    await withPrismaStubs(
-      {
-        'purchaseOrder.findUnique': async () => purchaseOrderDraft(),
-        'actionPolicy.findMany': async () => [],
-        $transaction: async () => {
-          transactionCalled += 1;
-          throw new Error('unexpected transaction in deny path');
+for (const preset of ['phase2_core', 'phase3_strict']) {
+  test(`POST /purchase-orders/:id/submit: ${preset} required action denies when policy is missing`, async () => {
+    await withPurchaseOrderPolicyEnv(preset, async () => {
+      let transactionCalled = 0;
+      await withPrismaStubs(
+        {
+          'purchaseOrder.findUnique': async () => purchaseOrderDraft(),
+          'actionPolicy.findMany': async () => [],
+          $transaction: async () => {
+            transactionCalled += 1;
+            throw new Error('unexpected transaction in deny path');
+          },
         },
-      },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'POST',
-            url: '/purchase-orders/po-001/submit',
-            headers: adminHeaders(),
-            payload: {},
-          });
-          assert.equal(res.statusCode, 403, res.body);
-          const payload = JSON.parse(res.body);
-          assert.equal(payload?.error?.code, 'ACTION_POLICY_DENIED');
-          assert.equal(transactionCalled, 0);
-        } finally {
-          await server.close();
-        }
-      },
-    );
+        async () => {
+          const server = await buildServer({ logger: false });
+          try {
+            const res = await server.inject({
+              method: 'POST',
+              url: '/purchase-orders/po-001/submit',
+              headers: adminHeaders(),
+              payload: {},
+            });
+            assert.equal(res.statusCode, 403, res.body);
+            const payload = JSON.parse(res.body);
+            assert.equal(payload?.error?.code, 'ACTION_POLICY_DENIED');
+            assert.equal(transactionCalled, 0);
+          } finally {
+            await server.close();
+          }
+        },
+      );
+    });
   });
-});
 
-test('POST /purchase-orders/:id/submit: policy allow reaches downstream submit path (not ACTION_POLICY_DENIED)', async () => {
-  await withPurchaseOrderPolicyEnv(async () => {
-    let transactionCalled = 0;
-    let updateCalled = 0;
-    const tx = {
-      purchaseOrder: {
-        update: async ({ where, data }) => {
-          updateCalled += 1;
-          return {
-            id: where.id,
+  test(`POST /purchase-orders/:id/submit: ${preset} policy allow reaches downstream submit path (not ACTION_POLICY_DENIED)`, async () => {
+    await withPurchaseOrderPolicyEnv(preset, async () => {
+      let transactionCalled = 0;
+      let updateCalled = 0;
+      const tx = {
+        purchaseOrder: {
+          update: async ({ where, data }) => {
+            updateCalled += 1;
+            return {
+              id: where.id,
+              status: data.status,
+              projectId: 'proj-001',
+            };
+          },
+        },
+        project: {
+          findUnique: async () => null,
+        },
+        approvalRule: {
+          findMany: async () => [
+            {
+              id: 'rule-po-submit',
+              flowType: 'purchase_order',
+              ruleKey: 'purchase-order-default',
+              version: 1,
+              isActive: true,
+              conditions: {},
+              steps: [{ approverUserId: 'admin-user', stepOrder: 1 }],
+            },
+          ],
+        },
+        approvalInstance: {
+          findFirst: async () => null,
+          create: async ({ data }) => ({
+            id: 'approval-001',
+            flowType: data.flowType,
+            targetTable: data.targetTable,
+            targetId: data.targetId,
+            projectId: data.projectId,
             status: data.status,
-            projectId: 'proj-001',
-          };
+            currentStep: data.currentStep,
+            ruleId: data.ruleId,
+            createdBy: data.createdBy,
+            stagePolicy: data.stagePolicy ?? null,
+            steps: (data.steps?.create ?? []).map((step, index) => ({
+              id: `step-${index + 1}`,
+              ...step,
+            })),
+          }),
         },
-      },
-      project: {
-        findUnique: async () => null,
-      },
-      approvalRule: {
-        findMany: async () => [
-          {
-            id: 'rule-po-submit',
-            flowType: 'purchase_order',
-            ruleKey: 'purchase-order-default',
-            version: 1,
-            isActive: true,
-            conditions: {},
-            steps: [{ approverUserId: 'admin-user', stepOrder: 1 }],
-          },
-        ],
-      },
-      approvalInstance: {
-        findFirst: async () => null,
-        create: async ({ data }) => ({
-          id: 'approval-001',
-          flowType: data.flowType,
-          targetTable: data.targetTable,
-          targetId: data.targetId,
-          projectId: data.projectId,
-          status: data.status,
-          currentStep: data.currentStep,
-          ruleId: data.ruleId,
-          createdBy: data.createdBy,
-          stagePolicy: data.stagePolicy ?? null,
-          steps: (data.steps?.create ?? []).map((step, index) => ({
-            id: `step-${index + 1}`,
-            ...step,
-          })),
-        }),
-      },
-      evidenceSnapshot: {
-        findFirst: async () => null,
-        create: async ({ data }) => ({
-          id: 'snapshot-001',
-          approvalInstanceId: data.approvalInstanceId,
-          targetTable: data.targetTable,
-          targetId: data.targetId,
-          version: data.version,
-        }),
-      },
-      annotation: {
-        findUnique: async () => null,
-      },
-      referenceLink: {
-        findMany: async () => [],
-      },
-      chatMessage: {
-        findMany: async () => [],
-      },
-    };
+        evidenceSnapshot: {
+          findFirst: async () => null,
+          create: async ({ data }) => ({
+            id: 'snapshot-001',
+            approvalInstanceId: data.approvalInstanceId,
+            targetTable: data.targetTable,
+            targetId: data.targetId,
+            version: data.version,
+          }),
+        },
+        annotation: {
+          findUnique: async () => null,
+        },
+        referenceLink: {
+          findMany: async () => [],
+        },
+        chatMessage: {
+          findMany: async () => [],
+        },
+      };
 
-    await withPrismaStubs(
-      {
-        'purchaseOrder.findUnique': async () => purchaseOrderDraft(),
-        'actionPolicy.findMany': async () => [
-          {
-            id: 'policy-po-submit-allow',
-            flowType: 'purchase_order',
-            actionKey: 'submit',
-            priority: 100,
-            isEnabled: true,
-            subjects: null,
-            stateConstraints: null,
-            requireReason: false,
-            guards: null,
+      await withPrismaStubs(
+        {
+          'purchaseOrder.findUnique': async () => purchaseOrderDraft(),
+          'actionPolicy.findMany': async () => [
+            {
+              id: 'policy-po-submit-allow',
+              flowType: 'purchase_order',
+              actionKey: 'submit',
+              priority: 100,
+              isEnabled: true,
+              subjects: null,
+              stateConstraints: null,
+              requireReason: false,
+              guards: null,
+            },
+          ],
+          $transaction: async (callback) => {
+            transactionCalled += 1;
+            return callback(tx);
           },
-        ],
-        $transaction: async (callback) => {
-          transactionCalled += 1;
-          return callback(tx);
+          'auditLog.create': async () => ({ id: 'audit-001' }),
         },
-        'auditLog.create': async () => ({ id: 'audit-001' }),
-      },
-      async () => {
-        const server = await buildServer({ logger: false });
-        try {
-          const res = await server.inject({
-            method: 'POST',
-            url: '/purchase-orders/po-001/submit',
-            headers: adminHeaders(),
-            payload: {},
-          });
-          assert.equal(res.statusCode, 200, res.body);
-          const payload = JSON.parse(res.body);
-          assert.equal(payload?.id, 'po-001');
-          assert.equal(payload?.status, 'pending_qa');
-          assert.equal(updateCalled, 1);
-          assert.equal(transactionCalled, 1);
-        } finally {
-          await server.close();
-        }
-      },
-    );
+        async () => {
+          const server = await buildServer({ logger: false });
+          try {
+            const res = await server.inject({
+              method: 'POST',
+              url: '/purchase-orders/po-001/submit',
+              headers: adminHeaders(),
+              payload: {},
+            });
+            assert.equal(res.statusCode, 200, res.body);
+            const payload = JSON.parse(res.body);
+            assert.equal(payload?.id, 'po-001');
+            assert.equal(payload?.status, 'pending_qa');
+            assert.equal(updateCalled, 1);
+            assert.equal(transactionCalled, 1);
+          } finally {
+            await server.close();
+          }
+        },
+      );
+    });
   });
-});
+}


### PR DESCRIPTION
## 概要
- `phase3_strict` でも expense / purchase order の高リスク route preset が `phase2_core` と同じ期待動作を満たすことを backend route test で追加確認
- expense は `submit / mark_paid / unmark_paid`、purchase order は `submit` を対象に、policy 未定義時拒否と policy 定義時の downstream 到達を自動化

## 変更内容
- `packages/backend/test/expensePolicyEnforcementPreset.test.js`
  - `submit / mark_paid / unmark_paid` の deny / allow を `phase3_strict` でも追加検証
- `packages/backend/test/purchaseOrderPolicyEnforcementPreset.test.js`
  - `submit` の deny / allow を `phase3_strict` でも追加検証

## 確認
- `npx prettier --check packages/backend/test/expensePolicyEnforcementPreset.test.js packages/backend/test/purchaseOrderPolicyEnforcementPreset.test.js`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres node --test packages/backend/test/expensePolicyEnforcementPreset.test.js packages/backend/test/purchaseOrderPolicyEnforcementPreset.test.js`
- `git diff --check`

Refs: #1312 #1308
