### PR TITLE
docs: add English parity for integration requirements

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -1,0 +1,25 @@
+# ERP4 English Documentation Index
+
+Updated: 2026-03-17
+
+## Purpose
+
+- Provide English counterparts for operational and requirements documents that are already maintained in Japanese.
+- Keep the English documents detailed enough for implementation review, API review, and external stakeholder alignment.
+- Make the current translation scope explicit so missing English coverage is visible.
+
+## Current scope
+
+This directory currently covers the payroll/accounting integration and management-accounting documents that were expanded in March 2026.
+
+- `requirements/non-chat-spec-index.md`
+- `requirements/external-csv-integration-common-spec.md`
+- `requirements/payroll-rakuda-employee-master-csv.md`
+- `requirements/payroll-rakuda-attendance-csv.md`
+- `requirements/accounting-ics-journal-csv.md`
+- `requirements/management-accounting-report-requirements.md`
+
+## Notes
+
+- The Japanese documents under `docs/requirements/` remain the primary source for items that do not yet have an English counterpart.
+- When a Japanese document is updated and its English counterpart exists, both documents should be updated in the same PR whenever practical.

--- a/docs/en/requirements/accounting-ics-journal-csv.md
+++ b/docs/en/requirements/accounting-ics-journal-csv.md
@@ -1,0 +1,260 @@
+# Keiri Jokun Alpha Pro II Integration: ICS Journal CSV Specification (Initial Repo-Based Draft)
+
+Updated: 2026-03-16
+Related issues: `#1438`, `#1430`, `#1433`, `#1434`, `#1435`, `#1441`, `#1443`
+
+## Purpose
+
+- Organize the initial ICS journal CSV specification exported from ERP4 to Keiri Jokun Alpha Pro II based on the actual template file and current operational feedback.
+- Separate the fields that ERP4 can already supply, the fields that require additional mapping masters, and the import rules that remain unconfirmed.
+- Fix the baseline implementation contract as of 2026-03-16 for the API and dispatch logs that export `AccountingJournalStaging.status=ready` rows to ICS CSV.
+
+## Implemented baseline
+
+- `GET /integrations/accounting/exports/journals`
+  - Returns canonical JSON.
+- `GET /integrations/accounting/exports/journals?format=csv`
+  - Returns ICS CSV encoded as `CP932 + CRLF`.
+- `POST /integrations/accounting/exports/journals/dispatch`
+  - Persists the export result with `idempotencyKey`.
+- `GET /integrations/accounting/exports/journals/dispatch-logs`
+  - Returns dispatch history.
+
+### Export target
+
+- Only rows with `AccountingJournalStaging.status='ready'` are exported.
+- If `pending_mapping` or `blocked` rows remain in the same scope, export stops with `409 accounting_journal_mapping_incomplete`.
+- Even for ready rows, export stops with `409 accounting_journal_ready_row_incomplete` when any of the following is missing:
+  - `debitAccountCode`
+  - `creditAccountCode`
+  - `taxCode`
+  - positive `amount`
+
+### Scope
+
+- The current baseline filters only by `periodKey`.
+- When `periodKey` is omitted, all periods are included in scope.
+- `periodKey` must be in `YYYY-MM` format; invalid values return `400 invalid_period_key`.
+
+## Assumptions
+
+- Based on user input, the target product is `Keiri Jokun Alpha Pro II Version 26.002`.
+- The local file `21期_表形式入力フォーマット（ICS取込用）.CSV` is treated as the actual template.
+- For review and implementation reference, the repository also includes `docs/requirements/samples/21ki_ics_journal_header_sample.csv`, which contains only the header row.
+- Operational feedback indicates that the fields commonly entered during normal imports are:
+  - Date
+  - Debit code / credit code
+  - Debit name / credit name
+  - Amount
+  - Description
+- The actual template also contains additional columns such as department, branch, tax classification, and journal classification.
+
+## Actual template inspection result
+
+Target file: `21期_表形式入力フォーマット（ICS取込用）.CSV`
+
+### File format
+
+- Encoding: judged to be `CP932 / Shift_JIS`
+- BOM: none
+- Newlines: `CRLF`
+- Lines 1-4: title, company information, target period
+- Line 5: header row
+- Data rows: none
+- The repository keeps `docs/requirements/samples/21ki_ics_journal_header_sample.csv` as a UTF-8 restatement of the header row for review and implementation reference.
+- The runtime export converts to `CP932 + CRLF` to match the actual template.
+
+### Header columns (30 columns)
+
+1. Date
+2. Closing/adjustment flag
+3. Voucher number
+4. Department code
+5. Debit code
+6. Debit name
+7. Debit branch
+8. Debit branch description
+9. Debit branch kana
+10. Credit code
+11. Credit name
+12. Credit branch
+13. Credit branch description
+14. Credit branch kana
+15. Amount
+16. Description
+17. Tax classification
+18. Consideration
+19. Purchase classification
+20. Sales industry classification
+21. Journal classification
+22. Dummy1
+23. Dummy2
+24. Dummy3
+25. Dummy4
+26. Dummy5
+27. Bill number
+28. Bill due date
+29. Sticky note number
+30. Sticky note comment
+
+## Primary fields used in current operation
+
+Operator feedback states that the following fields are commonly used in day-to-day imports.
+
+- `Date`
+- `Debit code`
+- `Credit code`
+- `Debit name`
+- `Credit name`
+- `Amount`
+- `Description`
+
+For the initial implementation, those fields are treated as the primary required candidates, while the remaining columns are categorized as fixed-value, empty-value, or pending confirmation.
+
+## Logical field definition (initial draft)
+
+| CSV column                    | Intended use                         | Candidate ERP4 source                                  | Status          | Notes                                                       |
+| ----------------------------- | ------------------------------------ | ------------------------------------------------------ | --------------- | ----------------------------------------------------------- |
+| Date                          | Journal date                         | document date / posting date                           | Conditional     | The actual source date must be defined per accounting event |
+| Closing/adjustment flag       | Closing or correction classification | fixed-value candidate                                  | Unconfirmed     | The default value for ordinary imports must be confirmed    |
+| Voucher number                | Voucher identifier                   | ERP4-derived sequence                                  | Not implemented | Derivation from document numbers is a strong candidate      |
+| Department code               | Department axis                      | project/customer/vendor/employee derived code          | Not implemented | Depends on `#1434`                                          |
+| Debit code                    | Debit GL account                     | accounting mapping master                              | Not implemented | Depends on `#1441`                                          |
+| Debit name                    | Debit account name                   | mapping master or fixed name                           | Not implemented | Prefer to manage together with the code                     |
+| Debit branch                  | Debit subaccount                     | accounting mapping master                              | Not implemented | Must confirm whether optional or required                   |
+| Debit branch description      | Debit subaccount description         | project/customer/vendor name, etc.                     | Conditional     | Actual use is unconfirmed                                   |
+| Debit branch kana             | Debit subaccount kana                | stored in master                                       | Not implemented | ERP4 does not keep this today                               |
+| Credit code                   | Credit GL account                    | accounting mapping master                              | Not implemented | Depends on `#1441`                                          |
+| Credit name                   | Credit account name                  | mapping master or fixed name                           | Not implemented | Same as above                                               |
+| Credit branch                 | Credit subaccount                    | accounting mapping master                              | Not implemented | Same as above                                               |
+| Credit branch description     | Credit subaccount description        | project/customer/vendor name, etc.                     | Conditional     | Actual use is unconfirmed                                   |
+| Credit branch kana            | Credit subaccount kana               | stored in master                                       | Not implemented | ERP4 does not keep this today                               |
+| Amount                        | Journal amount                       | document amount / line amount                          | Conditional     | The balancing unit must be defined                          |
+| Description                   | Journal description                  | document number, project name, counterparty name, etc. | Conditional     | Character limit is unconfirmed                              |
+| Tax classification            | Tax code                             | mapped from `taxRate`                                  | Not implemented | Depends on `#1434` and `#1441`                              |
+| Consideration                 | Invoice/tax basis                    | gross or net amount                                    | Unconfirmed     | Must confirm whether used                                   |
+| Purchase classification       | Purchase category                    | mapping                                                | Unconfirmed     | Requiredness must be confirmed                              |
+| Sales industry classification | Sales category                       | mapping                                                | Unconfirmed     | May only apply to sales-side entries                        |
+| Journal classification        | Journal type                         | fixed value or mapping                                 | Unconfirmed     | Requiredness must be confirmed                              |
+| Dummy1-5                      | Reserved fields                      | fixed empty values                                     | Conditional     | Meaning in the template is unconfirmed                      |
+| Bill number                   | Bill information                     | none                                                   | Not implemented | Candidate to remain outside the initial scope               |
+| Bill due date                 | Bill information                     | none                                                   | Not implemented | Same as above                                               |
+| Sticky note number            | Memo                                 | none                                                   | Not implemented | Candidate to remain outside the initial scope               |
+| Sticky note comment           | Memo                                 | none                                                   | Not implemented | Candidate to remain outside the initial scope               |
+
+## Initial view of required columns
+
+### Currently primary required candidates
+
+- `Date`
+- `Debit code`
+- `Credit code`
+- `Debit name`
+- `Credit name`
+- `Amount`
+- `Description`
+
+### Conditional required candidates
+
+- `Department code`
+- `Tax classification`
+- `Journal classification`
+- `Debit branch` / `Credit branch`
+
+### Initial fixed-value or empty-value candidates
+
+- `Closing/adjustment flag`
+- `Dummy1` to `Dummy5`
+- `Bill number`
+- `Bill due date`
+- `Sticky note number`
+- `Sticky note comment`
+
+## Initial ERP4 event-to-journal conversion policy
+
+### Expected events
+
+- Expense approval
+- Vendor invoice approval
+- Invoice approval
+- Future extension for payment and receipt operations
+
+### Conversion policy
+
+- One document does not necessarily equal one voucher.
+- The design must allow expansion into multiple journal rows per detail line or allocation unit.
+- ERP4 creates accounting-event staging first, then converts it into ICS CSV.
+- As of 2026-03-16, the baseline creates `AccountingEvent` and `AccountingJournalStaging` when approvals for `expenses`, `invoices`, and `vendor_invoices` complete, and keeps unresolved rows as `pending_mapping` or `blocked`.
+- The `#1443` baseline converts only staging rows that have already become `ready`.
+
+### Minimum mapping required
+
+- Document type -> debit / credit GL account
+- project / department -> department code
+- vendor / customer / project -> branch candidates
+- tax rate -> tax classification
+
+## Initial output-unit policy
+
+- One voucher = one logical voucher.
+- A voucher may contain multiple detail lines.
+- The leading candidate is to output one CSV row as one debit/credit pair.
+- When multiple debit/credit rows belong to the same voucher, they share the same voucher number.
+
+## Initial error classification
+
+### Export-stopping errors
+
+- Missing debit or credit account code
+- Missing department code
+- Unmapped tax classification
+- Unbalanced debit and credit
+- Zero amount or negative amount that violates the business rule
+- `pending_mapping` or `blocked` rows remain in the export scope
+
+### Warnings
+
+- Name columns do not match the mapping master
+- Description approaches the character limit
+- Initial out-of-scope columns are emitted as empty values
+
+## Test considerations (initial draft)
+
+### Positive cases
+
+- CSV is generated with the same 30 columns as the current template.
+- It is encoded as `CP932 + CRLF`.
+- A sample using only the primary operational fields can be generated.
+- Multiple detail lines can share the same voucher number.
+
+### Negative cases
+
+- Failure on missing debit or credit code
+- Failure on missing department code
+- Failure on unmapped tax classification
+- Failure on unbalanced debit/credit
+- Undefined behavior when text exceeds the character limit
+
+## Items that still require confirmation
+
+1. Default value for `Closing/adjustment flag`
+2. Official numbering rule for `Voucher number`
+3. Whether `Department code` is required in actual operation
+4. Requiredness and code systems for `Tax classification`, `Consideration`, `Purchase classification`, `Sales industry classification`, and `Journal classification`
+5. Whether `Debit name` / `Credit name` must match the code-defined name or can be free auxiliary text
+6. Actual requiredness of `Debit branch` / `Credit branch`
+7. Character limit of `Description`
+8. Whether `CP932 + CRLF` is mandatory in actual operation
+
+## Current conclusion
+
+- `#1438` can move beyond simple inventory because the actual template is now available.
+- The baseline implementation for `#1443` already provides ICS CSV export, dispatch, and dispatch-log APIs.
+- At this stage, however, only the template columns and the primary operational fields are confirmed; requiredness, fixed values, and code systems are still open.
+- The next practical decisions are the closing/adjustment flag, department code, tax classification, branch handling, and description constraints.
+- Even after the baseline implementation, `#1434` and `#1441` must still finalize mapping masters, export validation rules, and CSV conversion rules.
+
+## Source files
+
+- `21期_表形式入力フォーマット（ICS取込用）.CSV`
+- `docs/requirements/erp4-payroll-accounting-gap-analysis.md`

--- a/docs/en/requirements/external-csv-integration-common-spec.md
+++ b/docs/en/requirements/external-csv-integration-common-spec.md
@@ -1,0 +1,218 @@
+# Common Integration Specification for Payroll and Accounting CSV Exports
+
+Updated: 2026-03-16
+Related issues: `#1435`, `#1430`
+
+## Purpose
+
+- Define the shared operational rules for CSV integrations targeting Payroll Rakuda and Keiri Jokun Alpha.
+- Standardize output units, redispatch behavior, auditability, and error handling before the individual adapter implementations are finalized.
+
+## Assumptions
+
+- Final column order, encoding, and required-field rules will be fixed after the actual templates are collected in `#1432`.
+- This document is a common design draft aligned with the current `IntegrationRun`, `LeaveIntegrationExportLog`, and `AuditLog` implementations.
+
+## 1. Scope
+
+- Payroll Rakuda exports
+  - employee master CSV
+  - confirmed attendance CSV
+- Keiri Jokun Alpha exports
+  - journal CSV
+
+## 2. Shared file-format principles
+
+### 2.1 Encoding and delimiters
+
+- Default canonical format
+  - encoding: `UTF-8`
+  - newline: `LF`
+  - delimiter: `,`
+  - header row: present
+- Exceptions
+  - If the actual product template requires `Shift_JIS` or `CRLF`, the adapter converts on output.
+  - The canonical internal representation remains `UTF-8 + LF`.
+- Implemented exception
+  - The `#1443` ICS journal CSV is already exported as `CP932 + CRLF` to match the actual template.
+
+### 2.2 Date, time, and numeric values
+
+- Date
+  - internal canonical: ISO 8601
+  - output CSV: formatted as required by the target product, for example `YYYY/MM/DD`
+- Time
+  - Payroll exports should send confirmed monthly aggregates; timestamp-level details are auxiliary.
+- Numeric values
+  - Decimal handling, negative values, and rounding must be converted explicitly in the adapter.
+  - Amounts must be represented in a way that allows machine validation of balance and totals.
+
+## 3. Output units
+
+### 3.1 Payroll exports
+
+- Employee master
+  - Full export is the initial default.
+  - Differential export remains a later option.
+- Attendance
+  - Monthly-closing unit.
+  - The confirmed monthly snapshot is the system of record.
+
+### 3.2 Accounting exports
+
+- Journal export
+  - Output is scoped by target period or event set.
+  - Each export must fix row count, total amount, and debit/credit balance.
+
+## 4. Status design
+
+### 4.1 Common export-job states
+
+- `draft`
+  - Export conditions are defined but no file has been generated.
+- `exported`
+  - File generation completed.
+- `failed`
+  - File generation failed.
+- `replayed`
+  - A repeated request reused a previous result under the same conditions.
+
+### 4.2 Mapping to current implementation
+
+- Existing `IntegrationRunStatus`
+  - `running`, `success`, `failed`
+- Existing leave dispatch
+  - `LeaveIntegrationExportLog`
+  - keeps `idempotencyKey`, `requestHash`, `reexportOfId`, `exportedUntil`, `exportedCount`
+- Employee-master dispatch
+  - `HrEmployeeMasterExportLog`
+  - keeps `idempotencyKey`, `requestHash`, `reexportOfId`, `exportedUntil`, `exportedCount`
+- ICS journal dispatch
+  - `AccountingIcsExportLog`
+  - keeps `idempotencyKey`, `requestHash`, `reexportOfId`, `periodKey`, `exportedUntil`, `exportedCount`
+- Common operational references
+  - `GET /integrations/jobs/exports`
+    - cross-source list API for the three export-log families
+    - the admin UI retrieves it from the `Settings` section with filters for kind, status, limit, and offset
+  - `POST /integrations/jobs/exports/:kind/:id/redispatch`
+    - re-exports a previously successful payload as a new log and tracks the source via `reexportOfId`
+  - `GET /integrations/reconciliation/summary`
+    - aggregate comparison of attendance closing, employee-master export, accounting ICS export, and journal staging by `periodKey`
+  - `GET /integrations/reconciliation/details`
+    - full employee-code differences for payroll, project/department breakdown for accounting, and sample rows for `pending_mapping`, `blocked`, and `invalid ready`
+
+A future common job model should generalize these already implemented patterns.
+
+## 5. Idempotency and redispatch
+
+### 5.1 Idempotency keys
+
+- Manual execution must carry `idempotencyKey`.
+- Same `idempotencyKey` with the same conditions
+  - may reuse the previous result.
+- Same `idempotencyKey` with different conditions
+  - must fail as `idempotency_conflict`.
+
+### 5.2 Redispatch
+
+- Redispatch keeps explicit linkage to the source job.
+- Redispatch records must retain:
+  - source job ID
+  - operator
+  - new idempotency key
+  - payload version being re-exported
+  - whether any material difference exists
+
+## 6. Audit and history
+
+### 6.1 Minimum recorded fields
+
+- integration kind
+- target period or closing key
+- exported row count
+- output file name
+- operator
+- execution timestamp
+- source job of redispatch
+- target job of redispatch
+- status
+- error code and message
+
+### 6.2 Existing foundations
+
+- `AuditLog`
+- `IntegrationRun`
+- `LeaveIntegrationExportLog`
+
+### 6.3 Policy
+
+- Each adapter should use audit event names that stay consistent with the existing `AuditLog` model.
+- Where evidence tracking is required, links to `approvalInstanceId` and `EvidenceSnapshot` must remain possible.
+
+## 7. Error policy
+
+### 7.1 Errors that must stop export before file generation
+
+- missing required codes
+- unbalanced debit and credit
+- period not closed
+- missing counterparty or employee codes
+- unmapped tax classification
+
+### 7.2 Retryable errors
+
+- temporary file-write failure
+- external storage or notification failure
+
+### 7.3 Error-code policy
+
+- Business-rule errors and execution errors should stay separate:
+  - `validation_*`
+  - `mapping_*`
+  - `idempotency_*`
+  - `io_*`
+  - `unexpected_*`
+
+## 8. Permissions and approval
+
+- Export operations are limited to administrative or operational-management roles.
+- Production-equivalent resending should require a reasoned redispatch path.
+- When approved data is exported, the integration jobs should stay cross-referenceable with approval and evidence artifacts.
+
+## 9. Recommended implementation order at this stage
+
+- Finalize per-adapter CSV columns in `#1436`, `#1437`, and `#1438`.
+- Implement individual adapters in `#1442` and `#1443`.
+- Implement common job management and redispatch in `#1444`.
+- Implement reconciliation reports in `#1445`.
+
+## 9.1 Initial implementation scope for `#1445`
+
+- Start with the aggregate summary API only:
+  - `GET /integrations/reconciliation/summary?periodKey=YYYY-MM`
+- In the admin UI, the `Integration Reconciliation Summary` card in `Settings` fetches this by month.
+- Initial comparison points:
+  - attendance-closing summary count and total minutes
+  - employee-code differences between full employee-master export and attendance closing
+  - `ready / pending_mapping / blocked` counts in accounting journal staging
+  - debit/credit balance flag for ready rows
+  - row-count agreement between the latest ICS export and the ready staging rows
+- The next step adds the detail API:
+  - `GET /integrations/reconciliation/details?periodKey=YYYY-MM`
+  - payroll: full employee-code difference list
+  - accounting: project and department breakdown plus sample rows for `pending_mapping`, `blocked`, and `invalid ready`
+- UI drilldown views are intentionally separated into a later phase.
+
+## 10. Unresolved items
+
+- Actual encoding, line-ending, and field-length constraints of Payroll Rakuda and Keiri Jokun Alpha templates
+- How strictly a future common job table should model `draft/exported/imported/failed`
+- Whether ERP4 should receive and store an explicit "import completed" acknowledgment from the external systems
+
+## 11. Source files
+
+- `packages/backend/src/routes/integrations.ts`
+- `packages/backend/prisma/schema.prisma`
+- `docs/requirements/hr-crm-integration.md`
+- `docs/requirements/batch-jobs.md`
+- `docs/requirements/pdf-email.md`

--- a/docs/en/requirements/management-accounting-report-requirements.md
+++ b/docs/en/requirements/management-accounting-report-requirements.md
@@ -1,0 +1,279 @@
+# ERP4 Management Accounting Report Requirements (Initial Draft)
+
+Related issues: `#1446`, `#1430`, `#1433`, `#1434`, `#1435`, `#1439`, `#1440`, `#1441`
+
+## Purpose
+
+- Define the scope, users, aggregation axes, and update timing of the initial management-accounting reports on ERP4.
+- Clarify the assumption that statutory accounting remains in the external accounting system, while ERP4 handles the fast internal values required for management decisions.
+- Position the existing `project-profit`, `project-effort`, `overtime`, `delivery-due`, `burndown`, and `project-evm` implementations within the management-accounting context.
+
+## Assumptions
+
+- The primary specification for project profitability is `docs/requirements/profit-and-variance.md`.
+- The baseline for automated delivery and report formatting is `docs/requirements/workflow-report-expansion.md`.
+- Gaps related to payroll and accounting integrations are tracked in `docs/requirements/erp4-payroll-accounting-gap-analysis.md`.
+- In the initial phase, ERP4 treats internally reproducible source data as its own system of record, while clearly labeling differences from statutory accounting as preliminary management values.
+- The initial phase does not allocate company-wide overhead. Indirect costs are posted to shared or pseudo projects, and allocation rules are deferred to a later phase.
+
+## Expected users
+
+| User                    | Primary use                                                                   | Required granularity                                  | Already covered by existing implementation                   | Additional requirement                                   |
+| ----------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------ | -------------------------------------------------------- |
+| Executives              | Monthly sales, cost, gross profit, backlog, and loss-making project detection | Monthly, by department, by project                    | Project profit, overdue unbilled deliveries, effort variance | Department P/L, company-wide KPI dashboard               |
+| Administration          | Reproducibility after close, periodic delivery, pre-accounting verification   | Monthly, by project, by employee, by delivery history | CSV/PDF delivery, project profit, overtime                   | Pre-payroll/accounting reconciliation, closing snapshots |
+| PMs / operational leads | Project profitability, effort overrun, unbilled delivery checks               | By project, by user, by group, weekly/monthly         | Project profit, effort variance, burndown, EVM               | Dashboard navigation, role-based visibility              |
+
+## Reports already available in ERP4
+
+### Existing APIs / UI / delivery
+
+| Area                        | API / screen                                      | Purpose                                                  | Main axes                         | Output           |
+| --------------------------- | ------------------------------------------------- | -------------------------------------------------------- | --------------------------------- | ---------------- |
+| Effort variance             | `GET /reports/project-effort/:projectId`          | Project-level effort and expense actuals                 | project, from, to                 | JSON / CSV / PDF |
+| Project profitability       | `GET /reports/project-profit/:projectId`          | Sales, direct cost, gross profit                         | project, from, to                 | JSON / CSV / PDF |
+| Profitability by user       | `GET /reports/project-profit/:projectId/by-user`  | User-level profitability via labor-cost-ratio allocation | project, userIds, from, to        | JSON / CSV / PDF |
+| Profitability by group      | `GET /reports/project-profit/:projectId/by-group` | Profitability by user group                              | project, userIds, label, from, to | JSON / CSV / PDF |
+| Group effort                | `GET /reports/group-effort`                       | Effort total for a user set                              | userIds, from, to                 | JSON / CSV / PDF |
+| Overtime by user            | `GET /reports/overtime/:userId`                   | Individual effort totals and overtime view               | user, from, to                    | JSON / CSV / PDF |
+| Overdue unbilled deliveries | `GET /reports/delivery-due`                       | Milestone-level unbilled delivery monitoring             | project, from, to                 | JSON / CSV / PDF |
+| Burndown                    | `GET /reports/burndown/:projectId`                | Burn performance vs baseline                             | project, baseline, from, to       | JSON             |
+| EVM                         | `GET /reports/project-evm/:projectId`             | PV / EV / AC / SPI / CPI                                 | project, from, to                 | JSON             |
+
+### Current strengths
+
+- ERP4 can already reproduce project-level sales, cost, effort, and gross profit from internal data alone.
+- CSV/PDF output and scheduled delivery foundations already exist.
+- For PM-facing profitability and effort control, the current implementation already forms a workable MVP baseline.
+
+### Current gaps
+
+- No authoritative department P/L source exists.
+  - `department` exists on `UserAccount`, but it is not normalized as a reporting axis for revenue and cost.
+- No authoritative payroll-cost source exists.
+  - Current labor cost is `time_entries * rate_cards.unitPrice`, which is a management rate rather than confirmed payroll cost.
+- There is no journal-level aggregation aligned to statutory accounting categories.
+- There is no management-accounting snapshot that guarantees reproducibility after monthly close.
+- Role-based dashboard requirements are not yet fully documented.
+
+## Initial report list
+
+### R1. Project profitability summary
+
+- Purpose: confirm revenue, direct cost, gross profit, gross margin, and effort actuals by project.
+- Users: executives, administration, PMs
+- Aggregation axes:
+  - project
+  - from / to
+- Data sources:
+  - `Invoice`
+  - `VendorInvoice`
+  - `Expense`
+  - `TimeEntry`
+  - `RateCard`
+- Update timing:
+  - on-demand UI
+  - monthly / weekly scheduled delivery
+- Implementation status:
+  - largely covered by existing `project-profit`
+- Notes:
+  - treated as preliminary management values
+  - differences from statutory accounting are tolerated and reconciled on the external-accounting side
+
+### R2. Project profitability drilldown (by user / by group)
+
+- Purpose: identify why cost overruns occur and how profitability differs across assignees and teams.
+- Users: executives, administration, PMs
+- Aggregation axes:
+  - project
+  - user / user group
+  - from / to
+- Data sources:
+  - `project-profit-by-user`
+  - `project-profit-by-group`
+- Update timing:
+  - on-demand
+  - monthly delivery
+- Implementation status:
+  - existing APIs are available
+  - the Reports screen already exposes drilldown for by-user and by-group views
+- Requirement notes:
+  - `allocationMethod` must be displayed
+  - the UI must explicitly state that the calculation uses labor-cost-ratio allocation
+
+### R3. Department profit and loss
+
+- Purpose: allow executives and administration to understand sales, cost, and gross profit by department.
+- Users: executives, administration
+- Aggregation axes:
+  - department
+  - month
+  - optional project drilldown
+- Initial data-source policy:
+  - revenue: `Invoice.projectId -> Project`
+  - direct cost: `VendorInvoice`, `Expense`, `TimeEntry`
+  - department axis: initially use the project's owning department or responsible department as the primary candidate
+- Implementation prerequisites:
+  - normalized department-code rules and `project -> department` rules are required
+  - depends on `#1434`, `#1439`, and `#1441`
+- Phase:
+  - requirements only in the initial phase
+  - implementation comes later
+
+### R4. Monthly KPI dashboard
+
+- Purpose: show monthly management indicators in one place.
+- Users: executives, administration
+- Initial KPIs:
+  - revenue actual
+  - direct cost
+  - gross profit
+  - gross margin
+  - overdue unbilled delivery count / amount
+  - effort actuals
+  - overtime
+  - number of loss-making projects
+- Aggregation granularity:
+  - monthly
+  - company / department / project
+- Data sources:
+  - R1, `delivery-due`, `group-effort`, `overtime`
+- Implementation prerequisites:
+  - reuse existing report APIs first
+  - KPI card/dashboard layout is a separate issue
+- Initial implementation:
+  - `GET /reports/management-accounting/summary?from=YYYY-MM-DD&to=YYYY-MM-DD`
+  - `GET /reports/management-accounting/summary?from=YYYY-MM-DD&to=YYYY-MM-DD&format=csv`
+  - one API returns revenue, direct cost, gross profit, overdue unbilled values, overtime, and loss-making-project count from ERP4 internal data
+  - when multiple currencies exist, top-level aggregated monetary KPI fields are omitted and `currencyBreakdown[]` is returned instead
+  - CSV is flattened into three sections: `summary`, `currency_breakdown`, and `top_red_project`
+  - the initial UI exposes a management-accounting summary card and CSV download under `Reports`, while project-level confirmation continues to use the existing `project-profit`
+
+### R5. Pre-close reconciliation report for administration
+
+- Purpose: verify closing-scope counts and unresolved items before payroll/accounting export.
+- Users: administration
+- Required checks:
+  - unapproved expenses, vendor invoices, leave requests, and time entries in the target period
+  - overdue unbilled deliveries
+  - worklogs without rate cards
+  - masters without external codes
+- Implementation prerequisites:
+  - depends on `#1433`, `#1434`, `#1435`, `#1439`, `#1440`, and `#1441`
+- Phase:
+  - requirements first
+  - implementation later
+
+## Aggregation axes and data-source definitions
+
+### Revenue
+
+- Initial definition: `Invoice.totalAmount`
+- Inclusion rule: `status in (approved, sent, paid)`
+- Period basis: `issueDate`
+- Notes:
+  - receipt-based accounting is out of scope in the initial phase
+  - when multiple currencies are present, values are separated by currency and not aggregated into one top-level monetary figure
+
+### Cost
+
+- Outsourcing / purchases: `VendorInvoice.totalAmount`
+- Direct expenses: `Expense.amount`
+- Labor cost: `TimeEntry.minutes * RateCard.unitPrice`
+- Notes:
+  - labor cost is management-rate based, not payroll-confirmed cost
+  - after payroll integration is complete, both payroll-confirmed labor cost and management-rate labor cost may coexist
+
+### Department
+
+- Initial requirement:
+  - the authoritative department axis for reporting must come from a normalized department master with external-integration codes
+  - free-text `UserAccount.department` must not be treated as the reporting system of record
+- Dependencies:
+  - `#1434` external code-system design
+  - `#1439` HR/payroll prerequisite master data
+
+### Project
+
+- Initial requirement:
+  - project profitability uses `Project.id` as the authoritative internal key
+  - display and external references use `Project.code`
+
+### Labor-cost allocation
+
+- Initial policy:
+  - project-level profitability keeps the existing `labor_cost` / `minutes` based allocation
+  - department-level P/L requires a later allocation rule
+- Initial operational handling:
+  - shared labor cost is aggregated into shared/admin projects
+  - redistribution from there is deferred to a later phase
+
+## Update timing
+
+- On-demand APIs:
+  - project profitability
+  - effort variance
+  - burndown
+  - EVM
+- Scheduled delivery:
+  - monthly project profitability, overdue unbilled deliveries, overtime, KPI summary
+- Monthly close:
+  - initially covered by `PeriodLock` plus operational evidence
+  - a dedicated snapshot model is expected later
+
+## Permission requirements
+
+- Existing report APIs are limited to `admin` / `mgmt`
+- Initial-phase direction:
+  - company-wide KPI and department P/L remain limited to `admin`, `mgmt`
+  - PM-only visibility for owned projects is desired, but still differs from current route design
+- Conclusion:
+  - record the requirement that PMs should only view their own projects, and treat implementation as a later task
+
+## Initial KPI table
+
+| KPI                       | Definition                                       | Existing source                               | Status                                        |
+| ------------------------- | ------------------------------------------------ | --------------------------------------------- | --------------------------------------------- |
+| Monthly revenue           | Sum of `Invoice.totalAmount` in the target month | `project-profit` aggregation logic            | partially reusable                            |
+| Monthly direct cost       | `VendorInvoice + Expense + laborCost`            | `project-profit` aggregation logic            | partially reusable                            |
+| Monthly gross profit      | revenue - direct cost                            | `project-profit` aggregation logic            | partially reusable                            |
+| Gross margin              | gross profit / revenue                           | `project-profit` aggregation logic            | partially reusable                            |
+| Effort actuals            | sum of `TimeEntry.minutes`                       | `project-effort`, `group-effort`              | implemented                                   |
+| Overtime                  | total hours from `reportOvertime`                | `overtime`                                    | implemented, but definition may need revision |
+| Overdue unbilled count    | count from `delivery-due`                        | `delivery-due`                                | implemented                                   |
+| Loss-making project count | number of projects with gross profit < 0         | cross-project aggregation of `project-profit` | not implemented                               |
+
+## Initial phase boundary
+
+### Included in the initial implementation phase
+
+- Project profitability and its delivery pipeline
+- By-user and by-group profitability drilldown
+- Effort variance, overdue unbilled deliveries, and overtime
+- KPI requirement definition for the management-accounting dashboard
+
+### Requirements-only items deferred to later implementation
+
+- Department P/L
+- Payroll-confirmed labor cost
+- Journal-category aggregation
+- Company-wide overhead allocation
+- Monthly closing snapshots
+
+## Links to subsequent issues
+
+- `#1433`: gap analysis between ERP4 source data and required items
+- `#1434`: external code-system design
+- `#1435`: common integration specification
+- `#1439`: HR/payroll prerequisite masters
+- `#1440`: confirmed attendance data
+- `#1441`: accounting events and journal conversion rules
+- `#1447`: implementation of the initial reports defined here
+
+## Repository-derived open issues
+
+- Whether department P/L should use `Project`, `User`, or `Group` as the authoritative department anchor
+- Whether labor cost should be displayed as management-rate based, payroll-confirmed, or both
+- How PM-facing visibility should be split across routes, dashboards, and subscriptions
+- Whether monthly reproducibility is sufficiently covered by `PeriodLock` alone or requires snapshots
+- Whether the KPI dashboard should remain monthly only or later support weekly / quarterly views

--- a/docs/en/requirements/non-chat-spec-index.md
+++ b/docs/en/requirements/non-chat-spec-index.md
@@ -1,0 +1,52 @@
+# Non-Chat Specification Index
+
+Purpose: provide a single entry point for specifications outside chat features, including projects, estimates/invoices, time, expenses, approvals, reports, integrations, and operations.
+
+## 1. Primary specifications (recommended reading order)
+
+- Scope and overall shape: `docs/requirements/mvp-scope.md`
+- Domain, data model, and API draft: `docs/requirements/domain-api-draft.md`
+- Screens and operational flows (estimate / invoice / purchase / vendor invoice): `docs/requirements/estimate-invoice-po-ui.md`, `docs/requirements/delivery-invoice-flow.md`, `docs/requirements/vendor-doc-linking.md`, `docs/requirements/document-template-variants.md`
+- Annotations and evidence: `docs/requirements/annotations.md`, `docs/requirements/workflow-evidence-pack.md`
+- Approval, alerts, notifications, and ActionPolicy: `docs/requirements/approval-alerts.md`, `docs/requirements/approval-log.md`, `docs/requirements/alerts-notify.md`, `docs/requirements/alert-suppression.md`, `docs/requirements/notifications.md`, `docs/requirements/approval-ack-messages.md`, `docs/requirements/action-policy-high-risk-apis.md`, `docs/requirements/action-policy-failsafe-inventory.md`
+- External integrations (payroll/accounting): `docs/requirements/erp4-payroll-accounting-gap-analysis.md`, `docs/requirements/external-code-system-design.md`, `docs/en/requirements/external-csv-integration-common-spec.md`, `docs/requirements/hr-crm-integration.md`, `docs/en/requirements/payroll-rakuda-employee-master-csv.md`, `docs/en/requirements/payroll-rakuda-attendance-csv.md`, `docs/en/requirements/accounting-ics-journal-csv.md`
+- Spec/implementation alignment review (2026-02): `docs/requirements/spec-review-2026-02-10.md`
+- Project, task, milestone, and recurring project operations:
+  - `docs/requirements/project-task-milestone-flow.md`
+  - `docs/requirements/recurring-project-template.md`
+  - `docs/requirements/project-member-ops.md`
+  - `docs/requirements/reassignment-policy.md`
+- Time, expense, leave, daily report, and wellbeing:
+  - API and core concepts: `docs/requirements/domain-api-draft.md`
+  - Wellbeing: `docs/requirements/wellbeing-policy.md`
+  - Expense settlement: `docs/requirements/expense-settlement.md`
+  - Missing daily reports: `docs/requirements/daily-report-missing.md`
+- Profitability, budget variance, and rate cards: `docs/requirements/profit-and-variance.md`, `docs/requirements/rate-card.md`
+- Management accounting and executive reporting: `docs/en/requirements/management-accounting-report-requirements.md`
+- Authentication, identity, and access control: `docs/requirements/id-management.md`, `docs/requirements/access-control.md`, `docs/requirements/rbac-matrix.md`
+- Operations (backup, jobs, monitoring): `docs/requirements/backup-restore.md`, `docs/requirements/batch-jobs.md`, `docs/requirements/ops-monitoring.md`
+- Data migration: `docs/requirements/migration-mapping.md`, `docs/requirements/migration-tool.md`, `docs/requirements/db-migration.md`, `docs/requirements/migration-poc.md`
+- QA and test evidence: `docs/requirements/qa-plan.md`, `docs/manual/manual-test-checklist.md`, `docs/test-results/README.md`
+
+Note: for chat features, the primary specifications are `docs/requirements/chat-rooms.md` and the room-integration supplements under `docs/requirements/project-chat.md`.
+
+## 2. Confirmed decisions (summary)
+
+- Time entries are recorded without approval by default; only significant edits go through approval flow.
+- Expenses must always be attached to a project. Shared costs are handled through internal/admin projects.
+- Invoices may be issued without estimates. Milestone linkage is optional. Unbilled overdue deliveries are handled by alerts and reports.
+- Numbering uses `PYYYY-MM-NNNN` with per-kind, per-month sequences.
+- Physical deletes are prohibited. Logical delete plus reason code is the default. Re-assignment and delete-like changes are blocked while approval is open.
+
+## 3. Maintenance notes
+
+- `docs/requirements/mvp-scope.md` is a summary document. For final approval and operational behavior, refer to `docs/requirements/approval-alerts.md`.
+- Approval actions are standardized on `POST /approval-instances/:id/act`; dedicated per-resource `/approve` endpoints are not the target design.
+
+## 4. Open checks (non-chat)
+
+- Whether estimate numbers must be searchable and persisted as first-class identifiers.
+- Whether invoice `dueDate` must be mandatory or warning-only.
+- Ownership and permission model for payment/mark-paid operations, including partial payment handling.
+- Period locking rules and how they align with `period_locks`.
+- Production S3 values for backup (`bucket`, `region`, `KMS`) and migration timing.

--- a/docs/en/requirements/payroll-rakuda-attendance-csv.md
+++ b/docs/en/requirements/payroll-rakuda-attendance-csv.md
@@ -1,0 +1,219 @@
+# Payroll Rakuda Integration: Attendance CSV Specification (Initial Repo-Based Draft)
+
+Updated: 2026-03-15
+Related issues: `#1437`, `#1430`, `#1433`, `#1435`, `#1440`
+
+## Purpose
+
+- Clarify which data can already be reused for Payroll Rakuda attendance export and which monthly-closing and summary models are still required.
+- Define the logical fields and responsibility boundaries under the policy that payroll CSV must be based on monthly confirmed attendance aggregates, not raw time-entry details.
+
+## Assumptions
+
+- The target product is assumed to be `Kyuyo Rakuda Pro Version 26.00 Rev.10.31`.
+- The actual CSV template, encoding, and required fields are still unknown and depend on `#1431` and `#1432`.
+- Payroll Rakuda attendance CSV import is not used in current operation.
+- Operators understand that attendance-summary CSV import is possible, but the template has not been obtained.
+- Based on official Q&A, using CSV attendance import may switch the product from traditional time cards to a simplified aggregate-only time-card mode.
+- The current ERP4 export is only `GET /integrations/hr/exports/leaves`, which exports approved leave details.
+- `TimeEntry` is a worklog/project-cost model, not a payroll-grade attendance system of record.
+- Snapshot models required for monthly confirmation, versioned closing, and reproducible re-export were started as `AttendanceClosingPeriod` and `AttendanceMonthlySummary`.
+- The first implementation phase provides `POST /integrations/hr/attendance/closings` and `GET /integrations/hr/attendance/closings*` for confirmed monthly snapshots.
+
+## Current ERP4 source data
+
+### Leave
+
+- `LeaveRequest`
+  - `userId`
+  - `leaveType`
+  - `startDate`
+  - `endDate`
+  - `hours`
+  - `minutes`
+  - `startTimeMinutes`
+  - `endTimeMinutes`
+  - `status`
+  - `updatedAt`
+- `LeaveType`
+  - `code`
+  - `name`
+  - `unit`
+  - `isPaid`
+- Existing export
+  - `GET /integrations/hr/exports/leaves?target=attendance|payroll`
+  - `POST /integrations/hr/exports/leaves/dispatch`
+  - `GET /integrations/hr/exports/leaves/dispatch-logs`
+
+### Worklog / working-time evidence
+
+- `TimeEntry`
+  - `userId`
+  - `projectId`
+  - `workDate`
+  - `minutes`
+  - `workType`
+  - `location`
+  - `status`
+  - `approvedBy`
+  - `approvedAt`
+
+### Leave setting and working-day configuration
+
+- `LeaveSetting.defaultWorkdayMinutes`
+- `LeaveGrant`, `LeaveCompGrant`, `LeaveCompConsumption`
+- `WorkdayCalendar` routes
+
+## What is still missing in ERP4
+
+| Topic                                                    | Current state                                       | Status          | Notes                                                 |
+| -------------------------------------------------------- | --------------------------------------------------- | --------------- | ----------------------------------------------------- |
+| Monthly confirmed attendance table                       | none                                                | Not implemented | `#1440`                                               |
+| Versioned monthly closing                                | none                                                | Not implemented | snapshot model required                               |
+| Working-day count                                        | not stored                                          | Not implemented | cannot be derived safely from leave and worklog alone |
+| Scheduled work minutes                                   | no per-person value                                 | Not implemented | only global default exists                            |
+| Overtime buckets (statutory, extra, late-night, holiday) | absent                                              | Not implemented | `TimeEntry.minutes` alone is insufficient             |
+| Late arrival / early leave / absence                     | absent                                              | Not implemented | requires actual attendance/timestamp model            |
+| Closing state                                            | initial support in `AttendanceClosingPeriod.status` | Conditional     | `PeriodLock` integration is future work               |
+| Monthly employee attendance summary                      | initial support in `AttendanceMonthlySummary`       | Conditional     | currently covers totals, not all buckets              |
+
+## Logical field definition (initial draft)
+
+| Logical field            | Intended meaning             | ERP4 source                                        | Status          | Notes                                                  |
+| ------------------------ | ---------------------------- | -------------------------------------------------- | --------------- | ------------------------------------------------------ |
+| employeeCode             | Employee key                 | none yet                                           | Not implemented | depends on the same employee-key foundation as `#1436` |
+| closingMonth             | Target month                 | none yet                                           | Not implemented | requires closing model                                 |
+| workingDays              | Number of worked days        | none                                               | Not implemented | no attendance-grade workday rule exists                |
+| scheduledMinutes         | Scheduled work minutes       | `LeaveSetting.defaultWorkdayMinutes` as reference  | Conditional     | no per-person schedule yet                             |
+| actualMinutes            | Actual work minutes          | derivable from `TimeEntry.minutes`                 | Conditional     | worklog-based, not attendance-grade                    |
+| overtimeMinutes          | Overtime total               | existing overtime reporting has only simple totals | Conditional     | no statutory buckets yet                               |
+| paidLeaveMinutes         | Paid leave consumed          | `LeaveRequest` + `LeaveType.isPaid`                | Available       | monthly confirmed aggregation still needed             |
+| unpaidLeaveMinutes       | Unpaid leave consumed        | `LeaveRequest` + `LeaveType.isPaid=false`          | Available       | same as above                                          |
+| compensatoryLeaveMinutes | Comp time / substitute leave | leave-type and comp-grant data                     | Conditional     | output classification still undecided                  |
+| tardinessMinutes         | Late arrival                 | none                                               | Not implemented | requires attendance timestamps                         |
+| earlyLeaveMinutes        | Early leave                  | none                                               | Not implemented | same as above                                          |
+| absenceDays              | Absence days                 | none                                               | Not implemented | requires schedule vs actual comparison                 |
+| note                     | Free note                    | `LeaveRequest.notes` exists                        | Conditional     | whether payroll CSV should carry this is unconfirmed   |
+
+## Role of the existing leave export
+
+### What is already possible
+
+- Approved leave details can be exported with `attendance` or `payroll` targets.
+- `GET /integrations/hr/exports/leaves` supports differential extraction with `updatedSince`, `limit`, and `offset`.
+- `POST /integrations/hr/exports/leaves/dispatch` supports managed redispatch through `idempotencyKey` in the request body.
+- The payload already includes `leaveTypeName`, `leaveTypeUnit`, `leaveTypeIsPaid`, and `requestedMinutes`.
+- `POST /integrations/hr/attendance/closings` creates a period-based closing snapshot.
+- `GET /integrations/hr/attendance/closings` and `GET /integrations/hr/attendance/closings/:id/summaries` expose the closed data.
+
+### What the leave export still does not solve
+
+- It is not a monthly confirmed employee summary.
+- It does not include worked-day count, scheduled minutes, or overtime buckets.
+- It does not provide closing month, closing version, or reproducible export lineage.
+- The responsibility boundary between approved leave details and payroll-grade confirmed attendance is still separate.
+- `AttendanceMonthlySummary` currently covers total overtime and paid/unpaid leave only; statutory buckets are not implemented.
+- `AttendanceClosingPeriod` is dedicated to payroll-oriented snapshots and does not yet integrate with `PeriodLock`.
+
+## Initial closing policy
+
+### Principles
+
+- Payroll CSV must be generated from monthly confirmed attendance values.
+- Raw `TimeEntry` or `LeaveRequest` rows must not be exported directly to payroll CSV.
+- In the initial implementation, closing is rejected if unapproved `TimeEntry` or `LeaveRequest` rows remain in the target month.
+
+### Closing scope
+
+- Active employees in the target month
+- Approved leave
+- Confirmed time/attendance values eligible for payroll calculation
+
+### Recalculation and re-export
+
+- If source data changes after closing, a new closing version must be created.
+- Every CSV export must record which closing version it came from.
+- The initial implementation adds a new version with `reclose=true` and marks the previous version as `superseded`.
+
+## Initial ERP4-to-CSV mapping strategy
+
+### Fields that can already be derived logically
+
+| CSV logical field      | Current source                  | Condition                            |
+| ---------------------- | ------------------------------- | ------------------------------------ |
+| paidLeaveMinutes       | approved leave + `isPaid=true`  | monthly aggregation logic required   |
+| unpaidLeaveMinutes     | approved leave + `isPaid=false` | same                                 |
+| leaveBreakdown         | leave-type-based breakdown      | possible by extending leave export   |
+| actualMinutesCandidate | sum of `TimeEntry.minutes`      | must be labeled as non-payroll-grade |
+
+### Fields that cannot be produced from current data alone
+
+| CSV logical field                    | Reason                                                |
+| ------------------------------------ | ----------------------------------------------------- |
+| workingDays                          | no authoritative workday rule exists                  |
+| scheduledMinutes                     | no per-person work schedule exists                    |
+| overtimeMinutesByType                | no statutory/late-night/holiday classification exists |
+| tardinessMinutes / earlyLeaveMinutes | no attendance timestamps                              |
+| absenceDays                          | no schedule-vs-actual gap calculation                 |
+| closingMonth / closingVersion        | no finalized payroll export versioning model          |
+
+## Initial rounding policy
+
+- Internal canonical values use minutes.
+- If the actual CSV requires hours, half-hours, or 10-minute units, conversion must happen in the output adapter.
+- Rounding rules must be fixed when creating the monthly confirmed snapshot, not recalculated at CSV generation time.
+
+## Initial error categories
+
+### Export-stopping errors
+
+- Target month is not closed
+- Employee code is missing
+- Required source data is missing for a closing target employee
+- Required schedule / workday definition is missing
+
+### Warning-level issues
+
+- Leave exists but no corresponding time entry exists
+- Time entries exist but do not align with approved leave
+- Worklog-based `actualMinutes` diverges from the attendance system of record
+
+## Test coverage considerations
+
+### Positive cases
+
+- One confirmed monthly row is generated per employee.
+- Approved leave is aggregated separately into paid and unpaid leave minutes.
+- Re-export reproduces the same closing version.
+
+### Negative cases
+
+- Export request for an unclosed month is rejected.
+- Missing employee codes in closing targets cause export failure.
+- Missing schedule-related values cause export failure.
+- Re-export never silently shifts from one closing version to another.
+
+## Items that still require confirmation
+
+1. Actual Payroll Rakuda attendance CSV columns, order, and required fields
+2. What exactly qualifies as a confirmed monthly value
+   - approved worklogs
+   - attendance-specific monthly closing
+   - approved leave
+3. Required overtime granularity
+   - total overtime only
+   - or statutory / extra / late-night / holiday buckets
+4. Leave output granularity
+   - paid/unpaid totals only
+   - or leave-type-specific breakdowns
+5. System of record for scheduled minutes
+   - company default
+   - employment-type-based
+   - or person-specific
+6. Whether `TimeEntry` should remain only an upstream source or be treated as part of confirmed attendance logic
+
+## Current conclusion
+
+- `#1437` can move forward only as a source-data and responsibility-boundary draft until the real payroll template is obtained.
+- The `#1440` baseline now provides closing and summary foundations, but it is not yet a full payroll attendance model.
+- The next material design decisions are the attendance source of truth, closing granularity, and overtime bucket rules.

--- a/docs/en/requirements/payroll-rakuda-employee-master-csv.md
+++ b/docs/en/requirements/payroll-rakuda-employee-master-csv.md
@@ -1,0 +1,227 @@
+# Payroll Rakuda Integration: Employee Master CSV Specification (Initial Repo-Based Draft)
+
+Updated: 2026-03-15
+Related issues: `#1436`, `#1430`, `#1433`, `#1434`, `#1435`, `#1439`, `#1442`
+
+## Purpose
+
+- Separate what can already be determined from the repository from what still depends on the actual Payroll Rakuda template and operational confirmation.
+- Inventory which fields ERP4 can already provide, which fields require additional implementation, and which fields require fixed values or mapping values.
+
+## Assumptions
+
+- This document is an initial draft based on the repository state as of 2026-03-10.
+- The target product is assumed to be `Kyuyo Rakuda Pro Version 26.00 Rev.10.31`.
+- The product version is known, but the actual CSV column definition, encoding, and required columns remain pending and are tracked in `#1432`.
+- CSV import into Payroll Rakuda is not used in the current operation.
+- No explicit downloadable employee-master CSV template has been found in the product UI or the official site.
+- The existing `GET /integrations/hr/exports/users` endpoint is an HR/ID integration export, not the payroll-specific CSV itself.
+- `UserAccount.externalId` is reserved for IdP/SCIM and must not double as the payroll employee key.
+- The initial `#1442` implementation adds canonical employee-master export, dispatch, and dispatch logs.
+
+## Fields currently available in ERP4
+
+### Existing sources
+
+- `UserAccount`
+  - `id`
+  - `externalId`
+  - `userName`
+  - `displayName`
+  - `givenName`
+  - `familyName`
+  - `active`
+  - `emails`
+  - `phoneNumbers`
+  - `department`
+  - `organization`
+  - `managerUserId`
+  - `createdAt`
+  - `updatedAt`
+- Existing export endpoint
+  - `GET /integrations/hr/exports/users`
+  - Supports `updatedSince`, `limit`, and `offset`
+
+## Logical field definition (initial draft)
+
+The actual CSV column names will be finalized after `#1432`. This section defines the logical fields on the ERP4 side.
+
+| Logical field       | Intended use                   | ERP4 source                                          | Status          | Notes                                            |
+| ------------------- | ------------------------------ | ---------------------------------------------------- | --------------- | ------------------------------------------------ |
+| employeeCode        | Payroll-system employee key    | `UserAccount.employeeCode`                           | Available       | Added by `#1439` foundation work                 |
+| loginId             | Secondary identifier           | `UserAccount.userName`                               | Available       | Not a primary key because login IDs may change   |
+| externalIdentityId  | IdP/SCIM external identity     | `UserAccount.externalId`                             | Available       | Informational only                               |
+| displayName         | Display name                   | `UserAccount.displayName`                            | Available       | Fallback rule is required when missing           |
+| familyName          | Family name                    | `UserAccount.familyName`                             | Available       | No automatic split from `displayName` is planned |
+| givenName           | Given name                     | `UserAccount.givenName`                              | Available       | Same as above                                    |
+| activeFlag          | Active/inactive state          | `UserAccount.active`                                 | Available       | Current state, not termination date              |
+| departmentName      | Department display name        | `UserAccount.department`                             | Conditional     | Name only; code is not implemented               |
+| organizationName    | Organization display name      | `UserAccount.organization`                           | Conditional     | Code system not implemented                      |
+| managerEmployeeCode | Manager employee code          | derived from `managerUserId`                         | Not implemented | Requires manager-to-employee-code conversion     |
+| email               | Contact email                  | `UserAccount.emails`                                 | Conditional     | Primary-selection rule is required               |
+| phone               | Contact phone                  | `UserAccount.phoneNumbers`                           | Conditional     | Primary-selection rule is required               |
+| employmentType      | Employment classification      | `UserAccount.employmentType`                         | Available       | Added by `#1439` foundation work                 |
+| title               | Job title                      | none                                                 | Not implemented | Payroll title vs display title needs design      |
+| joinDate            | Hire date                      | `UserAccount.joinedAt`                               | Available       | Added by `#1439` foundation work                 |
+| leaveDate           | Separation date                | `UserAccount.leftAt`                                 | Available       | Added by `#1439` foundation work                 |
+| payrollGroup        | Payroll/closing scheme         | `EmployeePayrollProfile.payrollType` / `closingType` | Conditional     | Actual CSV mapping still needs confirmation      |
+| defaultWorkMinutes  | Default scheduled work minutes | `LeaveSetting.defaultWorkdayMinutes`                 | Conditional     | Only global default exists today                 |
+| bankAccount         | Payment account                | `EmployeePayrollProfile.bankInfo`                    | Conditional     | Granularity must be confirmed                    |
+| note                | Free note                      | optional                                             | Undecided       | Prefer not to use unless required                |
+
+## Initial classification of required, optional, and fixed-value fields
+
+### Fields that can already be considered tentatively required within ERP4
+
+- `loginId`
+- `displayName` or `familyName` / `givenName`
+- `activeFlag`
+
+### Fields likely required for payroll operation but not yet fully implemented in ERP4
+
+- `employeeCode`
+- `employmentType`
+- `joinDate`
+- `payrollGroup`
+- `departmentCode` or an equivalent organizational code required for payroll aggregation
+
+### Optional candidates
+
+- `email`
+- `phone`
+- `title`
+- `managerEmployeeCode`
+
+### Candidates that require fixed values or mapping values
+
+- Active/inactive code values
+- Employment-type codes
+- Department or organization codes
+- Payroll-group codes
+
+## Output policy (initial draft)
+
+### Output unit
+
+- Full export is the initial default.
+- The existing users export supports `updatedSince`, but whether Payroll Rakuda safely accepts differential master import is still unknown.
+
+### Sort order
+
+- Initial proposal: `employeeCode ASC`
+
+### Encoding and line endings
+
+- Internal canonical format: `UTF-8 + LF`
+- Adapter output may convert to `Shift_JIS` / `CRLF` if required by the actual template.
+
+## Current implementation baseline
+
+- API
+  - `GET /integrations/hr/exports/users/employee-master`
+  - `POST /integrations/hr/exports/users/employee-master/dispatch`
+  - `GET /integrations/hr/exports/users/employee-master/dispatch-logs`
+- Canonical CSV header
+  - `employeeCode`
+  - `loginId`
+  - `externalIdentityId`
+  - `displayName`
+  - `familyName`
+  - `givenName`
+  - `activeFlag`
+  - `employmentType`
+  - `joinDate`
+  - `leaveDate`
+  - `departmentName`
+  - `organizationName`
+  - `departmentCode`
+  - `payrollType`
+  - `closingType`
+  - `paymentType`
+  - `titleCode`
+  - `email`
+  - `phone`
+- Initial validation
+  - Missing `employeeCode` returns `409 employee_master_employee_code_missing`
+- Dispatch behavior
+  - Supports `idempotencyKey` replay / conflict / in-progress handling
+  - Execution history is stored in `HrEmployeeMasterExportLog`
+
+### Empty-value behavior
+
+- Empty required columns stop the export.
+- Optional columns are emitted as empty strings.
+- Mapping failures stop the export and should be surfaced as `validation_*` or `mapping_*` failures.
+
+## Initial ERP4-to-CSV mapping strategy
+
+### Parts that can already be reused from the existing users export
+
+| CSV logical column  | Current export value | Notes                               |
+| ------------------- | -------------------- | ----------------------------------- |
+| loginId             | `userName`           | Reusable as-is                      |
+| displayName         | `displayName`        | Fallback rule needed when null      |
+| familyName          | `familyName`         | Null handling must be confirmed     |
+| givenName           | `givenName`          | Null handling must be confirmed     |
+| activeFlag          | `active`             | May require code conversion         |
+| departmentName      | `department`         | Name only; code mapping is separate |
+| organizationName    | `organization`       | Same as above                       |
+| managerEmployeeCode | `managerUserId`      | Requires employee-code conversion   |
+
+### Master data that still needs dedicated implementation
+
+| CSV logical column   | Recommended storage            | Reason                                       |
+| -------------------- | ------------------------------ | -------------------------------------------- |
+| employeeCode         | `UserAccount.employeeCode`     | Must be separated from `externalId`          |
+| employmentType       | `UserAccount.employmentType`   | Core employee attribute                      |
+| title                | dedicated employee profile     | Payroll-facing title needs explicit modeling |
+| payrollGroup         | `EmployeePayrollProfile`       | Closing and payroll schemes belong here      |
+| bankAccount          | `EmployeePayrollProfile`       | Sensitive information should be separated    |
+| joinDate / leaveDate | `UserAccount.joinedAt/leftAt`  | Core employee attribute                      |
+| departmentCode       | department/organization master | Display names are insufficient               |
+
+## Test coverage considerations
+
+### Positive cases
+
+- An active employee is exported as one row.
+- `displayName`, `familyName`, and `givenName` follow the documented fallback rule.
+- `updatedSince` correctly narrows the candidate set.
+
+### Negative cases
+
+- Missing `employeeCode` stops the export.
+- Missing required code mappings stop the export.
+- A manager exists but cannot be converted to `managerEmployeeCode`.
+- Multiple emails or phone numbers exist but no primary-selection rule resolves them.
+
+### Audit requirements
+
+- Full vs delta export mode
+- Target row count
+- Triggering operator
+- Export conditions
+- Missing-field list on failure
+
+## Items that still require confirmation
+
+The following cannot be finalized from the repository alone.
+
+1. Actual Payroll Rakuda employee-master CSV columns, order, and required fields
+2. `employeeCode` length, character set, and numbering rule
+3. Actual code systems for title, employment type, payroll group, and closing type
+4. Whether bank-account data should live in ERP4 or remain in another system of record
+5. Whether differential export is accepted, or whether full export is always required
+6. Whether active/inactive is sufficient, or whether hire and separation dates are mandatory
+
+## Operational facts known today
+
+- The current business process does not import employee-master CSV into Payroll Rakuda.
+- Based on the operator's understanding, employee-ledger CSV import is possible, but the actual template has not been obtained.
+- Therefore, the practical approach today is to first define what ERP4 can provide, then finalize the column-level contract after the template is collected.
+
+## Current conclusion
+
+- `#1436` can move forward as an ERP4-side source-field inventory, even before the real template is obtained.
+- The first implementation scope for `#1442` is the canonical export, dispatch, and dispatch log for employee-master data.
+- Final column names, code systems, and required-field rules still depend on `#1432`.

--- a/docs/requirements/non-chat-spec-index.md
+++ b/docs/requirements/non-chat-spec-index.md
@@ -9,7 +9,6 @@
 - 画面/運用（見積/請求/発注/仕入）: `docs/requirements/estimate-invoice-po-ui.md` / `docs/requirements/delivery-invoice-flow.md` / `docs/requirements/vendor-doc-linking.md` / `docs/requirements/document-template-variants.md`
 - 注釈/エビデンス（メモ/外部URL/内部参照）: `docs/requirements/annotations.md` / `docs/requirements/workflow-evidence-pack.md`
 - 承認/アラート/通知: `docs/requirements/approval-alerts.md` / `docs/requirements/approval-log.md` / `docs/requirements/alerts-notify.md` / `docs/requirements/alert-suppression.md` / `docs/requirements/notifications.md` / `docs/requirements/approval-ack-messages.md` / `docs/requirements/action-policy-high-risk-apis.md` / `docs/requirements/action-policy-failsafe-inventory.md`
-  <<<<<<< HEAD
 - 外部連携（給与/会計）: `docs/requirements/erp4-payroll-accounting-gap-analysis.md` / `docs/requirements/external-code-system-design.md` / `docs/requirements/external-csv-integration-common-spec.md` / `docs/requirements/hr-crm-integration.md` / `docs/requirements/payroll-rakuda-employee-master-csv.md` / `docs/requirements/payroll-rakuda-attendance-csv.md` / `docs/requirements/accounting-ics-journal-csv.md`
 - 仕様実装整合レビュー（2026-02）: `docs/requirements/spec-review-2026-02-10.md`
 - 案件/タスク/マイルストーン/定期案件:
@@ -30,6 +29,8 @@
 - QA/テスト: `docs/requirements/qa-plan.md` / `docs/manual/manual-test-checklist.md` / `docs/test-results/README.md`
 
 補足: チャットの一次ソースは `docs/requirements/chat-rooms.md` とし、`docs/requirements/project-chat.md` は room 統合方針・互換 alias の補助仕様として参照する。
+
+英語版のインデックスは `docs/en/README.md` と `docs/en/requirements/non-chat-spec-index.md` を参照する。
 
 ## 2. 仕様の確定事項（要点）
 


### PR DESCRIPTION
## Summary\n- add English counterparts for payroll/accounting integration requirement docs\n- add an English non-chat requirements index and documentation README\n- add a Japanese index link to the English documentation set\n\n## Verification\n- npx prettier --check docs/en/README.md docs/en/requirements/*.md docs/requirements/non-chat-spec-index.md\n- git diff --check\n