### PR TITLE
ops: record action policy phase3 trial evidence

### DIFF
--- a/docs/test-results/2026-03-08-action-policy-phase3-cutover-r1.md
+++ b/docs/test-results/2026-03-08-action-policy-phase3-cutover-r1.md
@@ -1,0 +1,64 @@
+# ActionPolicy phase3 cutover 記録
+
+- generatedAt: 2026-03-08T08:22:45Z
+- sourceReadinessRecord: `docs/test-results/2026-03-08-action-policy-phase3-readiness-r1.md`
+- branch: ops/1312-phase3-trial
+- commit: 83a143cd
+- fromPreset: `phase2_core`
+- toPreset: `phase3_strict`
+
+## 事前 readiness
+
+- ready: yes
+- from/to: 2026-03-07T08:22:04.406Z -> 2026-03-08T08:22:04.406Z
+- missing_static_callsites: 0
+- stale_required_actions: 0
+- dynamic_callsites: 0
+- fallback_unique_keys: 0
+- fallback_high_risk_keys: 0
+- fallback_medium_risk_keys: 0
+- fallback_unknown_risk_keys: 0
+
+## 切替手順
+
+```bash
+make action-policy-phase3-readiness-record
+# 環境変数または設定を phase3_strict に変更
+make action-policy-fallback-report
+make action-policy-fallback-report-json
+```
+
+- [ ] `phase3_strict` へ切替した
+- [ ] アプリ再起動 / 再デプロイを実施した
+
+## 主要操作確認
+
+- [ ] `invoice:send`
+- [ ] `invoice:mark_paid`
+- [ ] `purchase_order:send`
+- [ ] `expense:submit`
+- [ ] `expense:mark_paid`
+- [ ] `vendor_invoice:submit`
+- [ ] `vendor_invoice:update_lines`
+- [ ] `vendor_invoice:update_allocations`
+- [ ] `*:approve`
+- [ ] `*:reject`
+
+## 切替後 fallback 確認
+
+- [ ] `make action-policy-fallback-report-json` で新規 fallback key が 0 件
+- [ ] 影響があれば `flowType:actionKey:targetTable` を記録した
+
+```text
+(none)
+```
+
+## ロールバック
+
+- [ ] ロールバック不要
+- [ ] `phase2_core` へロールバックした
+- [ ] `ACTION_POLICY_REQUIRED_ACTIONS` 明示指定で段階復旧した
+
+## 所見
+
+-

--- a/docs/test-results/2026-03-08-action-policy-phase3-readiness-r1.md
+++ b/docs/test-results/2026-03-08-action-policy-phase3-readiness-r1.md
@@ -1,0 +1,34 @@
+# ActionPolicy phase3 readiness 記録
+
+- generatedAt: 2026-03-08T08:22:45Z
+- sourceLogDir: `tmp/action-policy-phase3-readiness/run-20260308-172204`
+- readinessText: `tmp/action-policy-phase3-readiness/run-20260308-172204/phase3-readiness.txt`
+- readinessJson: `tmp/action-policy-phase3-readiness/run-20260308-172204/phase3-readiness.json`
+- fallbackText: `tmp/action-policy-phase3-readiness/run-20260308-172204/fallback-report.txt`
+- fallbackJson: `tmp/action-policy-phase3-readiness/run-20260308-172204/fallback-report.json`
+- branch: ops/1312-phase3-trial
+- commit: 83a143cd
+
+## Summary
+
+- ready: yes
+- from/to: 2026-03-07T08:22:04.406Z -> 2026-03-08T08:22:04.406Z
+- missing_static_callsites: 0
+- stale_required_actions: 0
+- dynamic_callsites: 0
+- fallback_unique_keys: 0
+- fallback_high_risk_keys: 0
+- fallback_medium_risk_keys: 0
+- fallback_unknown_risk_keys: 0
+
+## Blockers
+
+```text
+(none)
+```
+
+## Fallback Keys
+
+```text
+(none)
+```

--- a/docs/test-results/README.md
+++ b/docs/test-results/README.md
@@ -36,6 +36,8 @@
 
 ### 2026-03-08
 
+- ActionPolicy phase3 readiness 記録 r1: docs/test-results/2026-03-08-action-policy-phase3-readiness-r1.md
+- ActionPolicy phase3 cutover 記録 r1: docs/test-results/2026-03-08-action-policy-phase3-cutover-r1.md
 - S3バックアップ readiness 記録 r1: docs/test-results/2026-03-08-backup-s3-readiness-r1.md
 - Dependabot alerts 監視記録 r1: docs/test-results/2026-03-08-dependabot-alerts-r1.md
 - ESLint10 readiness 記録 r1: docs/test-results/2026-03-08-eslint10-readiness-r1.md

--- a/packages/backend/test/readinessScripts.test.js
+++ b/packages/backend/test/readinessScripts.test.js
@@ -748,6 +748,57 @@ test('record-action-policy-phase3-readiness: writes report from provided source 
   });
 });
 
+test('record-action-policy-phase3-readiness: uses repo-relative paths when files are under repo tmp', () => {
+  const repoTmpRoot = path.join(ROOT_DIR, 'tmp');
+  mkdirSync(repoTmpRoot, { recursive: true });
+  const repoTempDir = mkdtempSync(
+    path.join(repoTmpRoot, 'action-policy-phase3-readiness-test-'),
+  );
+  try {
+    const relativeLogDir = path.join(
+      'tmp',
+      path.basename(repoTempDir),
+      'run-1',
+    );
+    const logDir = path.join(ROOT_DIR, relativeLogDir);
+    const outDir = path.join(repoTempDir, 'out');
+    mkdirSync(logDir, { recursive: true });
+    writeFileSync(
+      path.join(logDir, 'phase3-readiness.txt'),
+      'ready: yes\n## blockers\n(none)\n\n## fallback keys\n(none)\n',
+    );
+    writeFileSync(path.join(logDir, 'phase3-readiness.json'), '{}\n');
+    writeFileSync(path.join(logDir, 'fallback-report.txt'), 'unique_keys: 0\n');
+    writeFileSync(path.join(logDir, 'fallback-report.json'), '{}\n');
+
+    const res = runScript('record-action-policy-phase3-readiness.sh', {
+      LOG_DIR: relativeLogDir,
+      OUT_DIR: outDir,
+      DATE_STAMP: '2026-03-08',
+      RUN_LABEL: 'r-relpath',
+    });
+    assert.equal(res.status, 0, `${res.stderr}\n${res.stdout}`);
+
+    const report = readFileSync(
+      path.join(
+        outDir,
+        '2026-03-08-action-policy-phase3-readiness-r-relpath.md',
+      ),
+      'utf8',
+    );
+    assert.match(
+      report,
+      /sourceLogDir: `tmp\/action-policy-phase3-readiness-test-[^/]+\/run-1`/,
+    );
+    assert.match(
+      report,
+      /readinessText: `tmp\/action-policy-phase3-readiness-test-[^/]+\/run-1\/phase3-readiness\.txt`/,
+    );
+  } finally {
+    rmSync(repoTempDir, { recursive: true, force: true });
+  }
+});
+
 test('record-action-policy-phase3-readiness: auto increments run suffix when RUN_LABEL is omitted', () => {
   withTempDir((dir) => {
     const logDir = path.join(dir, 'logs');
@@ -833,6 +884,57 @@ test('record-action-policy-phase3-cutover: writes report from readiness record',
     assert.match(report, /- fromPreset: `phase2_core`/);
     assert.match(report, /- toPreset: `phase3_strict`/);
   });
+});
+
+test('record-action-policy-phase3-cutover: uses repo-relative readiness record path when source is under repo', () => {
+  const repoResultsRoot = path.join(ROOT_DIR, 'docs/test-results');
+  mkdirSync(repoResultsRoot, { recursive: true });
+  const repoTempDir = mkdtempSync(
+    path.join(repoResultsRoot, 'action-policy-phase3-cutover-test-'),
+  );
+  try {
+    const readinessRecord = path.join(
+      repoTempDir,
+      '2026-03-08-action-policy-phase3-readiness-r1.md',
+    );
+    const outDir = path.join(repoTempDir, 'out');
+    writeFileSync(
+      readinessRecord,
+      [
+        '# ActionPolicy phase3 readiness 記録',
+        '',
+        '- ready: yes',
+        '- from/to: 2026-03-07T00:00:00.000Z -> 2026-03-08T00:00:00.000Z',
+        '- missing_static_callsites: 0',
+        '- stale_required_actions: 0',
+        '- dynamic_callsites: 0',
+        '- fallback_unique_keys: 0',
+        '- fallback_high_risk_keys: 0',
+        '- fallback_medium_risk_keys: 0',
+        '- fallback_unknown_risk_keys: 0',
+        '',
+      ].join('\n'),
+    );
+
+    const res = runScript('record-action-policy-phase3-cutover.sh', {
+      READINESS_RECORD_FILE: path.relative(ROOT_DIR, readinessRecord),
+      OUT_DIR: outDir,
+      DATE_STAMP: '2026-03-08',
+      RUN_LABEL: 'r-relpath',
+    });
+    assert.equal(res.status, 0, `${res.stderr}\n${res.stdout}`);
+
+    const report = readFileSync(
+      path.join(outDir, '2026-03-08-action-policy-phase3-cutover-r-relpath.md'),
+      'utf8',
+    );
+    assert.match(
+      report,
+      /sourceReadinessRecord: `docs\/test-results\/action-policy-phase3-cutover-test-[^/]+\/2026-03-08-action-policy-phase3-readiness-r1\.md`/,
+    );
+  } finally {
+    rmSync(repoTempDir, { recursive: true, force: true });
+  }
 });
 
 test('record-action-policy-phase3-cutover: auto increments run suffix when RUN_LABEL is omitted', () => {

--- a/scripts/record-action-policy-phase3-cutover.sh
+++ b/scripts/record-action-policy-phase3-cutover.sh
@@ -48,6 +48,18 @@ resolve_absolute_path() {
   fi
 }
 
+format_source_path() {
+  local input="$1"
+  case "$input" in
+    "$ROOT_DIR"/*)
+      printf '%s\n' "${input#"$ROOT_DIR"/}"
+      ;;
+    *)
+      printf '%s\n' "$input"
+      ;;
+  esac
+}
+
 validate_date_stamp() {
   if ! [[ "$DATE_STAMP" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
     die "DATE_STAMP must be YYYY-MM-DD"
@@ -145,6 +157,8 @@ main() {
 
   local output_file
   output_file="$(resolve_output_file)"
+  local source_readiness_record
+  source_readiness_record="$(format_source_path "$READINESS_RECORD_FILE")"
 
   local ready from_to missing stale dynamic fallback_total fallback_high fallback_medium fallback_unknown
   ready="$(extract_scalar "$READINESS_RECORD_FILE" "ready")"
@@ -163,7 +177,7 @@ main() {
       echo "# ActionPolicy phase3 cutover 記録"
       echo
       echo "- generatedAt: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-      echo "- sourceReadinessRecord: \`$READINESS_RECORD_FILE\`"
+      echo "- sourceReadinessRecord: \`$source_readiness_record\`"
       echo "- branch: $(git -C "$ROOT_DIR" branch --show-current)"
       echo "- commit: $(git -C "$ROOT_DIR" rev-parse --short HEAD)"
       echo "- fromPreset: \`$FROM_PRESET\`"

--- a/scripts/record-action-policy-phase3-readiness.sh
+++ b/scripts/record-action-policy-phase3-readiness.sh
@@ -52,6 +52,18 @@ resolve_absolute_path() {
   fi
 }
 
+format_source_path() {
+  local input="$1"
+  case "$input" in
+    "$ROOT_DIR"/*)
+      printf '%s\n' "${input#"$ROOT_DIR"/}"
+      ;;
+    *)
+      printf '%s\n' "$input"
+      ;;
+  esac
+}
+
 validate_date_stamp() {
   if ! [[ "$DATE_STAMP" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
     die "DATE_STAMP must be YYYY-MM-DD"
@@ -188,6 +200,13 @@ main() {
   local output_file
   output_file="$(resolve_output_file)"
 
+  local source_log_dir source_readiness_text source_readiness_json source_fallback_text source_fallback_json
+  source_log_dir="$(format_source_path "$LOG_DIR")"
+  source_readiness_text="$(format_source_path "$READINESS_TEXT_FILE")"
+  source_readiness_json="$(format_source_path "$READINESS_JSON_FILE")"
+  source_fallback_text="$(format_source_path "$FALLBACK_TEXT_FILE")"
+  source_fallback_json="$(format_source_path "$FALLBACK_JSON_FILE")"
+
   local ready from to missing stale dynamic fallback_total fallback_high fallback_medium fallback_unknown
   ready="$(extract_scalar "$READINESS_TEXT_FILE" "ready")"
   from="$(extract_scalar "$READINESS_TEXT_FILE" "from")"
@@ -210,11 +229,11 @@ main() {
       echo "# ActionPolicy phase3 readiness 記録"
       echo
       echo "- generatedAt: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-      echo "- sourceLogDir: \`$LOG_DIR\`"
-      echo "- readinessText: \`$READINESS_TEXT_FILE\`"
-      echo "- readinessJson: \`$READINESS_JSON_FILE\`"
-      echo "- fallbackText: \`$FALLBACK_TEXT_FILE\`"
-      echo "- fallbackJson: \`$FALLBACK_JSON_FILE\`"
+      echo "- sourceLogDir: \`$source_log_dir\`"
+      echo "- readinessText: \`$source_readiness_text\`"
+      echo "- readinessJson: \`$source_readiness_json\`"
+      echo "- fallbackText: \`$source_fallback_text\`"
+      echo "- fallbackJson: \`$source_fallback_json\`"
       echo "- branch: $(git -C "$ROOT_DIR" branch --show-current)"
       echo "- commit: $(git -C "$ROOT_DIR" rev-parse --short HEAD)"
       echo


### PR DESCRIPTION
## Summary
- record the 2026-03-08 ActionPolicy phase3 readiness evidence under `docs/test-results/`
- add repo-relative source paths for the readiness / cutover record scripts and cover them in `packages/backend/test/readinessScripts.test.js`
- generate the paired cutover record template so #1308 / #1312 trial operations can reference a concrete run label

## Details
- readiness result on 2026-03-08:
  - `ready: yes`
  - `missing_static_callsites: 0`
  - `stale_required_actions: 0`
  - `dynamic_callsites: 0`
  - `fallback_unique_keys: 0`
- the cutover record is generated as a template only; actual `phase3_strict` switch / rollback execution remains an operational step outside this PR

## Verification
- `bash -n scripts/record-action-policy-phase3-readiness.sh scripts/record-action-policy-phase3-cutover.sh`
- `DATABASE_URL='postgresql://postgres:postgres@localhost:55444/postgres?schema=public' node --test packages/backend/test/readinessScripts.test.js`
- `DATABASE_URL='postgresql://postgres:postgres@localhost:55444/postgres?schema=public' make action-policy-phase3-trial-record`
- `git diff --check`

## Related
- Refs #1308
- Refs #1312
