### PR TITLE
docs: add backup s3 decision checklist

### DIFF
--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -1,10 +1,13 @@
 # バックアップ/リストア（Runbook）
 
 ## 入口
+
 詳細は `docs/requirements/backup-restore.md` を参照。
 DR計画（RTO/RPO/復元演習）は `docs/ops/dr-plan.md` を参照。
+S3 の確定値は `docs/ops/backup-s3-decision-checklist.md` に記録する。
 
 ## PoC/検証（Podman DB）
+
 `scripts/podman-poc.sh` にバックアップ/リストア手順が実装済み。
 
 ```bash
@@ -13,6 +16,6 @@ RESTORE_CONFIRM=1 ./scripts/podman-poc.sh restore
 ```
 
 注意:
+
 - リストアは破壊的操作になり得るため `RESTORE_CONFIRM=1` が必要
 - 必要に応じて `RESTORE_CLEAN=1` でスキーマの作り直しを行う
-

--- a/docs/ops/backup-s3-decision-checklist.md
+++ b/docs/ops/backup-s3-decision-checklist.md
@@ -1,0 +1,74 @@
+# Backup S3 設定決定シート
+
+目的:
+
+- `#544` の未確定項目を 1 枚で埋め、`docs/requirements/backup-restore.md` の暫定値を確定値へ置き換える。
+- S3 readiness 検証 (`make backup-s3-readiness-check` / `make backup-s3-readiness-record`) の前提値を明確にする。
+
+## 基本情報
+
+- decisionDate: YYYY-MM-DD
+- environment: prod|staging
+- owner: `<name>`
+- reviewers: `<name1>, <name2>`
+- relatedIssue: `#544`
+
+## 確定値
+
+- AWS account / project:
+- bucketName:
+- region:
+- s3Prefix:
+- encryptionMode: SSE-KMS|SSE-S3
+- kmsKeyIdOrAlias:
+- kmsKeyAdmin:
+- kmsKeyUsagePrincipals:
+- versioning: Enabled|Suspended
+- lifecycleDailyDays:
+- lifecycleWeeklyWeeks:
+- lifecycleMonthlyMonths:
+- replication / secondary copy:
+- publicAccessBlock: enabled|disabled
+
+## IAM / バケットポリシー
+
+- writeRoleArn:
+- readRoleArn:
+- restoreRoleArn:
+- CI / automation principal:
+- allowedNetworkBoundary: VPC endpoint|IP allowlist|none
+- bucketPolicyNotes:
+
+## 監査 / 責任分界
+
+- restoreApprover:
+- restoreExecutor:
+- auditLogLocation:
+- evidenceRecordPath: `docs/test-results/YYYY-MM-DD-backup-s3-readiness-rN.md`
+- incidentEscalation:
+
+## 検証コマンド
+
+```bash
+S3_BUCKET=... S3_REGION=... EXPECT_SSE=aws:kms SSE_KMS_KEY_ID=... \
+  make backup-s3-readiness-check
+```
+
+```bash
+RUN_CHECK=1 FAIL_ON_CHECK=1 \
+S3_BUCKET=... S3_REGION=... EXPECT_SSE=aws:kms SSE_KMS_KEY_ID=... \
+  make backup-s3-readiness-record
+```
+
+## 確認結果
+
+- summaryStatus: pass|warn|fail
+- summarySource: summary-line|legacy-log-scan
+- warningCount:
+- errorCount:
+- checkExitCode:
+- followUpRequired: yes|no
+
+## 未解決メモ
+
+-

--- a/docs/ops/index.md
+++ b/docs/ops/index.md
@@ -1,10 +1,13 @@
 # 運用ドキュメント（Runbook）
 
 ## 目的
+
 運用・引き継ぎ・障害対応を成立させるための「入口（目次）」です。運用者はまず本ページから辿ることを想定します。
 
 ## 目次
+
 ### 起動/デプロイ
+
 - ローカル/PoC 起動: [deploy-start](deploy-start.md)
 - さくらVPS（Ubuntu単体）+ Podman 試験動作: [sakura-vps-podman-trial](sakura-vps-podman-trial.md)
 - 設定（環境変数/シークレット）: [configuration](configuration.md)
@@ -12,21 +15,26 @@
   - DBユーザ最小権限（ロール分離）: [db-roles](db-roles.md)
 
 ### バックアップ/リストア
+
 - [backup-restore](backup-restore.md)
   - DR計画（RTO/RPO/復元演習）: [dr-plan](dr-plan.md)
   - 詳細: [docs/requirements/backup-restore.md](../requirements/backup-restore.md)
+  - S3決定シート: [backup-s3-decision-checklist](backup-s3-decision-checklist.md)
 
 ### 移行（Project-Open → ERP4）
+
 - [migration](migration.md)
   - 詳細: [docs/requirements/migration-runbook.md](../requirements/migration-runbook.md)
 
 ### 添付AVスキャン
+
 - [antivirus](antivirus.md)
   - 最終決定記録: [antivirus-decision-record](antivirus-decision-record.md)
   - 運用判断メモ: [antivirus-decision-proposal](antivirus-decision-proposal.md)
   - 詳細: [docs/requirements/chat-attachments-antivirus.md](../requirements/chat-attachments-antivirus.md)
 
 ### 監視/障害対応
+
 - health/readiness/ログ: [observability](observability.md)
 - SLI/SLO（暫定）: [slo](slo.md)
 - アラート設計: [alerting](alerting.md)
@@ -37,16 +45,19 @@
   - 既存資料: [docs/requirements/ops-monitoring.md](../requirements/ops-monitoring.md)
 
 ### リリース
+
 - 入口: [release](release.md)
 - 戦略/詳細: [release-strategy](release-strategy.md)
 - チェックリスト: [release-checklist](release-checklist.md)
 - Feature Flag 運用: [feature-flags](feature-flags.md)
 
 ### セキュリティ運用
+
 - [security](security.md)
   - ベースライン: [docs/security/security-baseline.md](../security/security-baseline.md)
 
 ### 性能
+
 - ベースライン（再計測手順）: [docs/performance/performance-baseline.md](../performance/performance-baseline.md)
 - 退行検知ポリシー: [docs/performance/perf-regression-policy.md](../performance/perf-regression-policy.md)
 - 計測結果: [docs/test-results/README.md](../test-results/README.md)

--- a/docs/requirements/backup-restore.md
+++ b/docs/requirements/backup-restore.md
@@ -1,21 +1,25 @@
 # バックアップ/リストア手順（草案）
 
 ## 対象範囲
+
 - PostgreSQL データベース（必須）
 - PDF ファイル（PDF_PROVIDER=local の場合）
 - 環境設定/シークレット（別管理）
 
 ## バックアップ方針（案）
+
 - DB: 日次の論理バックアップ（`pg_dump`）
 - 重要テーブルは週次でフルバックアップ
 - ロール/権限は `pg_dumpall --globals-only`
 
 ## バックアップ手順（例）
+
 1. `pg_dump` でスキーマ + データを取得
 2. 世代管理（例: 7日分）で保存
 3. リストア検証用に別DBへ復元
 
 ### Podman（PoC）での例
+
 - バックアップ（SQL）
   - `podman exec -e PGPASSWORD=postgres erp4-pg-poc sh -c "pg_dump -U postgres -d postgres" > /tmp/erp4-backup.sql`
 - バックアップ（globals）
@@ -31,16 +35,19 @@
   - 備考: `BACKUP_FILE`/`BACKUP_GLOBALS_FILE` は任意パス指定なので、信頼できる入力のみ使用する
 
 ## リストア手順（例）
+
 1. 空の DB を作成
 2. `psql` でバックアップを投入
 3. 接続/主要 API のスモーク確認
 
 ### Podman（PoC）での例
+
 - 必要に応じて `./scripts/podman-poc.sh start` でDBを起動
 - リストア後は `./scripts/podman-poc.sh check` で件数/金額の整合を確認
 - `RESTORE_CONFIRM=1` を付けた場合のみ restore が実行される
 
 ### 本番向けスクリプト（AWS/S3 例）
+
 - バックアップ（DB/グローバル/メタデータ/任意で添付）
   - `./scripts/backup-prod.sh backup`
 - S3 へアップロード（既存ローカルバックアップを転送）
@@ -50,6 +57,7 @@
   - `RESTORE_CONFIRM=1 ./scripts/backup-prod.sh restore`
 
 ### 検証環境（ローカル + 別ホスト退避 + 暗号化）
+
 - GPG で暗号化し、別ホストへ転送
   - `GPG_RECIPIENT=backup@example.com REMOTE_HOST=backup-host REMOTE_DIR=/var/backups/erp4 ./scripts/backup-prod.sh backup`
 - 別ホストから最新を取得してリストア
@@ -57,6 +65,7 @@
   - `RESTORE_CONFIRM=1 ASSET_DIR=/var/erp4-assets ./scripts/backup-prod.sh restore`
 
 注意:
+
 - `REMOTE_HOST` を指定した場合は `REMOTE_DIR` が必須
 - `REMOTE_KEEP_DAYS` を指定すると別ホスト側も世代削除を実行
 - GPGで暗号化した場合は復号用の鍵がローカルに必要（`GPG_HOME` を必要に応じて指定）
@@ -67,6 +76,7 @@
 - `SKIP_GLOBALS` を指定しない場合は globals ファイル必須（欠損時は restore を失敗させる）
 
 必要な環境変数（抜粋）
+
 - `DB_HOST`/`DB_PORT`/`DB_USER`/`DB_PASSWORD`/`DB_NAME`
 - `S3_BUCKET`/`S3_PREFIX`/`S3_REGION`/`S3_ENDPOINT_URL`
 - `SSE_KMS_KEY_ID` または `SSE_S3`（例: `AES256`）
@@ -80,6 +90,7 @@
 - 参考テンプレート: `docs/requirements/backup-restore.env.example`
 
 ## 保持期間/世代管理（決定）
+
 - 日次: 14日分
 - 週次: 8週分
 - 月次: 12か月分
@@ -87,6 +98,7 @@
 - 保管先は本番とは別リージョン/別アカウントに1世代以上保持
 
 ### RPO/RTO 目標（決定）
+
 - RPO: 通常データは最大24時間分の損失を許容（原則: 日次バックアップ）
 - RPO: 重要データは最大6時間分の損失を許容（運用で6時間ごとのバックアップを前提）
 - RTO: 通常データは4時間以内に復旧（DB + PDF/添付 + 主要設定）
@@ -94,12 +106,14 @@
   - 検知と対応開始の目標は30分以内（RTOには含めない）
 
 ## 暗号化/保管先（決定）
+
 - 保管先: オブジェクトストレージ（S3互換など）
 - 暗号化: KMSによるサーバーサイド暗号化を必須
 - 追加保護が必要な場合は `pg_dump` 生成物をGPGで二重暗号化
 - 復号キーの権限は管理部/経営の二重管理
 
 ## 本番運用（決定）
+
 - 実行タイミング: 深夜帯の日次（例: 02:00 JST）
 - 取得形式: `pg_dump -Fc`（DB）+ `pg_dumpall --globals-only`（ロール/権限）
 - 保存先: `s3://erp4-backups/erp4/<env>/{db,globals,assets,meta}/`（暫定。`<env>` は `prod` / `staging` など環境名に合わせて `S3_PREFIX` と一致させる）
@@ -109,14 +123,17 @@
 - 保持期間は S3 Lifecycle で管理（ローカル削除とは別）
 
 ### S3準備チェックリスト（未確定項目の整理）
+
 - バケット名: `s3://erp4-backups`（暫定）
 - リージョン: `ap-northeast-1`（暫定）
 - KMS: `alias/erp4-backup`（暫定、管理アカウント/キー管理者の決定が必要）
 - Versioning/Lifecycle: 保持期間に合わせたルールを設定
 - IAM権限: 書き込み専用/読み取り専用のロール分離
 - バケットポリシー: 退避先のアクセス制限（IP制限やVPCエンドポイント）
+- 決定シート: `docs/ops/backup-s3-decision-checklist.md` を更新し、確定値と責任分界を明文化する
 
 #### S3 事前検証コマンド
+
 - `scripts/check-backup-s3-readiness.sh` で設定値とS3状態を検証できる
   - 入力値バリデーション:
     - `STRICT`: `0|1`（既定: `1`）
@@ -147,25 +164,30 @@
   - 日付検証は GNU/BSD 両方の `date` 実装に対応（Linux/macOS の混在環境で実行可能）。
 
 ## S3/OSS 移行の開始条件（叩き台）
+
 - バケット/KMS/権限分離の準備が完了している
 - リストア検証が成功し、手順がドキュメント化されている
 - 監査ログ/復元承認の運用ルールが確定している
   - 切替後1週間はローカル/別ホストの並行保持を行う（暫定）
 
 ## 運用フロー/責任分界（案）
+
 - インフラ担当: バケット/KMS/IAM/ライフサイクルの管理
 - 運用担当: バックアップ実行/リストア検証の実施と記録
 - 管理部: 復元の実行承認、監査ログの確認
 - 経営: 復元の最終承認（重大障害時）
 
 ## 暫定運用（S3未整備の間）
+
 - ローカル保存 + 別ホスト退避 + GPG 暗号化
 - 退避先は rsync/scp で同期（`REMOTE_HOST`/`REMOTE_DIR`）
 - 別ホスト側の保持期間は `REMOTE_KEEP_DAYS` で管理（未指定の場合は手動）
 - S3移行後は1週間の並行保持を行い、問題なければローカル/別ホスト運用を廃止
 
 ## リストア検証（案）
+
 ### 定期リストア検証（暫定）
+
 - 頻度: 月次（第1営業日）
 - 手順:
   1. 退避先から最新を取得（S3 または REMOTE_HOST）
@@ -176,12 +198,14 @@
 - 失敗時は原因と対応を記録し、次回の手順を更新
 
 ## PDF/添付の扱い（案）
+
 - `PDF_PROVIDER=local` の場合は保存ディレクトリをバックアップ対象に含める
 - ストレージに移行する場合はオブジェクトストレージのライフサイクルポリシーを併用
 - 復元時は DB と PDF の世代を揃える（復元時刻の一致を記録）
 - 暫定運用: S3未整備の間はローカル保存 + 別ホスト退避 + GPG 暗号化で運用する
 
 ### PDF/添付のS3/OSS移行手順（叩き台）
+
 1. バケット準備（Versioning/Lifecycle/KMS/権限分離）
 2. 保存/参照のストレージレイヤーを追加（ローカル以外を選べる実装）
 3. 既存ローカル資産をOSSへ移行（件数/サイズ/ハッシュで整合確認）
@@ -190,12 +214,14 @@
 6. 切替後の監査・復元手順を更新し、次回検証に反映
 
 ## 検証チェックリスト
+
 - 主要テーブルの件数が一致
 - 最新データが復元されている
 - バッチ実行が再開できる
 
 ## TODO
+
 - 本番環境の保持期間/暗号化方針の確定【決定済み】
 - PDF/添付のバックアップ方式を最終決定【決定済み: ローカル+別ホスト退避】
-- S3 バケット名/リージョン/KMS の確定値を反映
+- `docs/ops/backup-s3-decision-checklist.md` を埋めて bucket/region/KMS/IAM/lifecycle の確定値を反映
 - S3/OSS 移行の時期を決定（未定）


### PR DESCRIPTION
## 概要
- `#544` の未確定項目を 1 枚で埋められる S3 設定決定シートを追加
- バックアップ/リストア要件と runbook から新シートへ到達できるよう導線を追加

## 変更内容
- 追加: `docs/ops/backup-s3-decision-checklist.md`
- 更新: `docs/requirements/backup-restore.md`
- 更新: `docs/ops/backup-restore.md`
- 更新: `docs/ops/index.md`

## 背景
- `#544` は bucket / region / KMS / lifecycle / IAM / 責任分界の確定値が未入力のまま残っている
- 実装や検証スクリプトは既に揃っているため、次の前進は意思決定情報を埋めるための定型化が妥当

## 影響
- ドキュメントのみ
- 実装や実行スクリプトには変更なし

## 検証
- `npx prettier --check docs/ops/backup-s3-decision-checklist.md docs/requirements/backup-restore.md docs/ops/backup-restore.md docs/ops/index.md`
- `git diff --check`
