### PR TITLE
chore: add make target for action policy phase3 trial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint format-check typecheck build test e2e ui-evidence mobile-regression-log frontend-dev-api podman-smoke pr-comments audit docs-image-links-check design-system-package-check eslint10-readiness-check eslint10-readiness-record dependabot-alerts-check dependabot-alerts-record dependabot-token-readiness-check backup-s3-readiness-check backup-s3-readiness-record po-migration-input-readiness-check po-migration-record po-migration-run-and-record av-staging-evidence av-staging-gate av-staging-readiness action-policy-fallback-report action-policy-fallback-report-json action-policy-phase3-readiness action-policy-phase3-readiness-json action-policy-phase3-readiness-record action-policy-phase3-cutover-record
+.PHONY: lint format-check typecheck build test e2e ui-evidence mobile-regression-log frontend-dev-api podman-smoke pr-comments audit docs-image-links-check design-system-package-check eslint10-readiness-check eslint10-readiness-record dependabot-alerts-check dependabot-alerts-record dependabot-token-readiness-check backup-s3-readiness-check backup-s3-readiness-record po-migration-input-readiness-check po-migration-record po-migration-run-and-record av-staging-evidence av-staging-gate av-staging-readiness action-policy-fallback-report action-policy-fallback-report-json action-policy-phase3-readiness action-policy-phase3-readiness-json action-policy-phase3-readiness-record action-policy-phase3-cutover-record action-policy-phase3-trial-record
 
 lint:
 	npm run lint --prefix packages/backend
@@ -104,3 +104,6 @@ action-policy-phase3-readiness-record:
 
 action-policy-phase3-cutover-record:
 	./scripts/record-action-policy-phase3-cutover.sh
+
+action-policy-phase3-trial-record:
+	./scripts/run-and-record-action-policy-phase3-trial.sh

--- a/docs/manual/agent-write-guardrails-guide.md
+++ b/docs/manual/agent-write-guardrails-guide.md
@@ -55,7 +55,7 @@
    - `fallback_medium_risk_keys: 0`
    - `fallback_unknown_risk_keys: 0`
 4. 収束判定後に `ACTION_POLICY_ENFORCEMENT_PRESET=phase3_strict` へ切り替える（`*:*` 相当）。
-5. 切替準備から切替記録までをまとめて開始する場合は `./scripts/run-and-record-action-policy-phase3-trial.sh` を使う。readiness record と cutover record が同じ run label で生成される。
+5. 切替準備から切替記録までをまとめて開始する場合は `make action-policy-phase3-trial-record` を使う。内部では `./scripts/run-and-record-action-policy-phase3-trial.sh` を呼び出し、readiness record と cutover record が同じ run label で生成される。
 6. 切替記録だけを個別に更新する場合は `make action-policy-phase3-cutover-record` で `docs/test-results/YYYY-MM-DD-action-policy-phase3-cutover-rN.md` を生成する。
 
 ### 切替前の確認コマンド
@@ -107,14 +107,14 @@ make action-policy-fallback-report-json
    - `make action-policy-phase3-readiness-json`
    - `make action-policy-phase3-readiness-record`
    - `make action-policy-phase3-cutover-record`
-   - `./scripts/run-and-record-action-policy-phase3-trial.sh`
+   - `make action-policy-phase3-trial-record`
    - `make action-policy-fallback-report`
    - `make action-policy-fallback-report-json`
 3. readiness report が `ready: no` の場合は `blockers` と `fallback keys` を起点に未収束箇所を特定し、ActionPolicy 追加に反映する。
 4. 補足: `action_policy_fallback_allowed` は実装上、`flowType/actionKey/targetTable` ごとにプロセス内で 1 回だけ記録されるため、レポートの `count` は実発生回数ではなくキー検出用の下限値として扱う。
 5. `make action-policy-phase3-readiness-record` は `tmp/action-policy-phase3-readiness/run-*` に text/json の観測結果を保存し、`docs/test-results/YYYY-MM-DD-action-policy-phase3-readiness-rN.md` を生成する。
 6. `make action-policy-phase3-cutover-record` は直近の readiness 記録を参照し、切替・主要操作確認・ロールバック結果を記入するための `docs/test-results/YYYY-MM-DD-action-policy-phase3-cutover-rN.md` を生成する。
-7. `./scripts/run-and-record-action-policy-phase3-trial.sh` は上記 2 つを連続実行し、同じ run label の readiness/cutover 記録を一対で作成する。
+7. `make action-policy-phase3-trial-record` は上記 2 つを連続実行し、同じ run label の readiness/cutover 記録を一対で作成する。
 
 ## 実行フロー（請求送信の標準例）
 

--- a/docs/manual/manual-test-checklist.md
+++ b/docs/manual/manual-test-checklist.md
@@ -34,11 +34,11 @@
   - 手順: `docs/manual/agent-write-guardrails-guide.md` の fail-safe 運用手順に従う
   - 前提: `npm run build --prefix packages/backend` 実行済み、`DATABASE_URL` 設定済み
   - 記録: `make action-policy-phase3-readiness-record` で `docs/test-results/YYYY-MM-DD-action-policy-phase3-readiness-rN.md` を生成できる
-  - 連続実行する場合: `./scripts/run-and-record-action-policy-phase3-trial.sh`
+  - 連続実行する場合: `make action-policy-phase3-trial-record`
   - 最低確認対象: `invoice:send`, `invoice:mark_paid`, `purchase_order:send`, `expense:submit`, `expense:mark_paid`, `vendor_invoice:submit`, `vendor_invoice:update_lines`, `vendor_invoice:update_allocations`, `*:approve`, `*:reject`
 - [ ] `phase2_core` -> `phase3_strict` の切替後も主要操作が継続し、`action_policy_fallback_allowed` の新規発生がないことを確認する
   - 記録: `make action-policy-phase3-cutover-record`
-  - 連続実行する場合: `./scripts/run-and-record-action-policy-phase3-trial.sh`
+  - 連続実行する場合: `make action-policy-phase3-trial-record`
 - [ ] `make action-policy-fallback-report` / `make action-policy-fallback-report-json` で fallback 集計を確認し、`flowType:actionKey:targetTable` ベースで未収束キーが 0 件であることを確認する
 - [ ] 問題発生時に `phase3_strict` -> `phase2_core` のロールバックと、必要な `ACTION_POLICY_REQUIRED_ACTIONS` 明示指定での段階復旧を確認する
   - ロールバック後は `make action-policy-phase3-readiness-json` と `make action-policy-fallback-report-json` で復旧対象キーのみが再出現していることを確認する

--- a/docs/test-results/action-policy-phase3-cutover-template.md
+++ b/docs/test-results/action-policy-phase3-cutover-template.md
@@ -29,6 +29,11 @@ make action-policy-fallback-report
 make action-policy-fallback-report-json
 ```
 
+```bash
+# readiness と cutover 記録を同じ run label で開始する場合
+make action-policy-phase3-trial-record
+```
+
 - [ ] `phase3_strict` へ切替した
 - [ ] アプリ再起動 / 再デプロイを実施した
 

--- a/docs/test-results/action-policy-phase3-readiness-template.md
+++ b/docs/test-results/action-policy-phase3-readiness-template.md
@@ -17,6 +17,8 @@ make action-policy-fallback-report-json
 ```bash
 # 推奨: 観測結果と docs/test-results 記録を一括生成
 make action-policy-phase3-readiness-record
+# readiness 記録から cutover 記録まで続けて開始する場合
+make action-policy-phase3-trial-record
 ```
 
 ## 前提


### PR DESCRIPTION
## 概要
- `run-and-record-action-policy-phase3-trial.sh` を `make` から実行できるようにし、運用手順を `make` ベースへ統一
- fail-safe manual / checklist / test-results template の参照コマンドを同期

## 変更内容
- `Makefile`
  - `action-policy-phase3-trial-record` を追加
- `docs/manual/agent-write-guardrails-guide.md`
- `docs/manual/manual-test-checklist.md`
- `docs/test-results/action-policy-phase3-readiness-template.md`
- `docs/test-results/action-policy-phase3-cutover-template.md`

## テスト
- `npx prettier --write docs/manual/agent-write-guardrails-guide.md docs/manual/manual-test-checklist.md docs/test-results/action-policy-phase3-readiness-template.md docs/test-results/action-policy-phase3-cutover-template.md`
- `make -n action-policy-phase3-trial-record`
- `git diff --check`

## 関連
- #1312
- #1308
