### PR TITLE
docs: index action policy phase3 records

### DIFF
--- a/docs/requirements/action-policy-failsafe-inventory.md
+++ b/docs/requirements/action-policy-failsafe-inventory.md
@@ -189,3 +189,4 @@ node scripts/report-action-policy-phase3-readiness.mjs --format=text
   - 主要業務の route preset / send preset（send + evidence gate）回帰テスト（invoice / purchase_order / expense / vendor_invoice / estimate / time / leave / approval）が green
   - required actions ギャップレポートで static callsite の missing 0
   - 試験運用時は `make action-policy-phase3-readiness-record` で readiness / fallback 集計の証跡を `docs/test-results/` に保存する
+  - readiness 記録から cutover 記録までまとめて開始する場合は `make action-policy-phase3-trial-record` を使い、同じ run label の readiness / cutover 記録を一対で残す

--- a/docs/test-results/README.md
+++ b/docs/test-results/README.md
@@ -20,6 +20,8 @@
 - S3バックアップ readiness 記録テンプレート: docs/test-results/backup-s3-readiness-template.md
 - ESLint10 readiness 記録テンプレート: docs/test-results/eslint10-readiness-template.md
 - Dependabot alerts 監視記録テンプレート: docs/test-results/dependabot-alerts-template.md
+- ActionPolicy phase3 readiness 記録テンプレート: docs/test-results/action-policy-phase3-readiness-template.md
+- ActionPolicy phase3 cutover 記録テンプレート: docs/test-results/action-policy-phase3-cutover-template.md
 - チャット添付AV（Staging）検証テンプレート: docs/test-results/chat-attachments-av-staging-template.md
 - DRリストア運用検証テンプレート: docs/test-results/dr-restore-template.md
 - モバイル回帰証跡テンプレート: docs/test-results/mobile-regression-template.md


### PR DESCRIPTION
## 概要
- ActionPolicy phase3 readiness / cutover のテンプレートを `docs/test-results/README.md` に索引追加
- fail-safe inventory に `make action-policy-phase3-trial-record` を追記し、試験運用時の一括記録導線を明確化

## 変更内容
- `docs/test-results/README.md`
  - ActionPolicy phase3 readiness/cutover テンプレートを追加
- `docs/requirements/action-policy-failsafe-inventory.md`
  - `make action-policy-phase3-trial-record` の利用意図を追記

## テスト
- `npx prettier --write docs/test-results/README.md docs/requirements/action-policy-failsafe-inventory.md`
- `git diff --check`

## 関連
- #1312
- #1308
