### PR TITLE
fix: refresh backend lockfile for audit transitive fixes

### DIFF
--- a/packages/backend/package-lock.json
+++ b/packages/backend/package-lock.json
@@ -2951,9 +2951,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3160,9 +3160,9 @@
       }
     },
     "node_modules/bn.js": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
     "node_modules/bowser": {


### PR DESCRIPTION
## Summary
- refresh `packages/backend/package-lock.json` only
- lift transitive `ajv` from `8.17.1` to `8.18.0`
- lift transitive `bn.js` from `4.12.2` to `4.12.3`

## Why
- `npm audit` on `main` showed 2 moderate backend vulnerabilities
  - `ajv` via Fastify schema/serialization chain
  - `bn.js` via `web-push -> asn1.js`
- `npm audit fix --package-lock-only` resolves both without changing `package.json`

## Validation
- `npm ci --prefix packages/backend`
- `DATABASE_URL='postgresql://user:pass@localhost:5432/postgres' npx prisma generate --schema packages/backend/prisma/schema.prisma`
- `npm run typecheck --prefix packages/backend`
- `npm run build --prefix packages/backend`
- `npm run test --prefix packages/backend`
- `npm audit --prefix packages/backend --audit-level=high`
