### PR TITLE
ops: validate backup S3 decision checklist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint format-check typecheck build test e2e ui-evidence mobile-regression-log frontend-dev-api podman-smoke pr-comments audit docs-image-links-check design-system-package-check eslint10-readiness-check eslint10-readiness-record dependabot-alerts-check dependabot-alerts-record dependabot-token-readiness-check dependency-watch-record backup-s3-readiness-check backup-s3-readiness-record po-migration-input-readiness-check po-migration-record po-migration-run-and-record av-staging-evidence av-staging-gate av-staging-readiness action-policy-fallback-report action-policy-fallback-report-json action-policy-phase3-readiness action-policy-phase3-readiness-json action-policy-phase3-readiness-record action-policy-phase3-cutover-record action-policy-phase3-trial-record
+.PHONY: lint format-check typecheck build test e2e ui-evidence mobile-regression-log frontend-dev-api podman-smoke pr-comments audit docs-image-links-check design-system-package-check eslint10-readiness-check eslint10-readiness-record dependabot-alerts-check dependabot-alerts-record dependabot-token-readiness-check dependency-watch-record backup-s3-decision-check backup-s3-readiness-check backup-s3-readiness-record po-migration-input-readiness-check po-migration-record po-migration-run-and-record av-staging-evidence av-staging-gate av-staging-readiness action-policy-fallback-report action-policy-fallback-report-json action-policy-phase3-readiness action-policy-phase3-readiness-json action-policy-phase3-readiness-record action-policy-phase3-cutover-record action-policy-phase3-trial-record
 
 lint:
 	npm run lint --prefix packages/backend
@@ -65,6 +65,9 @@ dependabot-token-readiness-check:
 
 dependency-watch-record:
 	./scripts/run-and-record-dependency-watch.sh
+
+backup-s3-decision-check:
+	node scripts/check-backup-s3-decision-checklist.mjs
 
 backup-s3-readiness-check:
 	./scripts/check-backup-s3-readiness.sh

--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -4,7 +4,7 @@
 
 詳細は `docs/requirements/backup-restore.md` を参照。
 DR計画（RTO/RPO/復元演習）は `docs/ops/dr-plan.md` を参照。
-S3 の確定値は `docs/ops/backup-s3-decision-checklist.md` に記録する。
+S3 の確定値は `docs/ops/backup-s3-decision-checklist.md` に記録する。入力妥当性は `make backup-s3-decision-check` で確認する。
 
 ## PoC/検証（Podman DB）
 

--- a/docs/ops/backup-s3-decision-checklist.md
+++ b/docs/ops/backup-s3-decision-checklist.md
@@ -74,3 +74,12 @@ S3_BUCKET=... S3_REGION=... EXPECT_SSE=aws:kms SSE_KMS_KEY_ID=... \
 ## 未解決メモ
 
 -
+
+## 自動検証
+
+```bash
+make backup-s3-decision-check
+```
+
+- `decisionDate` / `environment` / bucket / region / lifecycle / IAM / 責任分界の必須項目を検証する。
+- `SSE-S3` を選ぶ場合のみ、KMS 固有項目は `N/A` を許容する。

--- a/docs/quality/test-gaps.md
+++ b/docs/quality/test-gaps.md
@@ -26,7 +26,7 @@
 | Agent-First E2E（失敗系）                                  | 完了     | 承認不足（`APPROVAL_REQUIRED`）/証跡不足（`EVIDENCE_REQUIRED`）/理由不足（`REASON_REQUIRED`）を `packages/frontend/e2e/backend-agent-first-mvp.spec.ts` で検証。監査ログUIの AgentRun ドリルダウンを `packages/frontend/e2e/frontend-smoke-audit-agent-run.spec.ts` で検証 |
 | manual-test-checklist と自動テスト対応                     | 部分実装 | Agent-First失敗系の自動テスト参照を明示                                                                                                                                                                                                                                    |
 | #543 preflight（入力不足/形式不正）                        | 完了     | `packages/backend/test/readinessScripts.test.js` で `check-po-migration-input-readiness.sh` の主要失敗分岐・SUMMARY 行、および `generate-po-migration-report.mjs` の preflight セクション生成を自動検証                                                                    |
-| #544 readiness（前提不足時の失敗理由）                     | 完了     | `packages/backend/test/readinessScripts.test.js` で `check-backup-s3-readiness.sh` の主要失敗分岐（aws未導入 / EXPECT_SSE不正）を自動検証                                                                                                                                  |
+| #544 readiness / decision 入力妥当性                       | 完了     | `packages/backend/test/readinessScripts.test.js` で `check-backup-s3-readiness.sh` の主要失敗分岐（aws未導入 / EXPECT_SSE不正）と `check-backup-s3-decision-checklist.mjs` の placeholder / SSE-S3 条件分岐 / 妥当入力を自動検証                                           |
 
 ## 領域別の整理（現状）
 

--- a/docs/requirements/backup-restore.md
+++ b/docs/requirements/backup-restore.md
@@ -131,6 +131,7 @@
 - IAM権限: 書き込み専用/読み取り専用のロール分離
 - バケットポリシー: 退避先のアクセス制限（IP制限やVPCエンドポイント）
 - 決定シート: `docs/ops/backup-s3-decision-checklist.md` を更新し、確定値と責任分界を明文化する
+  - 入力妥当性は `make backup-s3-decision-check` で検証する
 
 #### S3 事前検証コマンド
 

--- a/packages/backend/test/readinessScripts.test.js
+++ b/packages/backend/test/readinessScripts.test.js
@@ -309,6 +309,155 @@ test('check-backup-s3-readiness: emits machine-readable SUMMARY line', () => {
   });
 });
 
+test('check-backup-s3-decision-checklist: fails when placeholders remain', () => {
+  withTempDir((dir) => {
+    const checklistPath = path.join(dir, 'backup-s3-decision-checklist.md');
+    writeFileSync(
+      checklistPath,
+      [
+        '# Backup S3 設定決定シート',
+        '',
+        '- decisionDate: YYYY-MM-DD',
+        '- environment: prod',
+        '- owner: <name>',
+        '- reviewers: alice, bob',
+        '- relatedIssue: #544',
+        '- AWS account / project: prod-shared',
+        '- bucketName: erp4-backups',
+        '- region: ap-northeast-1',
+        '- s3Prefix: erp4/prod',
+        '- encryptionMode: SSE-KMS',
+        '- kmsKeyIdOrAlias: alias/erp4-backup',
+        '- kmsKeyAdmin: <name>',
+        '- kmsKeyUsagePrincipals: ops-backup-role',
+        '- versioning: Enabled',
+        '- lifecycleDailyDays: 14',
+        '- lifecycleWeeklyWeeks: 8',
+        '- lifecycleMonthlyMonths: 12',
+        '- replication / secondary copy: none',
+        '- publicAccessBlock: enabled',
+        '- writeRoleArn: arn:aws:iam::123456789012:role/erp4-backup-write',
+        '- readRoleArn: arn:aws:iam::123456789012:role/erp4-backup-read',
+        '- restoreRoleArn: arn:aws:iam::123456789012:role/erp4-backup-restore',
+        '- CI / automation principal: github-actions',
+        '- allowedNetworkBoundary: VPC endpoint',
+        '- bucketPolicyNotes: allow only backup principals',
+        '- restoreApprover: ops-manager',
+        '- restoreExecutor: platform-team',
+        '- auditLogLocation: cloudtrail://backup',
+        '- incidentEscalation: oncall-platform',
+      ].join('\n'),
+    );
+
+    const res = runNodeScript('check-backup-s3-decision-checklist.mjs', [
+      `--file=${checklistPath}`,
+    ]);
+    assert.equal(res.status, 1, `${res.stderr}\n${res.stdout}`);
+    assert.match(String(res.stdout), /field=decisionDate/);
+    assert.match(String(res.stdout), /field=owner/);
+    assert.match(String(res.stdout), /field=kmsKeyAdmin/);
+  });
+});
+
+test('check-backup-s3-decision-checklist: passes with populated SSE-KMS checklist', () => {
+  withTempDir((dir) => {
+    const checklistPath = path.join(dir, 'backup-s3-decision-checklist.md');
+    writeFileSync(
+      checklistPath,
+      [
+        '# Backup S3 設定決定シート',
+        '',
+        '- decisionDate: 2026-03-08',
+        '- environment: prod',
+        '- owner: platform-team',
+        '- reviewers: security-lead, finance-owner',
+        '- relatedIssue: #544',
+        '- AWS account / project: prod-shared',
+        '- bucketName: erp4-backups-prod',
+        '- region: ap-northeast-1',
+        '- s3Prefix: erp4/prod',
+        '- encryptionMode: SSE-KMS',
+        '- kmsKeyIdOrAlias: alias/erp4-backup',
+        '- kmsKeyAdmin: security-team',
+        '- kmsKeyUsagePrincipals: arn:aws:iam::123456789012:role/erp4-backup-write',
+        '- versioning: Enabled',
+        '- lifecycleDailyDays: 14',
+        '- lifecycleWeeklyWeeks: 8',
+        '- lifecycleMonthlyMonths: 12',
+        '- replication / secondary copy: cross-account vault',
+        '- publicAccessBlock: enabled',
+        '- writeRoleArn: arn:aws:iam::123456789012:role/erp4-backup-write',
+        '- readRoleArn: arn:aws:iam::123456789012:role/erp4-backup-read',
+        '- restoreRoleArn: arn:aws:iam::123456789012:role/erp4-backup-restore',
+        '- CI / automation principal: github-actions-prod',
+        '- allowedNetworkBoundary: VPC endpoint',
+        '- bucketPolicyNotes: write/read/restore roles only',
+        '- restoreApprover: finance-director',
+        '- restoreExecutor: sre-oncall',
+        '- auditLogLocation: cloudtrail://prod-backup-audit',
+        '- incidentEscalation: sev-1-oncall',
+      ].join('\n'),
+    );
+
+    const res = runNodeScript('check-backup-s3-decision-checklist.mjs', [
+      `--file=${checklistPath}`,
+      '--format=json',
+    ]);
+    assert.equal(res.status, 0, `${res.stderr}\n${res.stdout}`);
+    const payload = JSON.parse(String(res.stdout));
+    assert.equal(payload.status, 'pass');
+    assert.equal(payload.issueCount, 0);
+  });
+});
+
+test('check-backup-s3-decision-checklist: allows blank KMS fields for SSE-S3', () => {
+  withTempDir((dir) => {
+    const checklistPath = path.join(dir, 'backup-s3-decision-checklist.md');
+    writeFileSync(
+      checklistPath,
+      [
+        '# Backup S3 設定決定シート',
+        '',
+        '- decisionDate: 2026-03-08',
+        '- environment: staging',
+        '- owner: platform-team',
+        '- reviewers: security-lead, finance-owner',
+        '- relatedIssue: #544',
+        '- AWS account / project: staging-shared',
+        '- bucketName: erp4-backups-staging',
+        '- region: ap-northeast-1',
+        '- s3Prefix: erp4/staging',
+        '- encryptionMode: SSE-S3',
+        '- kmsKeyIdOrAlias: N/A',
+        '- kmsKeyAdmin: N/A',
+        '- kmsKeyUsagePrincipals: N/A',
+        '- versioning: Enabled',
+        '- lifecycleDailyDays: 7',
+        '- lifecycleWeeklyWeeks: 4',
+        '- lifecycleMonthlyMonths: 6',
+        '- replication / secondary copy: none',
+        '- publicAccessBlock: enabled',
+        '- writeRoleArn: arn:aws:iam::123456789012:role/erp4-staging-backup-write',
+        '- readRoleArn: arn:aws:iam::123456789012:role/erp4-staging-backup-read',
+        '- restoreRoleArn: arn:aws:iam::123456789012:role/erp4-staging-backup-restore',
+        '- CI / automation principal: github-actions-staging',
+        '- allowedNetworkBoundary: none',
+        '- bucketPolicyNotes: staging only',
+        '- restoreApprover: staging-manager',
+        '- restoreExecutor: platform-team',
+        '- auditLogLocation: cloudtrail://staging-backup-audit',
+        '- incidentEscalation: platform-oncall',
+      ].join('\n'),
+    );
+
+    const res = runNodeScript('check-backup-s3-decision-checklist.mjs', [
+      `--file=${checklistPath}`,
+    ]);
+    assert.equal(res.status, 0, `${res.stderr}\n${res.stdout}`);
+    assert.match(String(res.stdout), /status: pass/);
+  });
+});
+
 test('record-backup-s3-readiness: writes a report from an existing log file', () => {
   withTempDir((dir) => {
     const logPath = path.join(dir, 'backup-s3-readiness.log');

--- a/scripts/check-backup-s3-decision-checklist.mjs
+++ b/scripts/check-backup-s3-decision-checklist.mjs
@@ -1,0 +1,347 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const DEFAULT_FILE = path.join(
+  ROOT_DIR,
+  "docs/ops/backup-s3-decision-checklist.md",
+);
+
+function parseArgs(argv) {
+  const options = {
+    file: DEFAULT_FILE,
+    format: "text",
+  };
+
+  for (const arg of argv) {
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      continue;
+    }
+    if (arg.startsWith("--file=")) {
+      options.file = path.resolve(process.cwd(), arg.slice("--file=".length));
+      continue;
+    }
+    if (arg.startsWith("--format=")) {
+      options.format = arg.slice("--format=".length);
+      continue;
+    }
+    throw new Error(`unknown arg: ${arg}`);
+  }
+
+  if (!["text", "json"].includes(options.format)) {
+    throw new Error(`--format must be text|json (got: ${options.format})`);
+  }
+
+  return options;
+}
+
+function normalizeFieldName(raw) {
+  return raw.trim();
+}
+
+function normalizeValue(raw) {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("`") && trimmed.endsWith("`") && trimmed.length >= 2) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+function parseChecklist(markdown) {
+  const fields = new Map();
+  for (const line of markdown.split(/\r?\n/)) {
+    const match = line.match(/^- ([^:]+):\s*(.*)$/);
+    if (!match) {
+      continue;
+    }
+    fields.set(normalizeFieldName(match[1]), normalizeValue(match[2]));
+  }
+  return fields;
+}
+
+function isPositiveInteger(value) {
+  return /^[1-9][0-9]*$/.test(value);
+}
+
+function isCalendarDate(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+  const date = new Date(`${value}T00:00:00Z`);
+  return (
+    !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value
+  );
+}
+
+function isPlaceholder(value) {
+  const normalized = value.trim();
+  if (!normalized || normalized === "-") {
+    return true;
+  }
+
+  const placeholders = new Set([
+    "YYYY-MM-DD",
+    "prod|staging",
+    "<name>",
+    "<name1>, <name2>",
+    "SSE-KMS|SSE-S3",
+    "Enabled|Suspended",
+    "enabled|disabled",
+    "VPC endpoint|IP allowlist|none",
+    "pass|warn|fail",
+    "summary-line|legacy-log-scan",
+    "yes|no",
+    "docs/test-results/YYYY-MM-DD-backup-s3-readiness-rN.md",
+  ]);
+
+  if (placeholders.has(normalized)) {
+    return true;
+  }
+
+  if (/\.\.\./.test(normalized)) {
+    return true;
+  }
+
+  if (/^<.*>$/.test(normalized)) {
+    return true;
+  }
+
+  return false;
+}
+
+function validateChecklist(fields) {
+  const issues = [];
+  const get = (name) => fields.get(name) ?? "";
+  const requireValue = (name, options = {}) => {
+    const value = get(name);
+    if (options.allowValues?.includes(value)) {
+      return value;
+    }
+    if (isPlaceholder(value)) {
+      issues.push({ field: name, reason: "placeholder_or_empty", value });
+    }
+    return value;
+  };
+
+  const decisionDate = requireValue("decisionDate");
+  if (
+    decisionDate &&
+    !isPlaceholder(decisionDate) &&
+    !isCalendarDate(decisionDate)
+  ) {
+    issues.push({
+      field: "decisionDate",
+      reason: "invalid_date",
+      value: decisionDate,
+    });
+  }
+
+  const environment = requireValue("environment");
+  if (
+    environment &&
+    !isPlaceholder(environment) &&
+    !["prod", "staging"].includes(environment)
+  ) {
+    issues.push({
+      field: "environment",
+      reason: "invalid_enum",
+      value: environment,
+    });
+  }
+
+  requireValue("owner");
+  requireValue("reviewers");
+
+  const relatedIssue = requireValue("relatedIssue");
+  if (
+    relatedIssue &&
+    !isPlaceholder(relatedIssue) &&
+    !/^#\d+$/.test(relatedIssue)
+  ) {
+    issues.push({
+      field: "relatedIssue",
+      reason: "invalid_issue_ref",
+      value: relatedIssue,
+    });
+  }
+
+  const bucketName = requireValue("bucketName");
+  if (
+    bucketName &&
+    !isPlaceholder(bucketName) &&
+    !/^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$/.test(bucketName)
+  ) {
+    issues.push({
+      field: "bucketName",
+      reason: "invalid_bucket_name",
+      value: bucketName,
+    });
+  }
+
+  requireValue("AWS account / project");
+
+  const region = requireValue("region");
+  if (
+    region &&
+    !isPlaceholder(region) &&
+    !/^[a-z]{2}-[a-z0-9-]+-\d+$/.test(region)
+  ) {
+    issues.push({ field: "region", reason: "invalid_region", value: region });
+  }
+
+  requireValue("s3Prefix");
+
+  const encryptionMode = requireValue("encryptionMode");
+  if (
+    encryptionMode &&
+    !isPlaceholder(encryptionMode) &&
+    !["SSE-KMS", "SSE-S3"].includes(encryptionMode)
+  ) {
+    issues.push({
+      field: "encryptionMode",
+      reason: "invalid_enum",
+      value: encryptionMode,
+    });
+  }
+
+  const kmsOptional =
+    encryptionMode &&
+    !isPlaceholder(encryptionMode) &&
+    encryptionMode === "SSE-S3";
+  const requireKmsField = (name) => {
+    const value = get(name);
+    if (kmsOptional && ["", "N/A", "n/a", "-"].includes(value.trim())) {
+      return value;
+    }
+    if (isPlaceholder(value)) {
+      issues.push({ field: name, reason: "placeholder_or_empty", value });
+    }
+    return value;
+  };
+
+  requireKmsField("kmsKeyIdOrAlias");
+  requireKmsField("kmsKeyAdmin");
+  requireKmsField("kmsKeyUsagePrincipals");
+
+  const versioning = requireValue("versioning");
+  if (
+    versioning &&
+    !isPlaceholder(versioning) &&
+    !["Enabled", "Suspended"].includes(versioning)
+  ) {
+    issues.push({
+      field: "versioning",
+      reason: "invalid_enum",
+      value: versioning,
+    });
+  }
+
+  for (const field of [
+    "lifecycleDailyDays",
+    "lifecycleWeeklyWeeks",
+    "lifecycleMonthlyMonths",
+  ]) {
+    const value = requireValue(field);
+    if (value && !isPlaceholder(value) && !isPositiveInteger(value)) {
+      issues.push({ field, reason: "invalid_positive_integer", value });
+    }
+  }
+
+  requireValue("replication / secondary copy");
+
+  const publicAccessBlock = requireValue("publicAccessBlock");
+  if (
+    publicAccessBlock &&
+    !isPlaceholder(publicAccessBlock) &&
+    !["enabled", "disabled"].includes(publicAccessBlock)
+  ) {
+    issues.push({
+      field: "publicAccessBlock",
+      reason: "invalid_enum",
+      value: publicAccessBlock,
+    });
+  }
+
+  requireValue("writeRoleArn");
+  requireValue("readRoleArn");
+  requireValue("restoreRoleArn");
+  requireValue("CI / automation principal");
+
+  const networkBoundary = requireValue("allowedNetworkBoundary");
+  if (
+    networkBoundary &&
+    !isPlaceholder(networkBoundary) &&
+    !["VPC endpoint", "IP allowlist", "none"].includes(networkBoundary)
+  ) {
+    issues.push({
+      field: "allowedNetworkBoundary",
+      reason: "invalid_enum",
+      value: networkBoundary,
+    });
+  }
+
+  requireValue("bucketPolicyNotes");
+  requireValue("restoreApprover");
+  requireValue("restoreExecutor");
+  requireValue("auditLogLocation");
+  requireValue("incidentEscalation");
+
+  return {
+    status: issues.length === 0 ? "pass" : "fail",
+    checkedFieldCount: fields.size,
+    issueCount: issues.length,
+    issues,
+  };
+}
+
+function printText(result, filePath) {
+  console.log(
+    `[backup-s3-decision-check] file: ${path.relative(process.cwd(), filePath)}`,
+  );
+  console.log(`[backup-s3-decision-check] status: ${result.status}`);
+  console.log(
+    `[backup-s3-decision-check] checkedFieldCount: ${result.checkedFieldCount}`,
+  );
+  console.log(`[backup-s3-decision-check] issueCount: ${result.issueCount}`);
+  for (const issue of result.issues) {
+    console.log(
+      `[backup-s3-decision-check][ERROR] field=${issue.field} reason=${issue.reason} value=${JSON.stringify(issue.value)}`,
+    );
+  }
+}
+
+async function main() {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      console.log(
+        "Usage: node scripts/check-backup-s3-decision-checklist.mjs [--file=docs/ops/backup-s3-decision-checklist.md] [--format=text|json]",
+      );
+      process.exit(0);
+    }
+
+    const markdown = fs.readFileSync(options.file, "utf8");
+    const result = validateChecklist(parseChecklist(markdown));
+
+    if (options.format === "json") {
+      console.log(JSON.stringify({ file: options.file, ...result }, null, 2));
+    } else {
+      printText(result, options.file);
+    }
+
+    process.exit(result.status === "pass" ? 0 : 1);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[backup-s3-decision-check][ERROR] ${message}`);
+    process.exit(2);
+  }
+}
+
+await main();


### PR DESCRIPTION
## 概要
- `docs/ops/backup-s3-decision-checklist.md` の必須項目を検証する `check-backup-s3-decision-checklist.mjs` を追加
- `make backup-s3-decision-check` を追加し、運用前に checklist の placeholder / enum / lifecycle 数値を検査できるようにした
- `#544` の判断材料として、現行 checklist を検証すると未確定項目が 28 件残ることを確認した

## 変更点
- `scripts/check-backup-s3-decision-checklist.mjs`
- `Makefile`
- `packages/backend/test/readinessScripts.test.js`
- `docs/ops/backup-s3-decision-checklist.md`
- `docs/requirements/backup-restore.md`
- `docs/ops/backup-restore.md`
- `docs/quality/test-gaps.md`

## 実行結果
- `node scripts/check-backup-s3-decision-checklist.mjs`
  - status: `fail`
  - issueCount: `28`
  - 主な未確定: `bucketName`, `region`, `encryptionMode`, `writeRoleArn`, `restoreApprover`

## テスト
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres node --test packages/backend/test/readinessScripts.test.js`
- `node scripts/check-backup-s3-decision-checklist.mjs || true`
- `make -n backup-s3-decision-check`
- `git diff --check`
