### PR TITLE
[codex] cover invoice mark-paid preset and refresh backend audit lockfile

### DIFF
--- a/packages/backend/package-lock.json
+++ b/packages/backend/package-lock.json
@@ -1453,9 +1453,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.12",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
-      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -1693,9 +1693,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/config": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.6.0.tgz",
-      "integrity": "sha512-MuAz1MK4PeG5/03YzfzX3CnFVHQ6qePGwUpQRzPzX5tT0ffJ3Tzi9zJZbBc+VzEGFCM8ghW/gTVDR85Syjt+Yw==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.7.0.tgz",
+      "integrity": "sha512-hmPI3tKLO2aP0Y5vugbjcnA9qqlfJndiT6ds4tw28U5hNHLWg+mHJEWAhjsSPgxjtmxhJ/EDIeIlyh+3Us0OPg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1747,17 +1747,17 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.6.0.tgz",
-      "integrity": "sha512-Sn5edRzhHqgRV2M+A0eIbY442B4mReWWf3pKs/LKreYgW7oa/up8JtK/s4iv/EQA097cyboZ08mmkpbLp+tZ3w==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.7.0.tgz",
+      "integrity": "sha512-7fmcbT7HHXBq/b+3h/dO1JI3fd8l8q7erf7xP7pRprh58hmSSnG8mg9K3yjW3h9WaHWUwngVFpSxxxivaitQ2w==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.6.0",
+        "@prisma/debug": "7.7.0",
         "@prisma/engines-version": "7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711",
-        "@prisma/fetch-engine": "7.6.0",
-        "@prisma/get-platform": "7.6.0"
+        "@prisma/fetch-engine": "7.7.0",
+        "@prisma/get-platform": "7.7.0"
       }
     },
     "node_modules/@prisma/engines-version": {
@@ -1767,36 +1767,50 @@
       "devOptional": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@prisma/engines/node_modules/@prisma/debug": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.7.0.tgz",
+      "integrity": "sha512-12J62XdqCmpiwJHhHdQxZeY3ckVCWIFmcJP8hg5dPTceeiQ0wiojXGFYTluKqFQfu46fRLgb/rLALZMAx3+dTA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.6.0.tgz",
-      "integrity": "sha512-ohZDwXvtmnbzOcutR2D13lDWpZP1wQjmPyztmt0AwXLzQI7q95EE7NYCvS+M6N6SivT+BM0NOqLmTH3wms4L3A==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.7.0.tgz",
+      "integrity": "sha512-MEUNzvKxvYnJ7kgvd6oNRnMmmiGNS9TYLB2weMeIXplnHdL/UWEGnvavYGnN7KLJ2n0iI4dDAyzSkHI3c7AscQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.6.0"
+        "@prisma/debug": "7.7.0"
       }
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.6.0.tgz",
-      "integrity": "sha512-N575Ni95c3FkduWY/eKTHqNYgNbceZ1tQaSknVtJjpKmiiBXmniESn/GTxsDvICC4ZeiNrXxioGInzQrCdx16w==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.7.0.tgz",
+      "integrity": "sha512-TfyzveBQoK4xALzsTpVhB/0KG1N8zOK0ap+RnBMkzGUu3f98fnQ4QtXa2wlKPhsO2X8a3N5ugFQgcKNoHGmDfw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.6.0",
+        "@prisma/debug": "7.7.0",
         "@prisma/engines-version": "7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711",
-        "@prisma/get-platform": "7.6.0"
+        "@prisma/get-platform": "7.7.0"
       }
     },
+    "node_modules/@prisma/fetch-engine/node_modules/@prisma/debug": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.7.0.tgz",
+      "integrity": "sha512-12J62XdqCmpiwJHhHdQxZeY3ckVCWIFmcJP8hg5dPTceeiQ0wiojXGFYTluKqFQfu46fRLgb/rLALZMAx3+dTA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.6.0.tgz",
-      "integrity": "sha512-ohZDwXvtmnbzOcutR2D13lDWpZP1wQjmPyztmt0AwXLzQI7q95EE7NYCvS+M6N6SivT+BM0NOqLmTH3wms4L3A==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.7.0.tgz",
+      "integrity": "sha512-MEUNzvKxvYnJ7kgvd6oNRnMmmiGNS9TYLB2weMeIXplnHdL/UWEGnvavYGnN7KLJ2n0iI4dDAyzSkHI3c7AscQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.6.0"
+        "@prisma/debug": "7.7.0"
       }
     },
     "node_modules/@prisma/get-platform": {
@@ -3317,15 +3331,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -3963,9 +3977,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.6.tgz",
-      "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -5193,9 +5207,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -6062,9 +6076,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.4.tgz",
-      "integrity": "sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -6099,9 +6113,9 @@
       }
     },
     "node_modules/nypm/node_modules/citty": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
-      "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -6616,16 +6630,16 @@
       }
     },
     "node_modules/prisma": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.6.0.tgz",
-      "integrity": "sha512-OKJIPT81K3+F+AayIkY/Y3mkF2NWoFh7lZApaaqPYy7EHILKdO0VsmGkP+hDKYTySHsFSyLWXm/JgcR1B8fY1Q==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.7.0.tgz",
+      "integrity": "sha512-HlgwRBt1uEFB9LStHL4HLYDvoi4BNu1rYA0hPG0zCAEyK9SaZBqp7E5Rjpc3Qh8Lex/ye/svoHZ0OWoFNhWxuQ==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "7.6.0",
+        "@prisma/config": "7.7.0",
         "@prisma/dev": "0.24.3",
-        "@prisma/engines": "7.6.0",
+        "@prisma/engines": "7.7.0",
         "@prisma/studio-core": "0.27.3",
         "mysql2": "3.15.3",
         "postgres": "3.4.7"
@@ -6685,11 +6699,14 @@
       "license": "ISC"
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -7461,9 +7478,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/packages/backend/test/invoicePolicyEnforcementPreset.test.js
+++ b/packages/backend/test/invoicePolicyEnforcementPreset.test.js
@@ -73,6 +73,15 @@ function invoiceDraft() {
   };
 }
 
+function approvedInvoice() {
+  return {
+    id: 'inv-002',
+    status: 'approved',
+    projectId: 'proj-001',
+    deletedAt: null,
+  };
+}
+
 function withInvoicePolicyEnv(preset, fn) {
   return withEnv(
     {
@@ -227,6 +236,99 @@ for (const preset of ['phase2_core', 'phase3_strict']) {
             assert.equal(payload?.status, 'pending_qa');
             assert.equal(updateCalled, 1);
             assert.equal(transactionCalled, 1);
+          } finally {
+            await server.close();
+          }
+        },
+      );
+    });
+  });
+
+  test(`POST /invoices/:id/mark-paid: ${preset} required action denies when policy is missing`, async () => {
+    await withInvoicePolicyEnv(preset, async () => {
+      let updateCalled = 0;
+      await withPrismaStubs(
+        {
+          'invoice.findUnique': async () => approvedInvoice(),
+          'actionPolicy.findMany': async () => [],
+          'invoice.update': async () => {
+            updateCalled += 1;
+            return null;
+          },
+        },
+        async () => {
+          const server = await buildServer({ logger: false });
+          try {
+            const res = await server.inject({
+              method: 'POST',
+              url: '/invoices/inv-002/mark-paid',
+              headers: adminHeaders(),
+              payload: {},
+            });
+            assert.equal(res.statusCode, 403, res.body);
+            const payload = JSON.parse(res.body);
+            assert.equal(payload?.error?.code, 'ACTION_POLICY_DENIED');
+            assert.equal(updateCalled, 0);
+          } finally {
+            await server.close();
+          }
+        },
+      );
+    });
+  });
+
+  test(`POST /invoices/:id/mark-paid: ${preset} policy allow reaches downstream mark-paid path (not ACTION_POLICY_DENIED)`, async () => {
+    await withInvoicePolicyEnv(preset, async () => {
+      let updateCalled = 0;
+      let auditCalled = 0;
+      await withPrismaStubs(
+        {
+          'invoice.findUnique': async () => approvedInvoice(),
+          'actionPolicy.findMany': async () => [
+            {
+              id: 'policy-invoice-mark-paid-allow',
+              flowType: 'invoice',
+              actionKey: 'mark_paid',
+              priority: 100,
+              isEnabled: true,
+              subjects: null,
+              stateConstraints: null,
+              requireReason: false,
+              guards: null,
+            },
+          ],
+          'invoice.update': async ({ where, data }) => {
+            updateCalled += 1;
+            return {
+              id: where.id,
+              status: data.status,
+              paidAt: data.paidAt,
+              paidBy: data.paidBy,
+              updatedBy: data.updatedBy,
+              lines: [],
+            };
+          },
+          'auditLog.create': async () => {
+            auditCalled += 1;
+            return { id: 'audit-002' };
+          },
+        },
+        async () => {
+          const server = await buildServer({ logger: false });
+          try {
+            const res = await server.inject({
+              method: 'POST',
+              url: '/invoices/inv-002/mark-paid',
+              headers: adminHeaders(),
+              payload: { paidAt: '2026-02-01' },
+            });
+            assert.equal(res.statusCode, 200, res.body);
+            const payload = JSON.parse(res.body);
+            assert.equal(payload?.id, 'inv-002');
+            assert.equal(payload?.status, 'paid');
+            assert.equal(payload?.paidBy, 'admin-user');
+            assert.equal(updateCalled, 1);
+            assert.equal(auditCalled, 1);
           } finally {
             await server.close();
           }

--- a/packages/backend/test/leaveEntitlementReminders.test.js
+++ b/packages/backend/test/leaveEntitlementReminders.test.js
@@ -3,6 +3,10 @@ import test from 'node:test';
 
 import { runLeaveEntitlementReminders } from '../dist/services/leaveEntitlementReminders.js';
 
+function futureMuteDate() {
+  return new Date(Date.now() + 24 * 60 * 60 * 1000);
+}
+
 function createClient({
   profiles = [],
   existingNotifications = [],
@@ -103,7 +107,7 @@ test('runLeaveEntitlementReminders: skips existing recipients and honors global 
     userPreferences: [
       {
         userId: 'ga-user-2',
-        muteAllUntil: new Date('2099-04-03T00:00:00.000Z'),
+        muteAllUntil: futureMuteDate(),
       },
     ],
   });


### PR DESCRIPTION
## What changed
- added `phase2_core` / `phase3_strict` preset coverage for `POST /invoices/:id/mark-paid`
- stabilized `leaveEntitlementReminders` mute-date test data so it no longer depends on a distant fixed calendar date
- refreshed `packages/backend/package-lock.json` to clear the backend `security-audit` findings on the current `main` baseline

## Why it changed
- `invoice:mark_paid` remained uncovered in the preset-focused regression tests on the current `main` line
- the leave entitlement reminder test still relied on a hard-coded future date instead of execution-relative fixture data
- rebasing the PR onto current `main` showed backend audit findings remained on the latest baseline and required a lockfile refresh

## Impact
- improves fail-safe regression coverage for a high-risk invoice state transition
- reduces future date-driven flakiness in leave reminder tests
- unblocks the PR's backend `security-audit` check without changing application source behavior

## Root cause
- earlier follow-up coverage for expense / purchase-order routes had already landed on `main`, but `invoice mark-paid` coverage had not
- the remaining reminder test used a fixed `muteAllUntil` value
- backend transitive dependencies still resolved to vulnerable versions on the current `main` lockfile

## Validation
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public npx --prefix packages/backend prisma generate --config packages/backend/prisma.config.ts`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public npm run build --prefix packages/backend`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public node packages/backend/scripts/run-tests.js test/invoicePolicyEnforcementPreset.test.js test/leaveEntitlementReminders.test.js`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public npm run test:ci --prefix packages/backend`
- `npm audit --prefix packages/backend --audit-level=high`

## Notes
- backend `test:ci` passed locally with `944/944`
- backend `npm audit --audit-level=high` now reports `0 vulnerabilities`
- vendor invoice policy-related tests still emit non-fatal Prisma audit warning logs in some paths when the DB is unreachable, but the suite succeeds
