### PR TITLE
docs: clarify employee master canonical scope

### DIFF
--- a/docs/en/requirements/payroll-rakuda-employee-master-csv.md
+++ b/docs/en/requirements/payroll-rakuda-employee-master-csv.md
@@ -1,6 +1,6 @@
 # Payroll Rakuda Integration: Employee Master CSV Specification (Initial Repo-Based Draft)
 
-Updated: 2026-03-15
+Updated: 2026-03-21
 Related issues: `#1436`, `#1430`, `#1433`, `#1434`, `#1435`, `#1439`, `#1442`
 
 ## Purpose
@@ -18,6 +18,8 @@ Related issues: `#1436`, `#1430`, `#1433`, `#1434`, `#1435`, `#1439`, `#1442`
 - The existing `GET /integrations/hr/exports/users` endpoint is an HR/ID integration export, not the payroll-specific CSV itself.
 - `UserAccount.externalId` is reserved for IdP/SCIM and must not double as the payroll employee key.
 - The initial `#1442` implementation adds canonical employee-master export, dispatch, and dispatch logs.
+- The canonical employee-master export schema version is `rakuda_employee_master_v1`.
+- `rakuda_employee_master_v1` means an internally stable ERP4-side canonical export, not a final Payroll Rakuda template-compatible layout.
 
 ## Fields currently available in ERP4
 
@@ -46,28 +48,28 @@ Related issues: `#1436`, `#1430`, `#1433`, `#1434`, `#1435`, `#1439`, `#1442`
 
 The actual CSV column names will be finalized after `#1432`. This section defines the logical fields on the ERP4 side.
 
-| Logical field       | Intended use                   | ERP4 source                                          | Status          | Notes                                            |
-| ------------------- | ------------------------------ | ---------------------------------------------------- | --------------- | ------------------------------------------------ |
-| employeeCode        | Payroll-system employee key    | `UserAccount.employeeCode`                           | Available       | Added by `#1439` foundation work                 |
-| loginId             | Secondary identifier           | `UserAccount.userName`                               | Available       | Not a primary key because login IDs may change   |
-| externalIdentityId  | IdP/SCIM external identity     | `UserAccount.externalId`                             | Available       | Informational only                               |
-| displayName         | Display name                   | `UserAccount.displayName`                            | Available       | Fallback rule is required when missing           |
-| familyName          | Family name                    | `UserAccount.familyName`                             | Available       | No automatic split from `displayName` is planned |
-| givenName           | Given name                     | `UserAccount.givenName`                              | Available       | Same as above                                    |
-| activeFlag          | Active/inactive state          | `UserAccount.active`                                 | Available       | Current state, not termination date              |
-| departmentName      | Department display name        | `UserAccount.department`                             | Conditional     | Name only; code is not implemented               |
-| organizationName    | Organization display name      | `UserAccount.organization`                           | Conditional     | Code system not implemented                      |
-| managerEmployeeCode | Manager employee code          | derived from `managerUserId`                         | Not implemented | Requires manager-to-employee-code conversion     |
-| email               | Contact email                  | `UserAccount.emails`                                 | Conditional     | Primary-selection rule is required               |
-| phone               | Contact phone                  | `UserAccount.phoneNumbers`                           | Conditional     | Primary-selection rule is required               |
-| employmentType      | Employment classification      | `UserAccount.employmentType`                         | Available       | Added by `#1439` foundation work                 |
-| title               | Job title                      | none                                                 | Not implemented | Payroll title vs display title needs design      |
-| joinDate            | Hire date                      | `UserAccount.joinedAt`                               | Available       | Added by `#1439` foundation work                 |
-| leaveDate           | Separation date                | `UserAccount.leftAt`                                 | Available       | Added by `#1439` foundation work                 |
-| payrollGroup        | Payroll/closing scheme         | `EmployeePayrollProfile.payrollType` / `closingType` | Conditional     | Actual CSV mapping still needs confirmation      |
-| defaultWorkMinutes  | Default scheduled work minutes | `LeaveSetting.defaultWorkdayMinutes`                 | Conditional     | Only global default exists today                 |
-| bankAccount         | Payment account                | `EmployeePayrollProfile.bankInfo`                    | Conditional     | Granularity must be confirmed                    |
-| note                | Free note                      | optional                                             | Undecided       | Prefer not to use unless required                |
+| Logical field       | Intended use                   | ERP4 source                                          | Status          | Notes                                                          |
+| ------------------- | ------------------------------ | ---------------------------------------------------- | --------------- | -------------------------------------------------------------- |
+| employeeCode        | Payroll-system employee key    | `UserAccount.employeeCode`                           | Available       | Added by `#1439` foundation work                               |
+| loginId             | Secondary identifier           | `UserAccount.userName`                               | Available       | Not a primary key because login IDs may change                 |
+| externalIdentityId  | IdP/SCIM external identity     | `UserAccount.externalId`                             | Available       | Informational only                                             |
+| displayName         | Display name                   | `UserAccount.displayName`                            | Available       | Fallback rule is required when missing                         |
+| familyName          | Family name                    | `UserAccount.familyName`                             | Available       | No automatic split from `displayName` is planned               |
+| givenName           | Given name                     | `UserAccount.givenName`                              | Available       | Same as above                                                  |
+| activeFlag          | Active/inactive state          | `UserAccount.active`                                 | Available       | Current state, not termination date                            |
+| departmentName      | Department display name        | `UserAccount.department`                             | Conditional     | Name only; code is not implemented                             |
+| organizationName    | Organization display name      | `UserAccount.organization`                           | Conditional     | Code system not implemented                                    |
+| managerEmployeeCode | Manager employee code          | `managerUserId` -> manager `employeeCode`            | Available       | Export stops when the manager employee code cannot be resolved |
+| email               | Contact email                  | `UserAccount.emails`                                 | Conditional     | Primary-selection rule is required                             |
+| phone               | Contact phone                  | `UserAccount.phoneNumbers`                           | Conditional     | Primary-selection rule is required                             |
+| employmentType      | Employment classification      | `UserAccount.employmentType`                         | Available       | Added by `#1439` foundation work                               |
+| title               | Job title                      | none                                                 | Not implemented | Payroll title vs display title needs design                    |
+| joinDate            | Hire date                      | `UserAccount.joinedAt`                               | Available       | Added by `#1439` foundation work                               |
+| leaveDate           | Separation date                | `UserAccount.leftAt`                                 | Available       | Added by `#1439` foundation work                               |
+| payrollGroup        | Payroll/closing scheme         | `EmployeePayrollProfile.payrollType` / `closingType` | Conditional     | Actual CSV mapping still needs confirmation                    |
+| defaultWorkMinutes  | Default scheduled work minutes | `LeaveSetting.defaultWorkdayMinutes`                 | Conditional     | Only global default exists today                               |
+| bankAccount         | Payment account                | `EmployeePayrollProfile.bankInfo`                    | Conditional     | Granularity must be confirmed                                  |
+| note                | Free note                      | optional                                             | Undecided       | Prefer not to use unless required                              |
 
 ## Initial classification of required, optional, and fixed-value fields
 
@@ -105,6 +107,7 @@ The actual CSV column names will be finalized after `#1432`. This section define
 
 - Full export is the initial default.
 - The existing users export supports `updatedSince`, but whether Payroll Rakuda safely accepts differential master import is still unknown.
+- In other words, `updatedSince` is an internal technical contract and does not by itself prove that delta import is operationally safe.
 
 ### Sort order
 
@@ -134,6 +137,7 @@ The actual CSV column names will be finalized after `#1432`. This section define
   - `leaveDate`
   - `departmentName`
   - `organizationName`
+  - `managerEmployeeCode`
   - `departmentCode`
   - `payrollType`
   - `closingType`
@@ -143,6 +147,8 @@ The actual CSV column names will be finalized after `#1432`. This section define
   - `phone`
 - Initial validation
   - Missing `employeeCode` returns `409 employee_master_employee_code_missing`
+  - Unresolved `managerEmployeeCode` returns `409 employee_master_manager_employee_code_missing`
+  - Blank `idempotencyKey` returns `400 invalid_idempotencyKey`
 - Dispatch behavior
   - Supports `idempotencyKey` replay / conflict / in-progress handling
   - Execution history is stored in `HrEmployeeMasterExportLog`
@@ -157,16 +163,16 @@ The actual CSV column names will be finalized after `#1432`. This section define
 
 ### Parts that can already be reused from the existing users export
 
-| CSV logical column  | Current export value | Notes                               |
-| ------------------- | -------------------- | ----------------------------------- |
-| loginId             | `userName`           | Reusable as-is                      |
-| displayName         | `displayName`        | Fallback rule needed when null      |
-| familyName          | `familyName`         | Null handling must be confirmed     |
-| givenName           | `givenName`          | Null handling must be confirmed     |
-| activeFlag          | `active`             | May require code conversion         |
-| departmentName      | `department`         | Name only; code mapping is separate |
-| organizationName    | `organization`       | Same as above                       |
-| managerEmployeeCode | `managerUserId`      | Requires employee-code conversion   |
+| CSV logical column  | Current export value                   | Notes                                                                                                                   |
+| ------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| loginId             | `userName`                             | Reusable as-is                                                                                                          |
+| displayName         | `displayName` or fallback display name | `displayName` is preferred; if blank, use `familyName + " " + givenName`, and if both are blank fall back to `userName` |
+| familyName          | `familyName`                           | Null handling must be confirmed                                                                                         |
+| givenName           | `givenName`                            | Null handling must be confirmed                                                                                         |
+| activeFlag          | `active`                               | May require code conversion                                                                                             |
+| departmentName      | `department`                           | Name only; code mapping is separate                                                                                     |
+| organizationName    | `organization`                         | Same as above                                                                                                           |
+| managerEmployeeCode | `managerUserId`                        | Converted to the manager employee code before export                                                                    |
 
 ### Master data that still needs dedicated implementation
 
@@ -185,7 +191,7 @@ The actual CSV column names will be finalized after `#1432`. This section define
 ### Positive cases
 
 - An active employee is exported as one row.
-- `displayName`, `familyName`, and `givenName` follow the documented fallback rule.
+- `displayName`, `familyName`, `givenName`, and `userName` follow the documented fallback rule.
 - `updatedSince` correctly narrows the candidate set.
 
 ### Negative cases

--- a/docs/requirements/payroll-rakuda-employee-master-csv.md
+++ b/docs/requirements/payroll-rakuda-employee-master-csv.md
@@ -156,7 +156,7 @@
 ### 実装済みエラーコード
 
 - `invalid_updatedSince`
-  - `updatedSince` が ISO-8601 datetime として不正
+  - `updatedSince` が RFC 3339 `date-time` 形式の日時文字列として不正
 - `employee_master_employee_code_missing`
   - 対象社員の `employeeCode` が未設定
 - `employee_master_manager_employee_code_missing`
@@ -165,33 +165,35 @@
   - 同一 `idempotencyKey` の export が実行中
 - `idempotency_conflict`
   - 同一 `idempotencyKey` に対して request hash が不一致
+- `invalid_idempotencyKey`
+  - `idempotencyKey` が trim 後に空文字のときの 400
 
 ## canonical v1 の出力範囲
 
 `rakuda_employee_master_v1` は、現物テンプレート未回収の段階で ERP4 側が安定供給できる列だけを固定した canonical export である。
 
-| 列名                | 出力 | source                                                | 備考                                                             |
-| ------------------- | ---- | ----------------------------------------------------- | ---------------------------------------------------------------- |
-| employeeCode        | 出力 | `UserAccount.employeeCode`                            | 未設定時は `409 employee_master_employee_code_missing`           |
-| loginId             | 出力 | `UserAccount.userName`                                | 補助識別子。給与キーではない                                     |
-| externalIdentityId  | 出力 | `UserAccount.externalId`                              | IdP/SCIM 用。給与専用キーではない                                |
-| displayName         | 出力 | `displayName` 優先、未設定時は `familyName+givenName` | 氏名分解は逆算しない                                             |
-| familyName          | 出力 | `UserAccount.familyName`                              | 未設定時は空値                                                   |
-| givenName           | 出力 | `UserAccount.givenName`                               | 未設定時は空値                                                   |
-| activeFlag          | 出力 | `UserAccount.active`                                  | `1` / `0` に正規化                                               |
-| employmentType      | 出力 | `UserAccount.employmentType`                          | `#1439` で追加済み                                               |
-| joinDate            | 出力 | `UserAccount.joinedAt`                                | `YYYY-MM-DD`                                                     |
-| leaveDate           | 出力 | `UserAccount.leftAt`                                  | `YYYY-MM-DD`                                                     |
-| departmentName      | 出力 | `UserAccount.department`                              | 表示名のみ。コード体系は別論点                                   |
-| organizationName    | 出力 | `UserAccount.organization`                            | 表示名のみ。コード体系は別論点                                   |
-| managerEmployeeCode | 出力 | `managerUserId` -> 上長 `employeeCode`                | 解決不能時は `409 employee_master_manager_employee_code_missing` |
-| departmentCode      | 出力 | `EmployeePayrollProfile.departmentCode`               | 未設定時は空値                                                   |
-| payrollType         | 出力 | `EmployeePayrollProfile.payrollType`                  | 実コード体系は未確定                                             |
-| closingType         | 出力 | `EmployeePayrollProfile.closingType`                  | 実コード体系は未確定                                             |
-| paymentType         | 出力 | `EmployeePayrollProfile.paymentType`                  | 実コード体系は未確定                                             |
-| titleCode           | 出力 | `EmployeePayrollProfile.titleCode`                    | 名称ではなく code を出す                                         |
-| email               | 出力 | `UserAccount.emails`                                  | primary 優先                                                     |
-| phone               | 出力 | `UserAccount.phoneNumbers`                            | primary 優先                                                     |
+| 列名                | 出力 | source                                                                                   | 備考                                                             |
+| ------------------- | ---- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| employeeCode        | 出力 | `UserAccount.employeeCode`                                                               | 未設定時は `409 employee_master_employee_code_missing`           |
+| loginId             | 出力 | `UserAccount.userName`                                                                   | 補助識別子。給与キーではない                                     |
+| externalIdentityId  | 出力 | `UserAccount.externalId`                                                                 | IdP/SCIM 用。給与専用キーではない                                |
+| displayName         | 出力 | `displayName` を優先し、空の場合は `familyName + " " + givenName`、両方空なら `userName` | 氏名分解は逆算しない                                             |
+| familyName          | 出力 | `UserAccount.familyName`                                                                 | 未設定時は空値                                                   |
+| givenName           | 出力 | `UserAccount.givenName`                                                                  | 未設定時は空値                                                   |
+| activeFlag          | 出力 | `UserAccount.active`                                                                     | `1` / `0` に正規化                                               |
+| employmentType      | 出力 | `UserAccount.employmentType`                                                             | `#1439` で追加済み                                               |
+| joinDate            | 出力 | `UserAccount.joinedAt`                                                                   | `YYYY-MM-DD`                                                     |
+| leaveDate           | 出力 | `UserAccount.leftAt`                                                                     | `YYYY-MM-DD`                                                     |
+| departmentName      | 出力 | `UserAccount.department`                                                                 | 表示名のみ。コード体系は別論点                                   |
+| organizationName    | 出力 | `UserAccount.organization`                                                               | 表示名のみ。コード体系は別論点                                   |
+| managerEmployeeCode | 出力 | `managerUserId` -> 上長 `employeeCode`                                                   | 解決不能時は `409 employee_master_manager_employee_code_missing` |
+| departmentCode      | 出力 | `EmployeePayrollProfile.departmentCode`                                                  | 未設定時は空値                                                   |
+| payrollType         | 出力 | `EmployeePayrollProfile.payrollType`                                                     | 実コード体系は未確定                                             |
+| closingType         | 出力 | `EmployeePayrollProfile.closingType`                                                     | 実コード体系は未確定                                             |
+| paymentType         | 出力 | `EmployeePayrollProfile.paymentType`                                                     | 実コード体系は未確定                                             |
+| titleCode           | 出力 | `EmployeePayrollProfile.titleCode`                                                       | 名称ではなく code を出す                                         |
+| email               | 出力 | `UserAccount.emails`                                                                     | primary 優先                                                     |
+| phone               | 出力 | `UserAccount.phoneNumbers`                                                               | primary 優先                                                     |
 
 `schemaVersion` は CSV 列としては出力せず、JSON payload のメタ情報として `rakuda_employee_master_v1` を返す。CSV ファイル内では暗黙の前提として扱う。
 


### PR DESCRIPTION
## Summary
- 社員マスタ canonical export の実装契約を schemaVersion と 20 列の出力範囲まで明文化
- canonical v1 で未対応・未確定の項目を分離
- 実テンプレート未回収のため、内部 canonical と実運用 import の境界を明記

## Testing
- /home/devuser/work/CodeX/ITDO_ERP4/packages/frontend/node_modules/.bin/prettier --check docs/requirements/payroll-rakuda-employee-master-csv.md
- git diff --check

## Related
- #1436
- #1430