### PR TITLE
[codex] Include HR attendance exports in integration job hub

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -12162,6 +12162,12 @@
                 },
                 {
                   "enum": [
+                    "hr_attendance_export"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "enum": [
                     "accounting_ics_export"
                   ],
                   "type": "string"
@@ -12248,6 +12254,12 @@
                 {
                   "enum": [
                     "hr_employee_master_export"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "enum": [
+                    "hr_attendance_export"
                   ],
                   "type": "string"
                 },

--- a/docs/requirements/external-csv-integration-common-spec.md
+++ b/docs/requirements/external-csv-integration-common-spec.md
@@ -102,7 +102,7 @@
   - `POST /integrations/accounting/mapping-rules/reapply`
 - 共通運用参照
   - `GET /integrations/jobs/exports`
-  - 既存 3 系統の export log を横断一覧化して参照する
+  - 既存 4 系統の export log（休暇 CSV、社員マスタ CSV、勤怠確定 CSV、ICS 仕訳 CSV）を横断一覧化して参照する
   - 管理画面では `Settings` 内の「連携ジョブ一覧」カードから種別 / ステータス / limit / offset を指定して取得する
   - `POST /integrations/jobs/exports/:kind/:id/redispatch`
   - 既存の成功済み export payload を新しい log として再出力し、`reexportOfId` で元ジョブを追跡する

--- a/packages/backend/src/routes/integrations.ts
+++ b/packages/backend/src/routes/integrations.ts
@@ -857,6 +857,7 @@ type IntegrationExportJobKind =
   | 'hr_leave_export_attendance'
   | 'hr_leave_export_payroll'
   | 'hr_employee_master_export'
+  | 'hr_attendance_export'
   | 'accounting_ics_export';
 
 function normalizeIntegrationExportJobKind(
@@ -866,6 +867,7 @@ function normalizeIntegrationExportJobKind(
     case 'hr_leave_export_attendance':
     case 'hr_leave_export_payroll':
     case 'hr_employee_master_export':
+    case 'hr_attendance_export':
     case 'accounting_ics_export':
       return value;
     default:
@@ -1049,6 +1051,9 @@ function buildIntegrationExportJobResponse(
         kind: 'hr_employee_master_export';
       } & ReturnType<typeof buildHrEmployeeMasterExportLogResponse>)
     | ({
+        kind: 'hr_attendance_export';
+      } & ReturnType<typeof buildHrAttendanceExportLogResponse>)
+    | ({
         kind: 'accounting_ics_export';
       } & ReturnType<typeof buildAccountingIcsExportLogResponse>),
 ) {
@@ -1065,12 +1070,18 @@ function buildIntegrationExportJobResponse(
     scope:
       item.kind === 'accounting_ics_export'
         ? { periodKey: item.periodKey }
-        : item.kind === 'hr_employee_master_export'
-          ? { updatedSince: item.updatedSince }
-          : {
-              target: item.target,
-              updatedSince: item.updatedSince,
-            },
+        : item.kind === 'hr_attendance_export'
+          ? {
+              periodKey: item.periodKey,
+              closingPeriodId: item.closingPeriodId,
+              closingVersion: item.closingVersion,
+            }
+          : item.kind === 'hr_employee_master_export'
+            ? { updatedSince: item.updatedSince }
+            : {
+                target: item.target,
+                updatedSince: item.updatedSince,
+              },
   };
 }
 
@@ -3177,10 +3188,11 @@ export async function registerIntegrationRoutes(app: FastifyInstance) {
         kind === 'hr_leave_export_payroll';
       const shouldLoadEmployeeMaster =
         !kind || kind === 'hr_employee_master_export';
+      const shouldLoadHrAttendance = !kind || kind === 'hr_attendance_export';
       const shouldLoadAccounting = !kind || kind === 'accounting_ics_export';
 
-      const [leaveLogs, employeeMasterLogs, accountingLogs] = await Promise.all(
-        [
+      const [leaveLogs, employeeMasterLogs, hrAttendanceLogs, accountingLogs] =
+        await Promise.all([
           shouldLoadLeave
             ? prisma.leaveIntegrationExportLog.findMany({
                 where: {
@@ -3228,6 +3240,27 @@ export async function registerIntegrationRoutes(app: FastifyInstance) {
                 take,
               })
             : Promise.resolve([]),
+          shouldLoadHrAttendance
+            ? prisma.hrAttendanceExportLog.findMany({
+                where: status ? { status } : undefined,
+                select: {
+                  id: true,
+                  idempotencyKey: true,
+                  reexportOfId: true,
+                  periodKey: true,
+                  closingPeriodId: true,
+                  closingVersion: true,
+                  status: true,
+                  exportedUntil: true,
+                  exportedCount: true,
+                  startedAt: true,
+                  finishedAt: true,
+                  message: true,
+                },
+                orderBy: [{ startedAt: 'desc' }, { id: 'desc' }],
+                take,
+              })
+            : Promise.resolve([]),
           shouldLoadAccounting
             ? prisma.accountingIcsExportLog.findMany({
                 where: status ? { status } : undefined,
@@ -3247,8 +3280,7 @@ export async function registerIntegrationRoutes(app: FastifyInstance) {
                 take,
               })
             : Promise.resolve([]),
-        ],
-      );
+        ]);
 
       const items = [
         ...leaveLogs.map((item) =>
@@ -3266,6 +3298,12 @@ export async function registerIntegrationRoutes(app: FastifyInstance) {
           buildIntegrationExportJobResponse({
             kind: 'hr_employee_master_export',
             ...buildHrEmployeeMasterExportLogResponse(item),
+          }),
+        ),
+        ...hrAttendanceLogs.map((item) =>
+          buildIntegrationExportJobResponse({
+            kind: 'hr_attendance_export',
+            ...buildHrAttendanceExportLogResponse(item),
           }),
         ),
         ...accountingLogs.map((item) =>
@@ -3593,6 +3631,146 @@ export async function registerIntegrationRoutes(app: FastifyInstance) {
             replayed: false,
             payload: created.payload,
             log: buildHrEmployeeMasterExportLogResponse(created),
+          };
+        }
+        case 'hr_attendance_export': {
+          const source = await prisma.hrAttendanceExportLog.findUnique({
+            where: { id },
+          });
+          if (!source) {
+            return reply
+              .code(
+                integrationExportRedispatchStatusCode(
+                  'integration_export_log_not_found',
+                ),
+              )
+              .send({ error: 'integration_export_log_not_found' });
+          }
+          if (source.status === IntegrationRunStatus.running) {
+            return reply.code(409).send({
+              error: 'dispatch_in_progress',
+              logId: source.id,
+            });
+          }
+          if (
+            !source.payload ||
+            source.status !== IntegrationRunStatus.success
+          ) {
+            return reply.code(409).send({
+              error: 'redispatch_source_not_exported',
+              logId: source.id,
+            });
+          }
+          const respondWithExistingHrAttendanceRedispatch = async (
+            existing: NonNullable<
+              Awaited<
+                ReturnType<typeof prisma.hrAttendanceExportLog.findUnique>
+              >
+            >,
+          ) => {
+            if (
+              existing.requestHash !== source.requestHash ||
+              existing.reexportOfId !== source.id
+            ) {
+              await logAudit({
+                ...auditContextFromRequest(req),
+                action: 'integration_hr_attendance_export_redispatch_conflict',
+                targetTable: 'HrAttendanceExportLog',
+                targetId: existing.id,
+                metadata: {
+                  sourceLogId: source.id,
+                  idempotencyKey,
+                  requestHash: source.requestHash,
+                  existingRequestHash: existing.requestHash,
+                  existingReexportOfId: existing.reexportOfId,
+                } as Prisma.InputJsonValue,
+              });
+              return reply.code(409).send({ error: 'idempotency_conflict' });
+            }
+            if (existing.status === IntegrationRunStatus.running) {
+              return reply.code(409).send({
+                error: 'dispatch_in_progress',
+                logId: existing.id,
+              });
+            }
+            await logAudit({
+              ...auditContextFromRequest(req),
+              action: 'integration_hr_attendance_export_redispatch_replayed',
+              targetTable: 'HrAttendanceExportLog',
+              targetId: existing.id,
+              metadata: {
+                sourceLogId: source.id,
+                idempotencyKey,
+                status: existing.status,
+                periodKey: existing.periodKey,
+              } as Prisma.InputJsonValue,
+            });
+            return {
+              replayed: true,
+              payload: existing.payload,
+              log: buildHrAttendanceExportLogResponse(existing),
+            };
+          };
+          const existing = await prisma.hrAttendanceExportLog.findUnique({
+            where: { idempotencyKey },
+          });
+          if (existing) {
+            return respondWithExistingHrAttendanceRedispatch(existing);
+          }
+          let created: Awaited<
+            ReturnType<typeof prisma.hrAttendanceExportLog.create>
+          >;
+          try {
+            created = await prisma.hrAttendanceExportLog.create({
+              data: {
+                idempotencyKey,
+                requestHash: source.requestHash,
+                reexportOfId: source.id,
+                periodKey: source.periodKey,
+                closingPeriodId: source.closingPeriodId,
+                closingVersion: source.closingVersion,
+                exportedUntil: source.exportedUntil,
+                status: IntegrationRunStatus.success,
+                exportedCount: source.exportedCount,
+                payload: source.payload,
+                message: 'redispatched',
+                startedAt: now,
+                finishedAt: now,
+                createdBy: actorId,
+              },
+            });
+          } catch (error) {
+            if (
+              error instanceof Prisma.PrismaClientKnownRequestError &&
+              error.code === 'P2002'
+            ) {
+              const concurrent = await prisma.hrAttendanceExportLog.findUnique({
+                where: { idempotencyKey },
+              });
+              if (concurrent) {
+                return respondWithExistingHrAttendanceRedispatch(concurrent);
+              }
+            }
+            throw error;
+          }
+          await logAudit({
+            ...auditContextFromRequest(req),
+            action: 'integration_hr_attendance_export_redispatched',
+            targetTable: 'HrAttendanceExportLog',
+            targetId: created.id,
+            metadata: {
+              sourceLogId: source.id,
+              idempotencyKey,
+              periodKey: created.periodKey,
+              closingPeriodId: created.closingPeriodId,
+              closingVersion: created.closingVersion,
+              exportedCount: created.exportedCount,
+            } as Prisma.InputJsonValue,
+          });
+          return {
+            replayed: false,
+            payload: created.payload,
+            log: buildHrAttendanceExportLogResponse(created),
           };
         }
         case 'accounting_ics_export': {

--- a/packages/backend/src/routes/validators.ts
+++ b/packages/backend/src/routes/validators.ts
@@ -1954,6 +1954,7 @@ const integrationExportJobKindSchema = Type.Union([
   Type.Literal('hr_leave_export_attendance'),
   Type.Literal('hr_leave_export_payroll'),
   Type.Literal('hr_employee_master_export'),
+  Type.Literal('hr_attendance_export'),
   Type.Literal('accounting_ics_export'),
 ]);
 

--- a/packages/backend/test/integrationExportJobsRoutes.test.js
+++ b/packages/backend/test/integrationExportJobsRoutes.test.js
@@ -64,6 +64,22 @@ test('GET /integrations/jobs/exports merges export logs across adapters', async 
           message: 'employee_master_employee_code_missing',
         },
       ],
+      'hrAttendanceExportLog.findMany': async () => [
+        {
+          id: 'attendance-log-001',
+          idempotencyKey: 'attendance-key-001',
+          reexportOfId: null,
+          periodKey: '2026-03',
+          closingPeriodId: 'attendance-close-001',
+          closingVersion: 4,
+          status: 'success',
+          exportedUntil: new Date('2026-03-15T11:00:00.000Z'),
+          exportedCount: 8,
+          startedAt: new Date('2026-03-15T11:00:00.000Z'),
+          finishedAt: new Date('2026-03-15T11:01:00.000Z'),
+          message: 'exported',
+        },
+      ],
       'accountingIcsExportLog.findMany': async () => [
         {
           id: 'accounting-log-001',
@@ -92,19 +108,26 @@ test('GET /integrations/jobs/exports merges export logs across adapters', async 
         });
         assert.equal(res.statusCode, 200, res.body);
         const body = JSON.parse(res.body);
-        assert.equal(body.items.length, 3);
+        assert.equal(body.items.length, 4);
         assert.deepEqual(
           body.items.map((item) => item.kind),
           [
             'accounting_ics_export',
+            'hr_attendance_export',
             'hr_employee_master_export',
             'hr_leave_export_attendance',
           ],
         );
         assert.equal(body.items[0].scope.periodKey, '2026-03');
-        assert.equal(body.items[1].scope.updatedSince, null);
-        assert.equal(body.items[1].reexportOfId, 'employee-log-000');
-        assert.equal(body.items[2].scope.target, 'attendance');
+        assert.equal(body.items[1].scope.periodKey, '2026-03');
+        assert.equal(body.items[1].scope.closingVersion, 4);
+        assert.equal(
+          body.items[1].scope.closingPeriodId,
+          'attendance-close-001',
+        );
+        assert.equal(body.items[2].scope.updatedSince, null);
+        assert.equal(body.items[2].reexportOfId, 'employee-log-000');
+        assert.equal(body.items[3].scope.target, 'attendance');
       } finally {
         await server.close();
       }
@@ -118,6 +141,7 @@ test('GET /integrations/jobs/exports applies kind and status filters to the rele
 
   let employeeMasterArgs = null;
   let leaveCalled = false;
+  let hrAttendanceCalled = false;
   let accountingCalled = false;
   await withPrismaStubs(
     {
@@ -145,6 +169,10 @@ test('GET /integrations/jobs/exports applies kind and status filters to the rele
         accountingCalled = true;
         return [];
       },
+      'hrAttendanceExportLog.findMany': async () => {
+        hrAttendanceCalled = true;
+        return [];
+      },
     },
     async () => {
       const server = await buildServer({ logger: false });
@@ -168,9 +196,82 @@ test('GET /integrations/jobs/exports applies kind and status filters to the rele
   );
 
   assert.equal(leaveCalled, false);
+  assert.equal(hrAttendanceCalled, false);
   assert.equal(accountingCalled, false);
   assert.deepEqual(employeeMasterArgs?.where, { status: 'success' });
   assert.equal(employeeMasterArgs?.take, 5);
+});
+
+test('GET /integrations/jobs/exports applies kind and status filters to HR attendance exports', async () => {
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+
+  let hrAttendanceArgs = null;
+  let leaveCalled = false;
+  let employeeCalled = false;
+  let accountingCalled = false;
+  await withPrismaStubs(
+    {
+      'leaveIntegrationExportLog.findMany': async () => {
+        leaveCalled = true;
+        return [];
+      },
+      'hrEmployeeMasterExportLog.findMany': async () => {
+        employeeCalled = true;
+        return [];
+      },
+      'hrAttendanceExportLog.findMany': async (args) => {
+        hrAttendanceArgs = args;
+        return [
+          {
+            id: 'attendance-log-002',
+            idempotencyKey: 'attendance-key-002',
+            reexportOfId: null,
+            periodKey: '2026-03',
+            closingPeriodId: 'attendance-close-002',
+            closingVersion: 2,
+            status: 'success',
+            exportedUntil: new Date('2026-03-16T00:00:00.000Z'),
+            exportedCount: 12,
+            startedAt: new Date('2026-03-16T12:00:00.000Z'),
+            finishedAt: new Date('2026-03-16T12:01:00.000Z'),
+            message: 'exported',
+          },
+        ];
+      },
+      'accountingIcsExportLog.findMany': async () => {
+        accountingCalled = true;
+        return [];
+      },
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'GET',
+          url: '/integrations/jobs/exports?kind=hr_attendance_export&status=success&limit=5&offset=0',
+          headers: {
+            'x-user-id': 'admin-user',
+            'x-roles': 'admin',
+          },
+        });
+        assert.equal(res.statusCode, 200, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body.items.length, 1);
+        assert.equal(body.items[0].kind, 'hr_attendance_export');
+        assert.equal(body.items[0].scope.periodKey, '2026-03');
+        assert.equal(body.items[0].scope.closingVersion, 2);
+      } finally {
+        await server.close();
+      }
+    },
+  );
+
+  assert.equal(leaveCalled, false);
+  assert.equal(employeeCalled, false);
+  assert.equal(accountingCalled, false);
+  assert.deepEqual(hrAttendanceArgs?.where, { status: 'success' });
+  assert.equal(hrAttendanceArgs?.take, 5);
 });
 
 test('GET /integrations/jobs/exports fetches offset + limit rows per source for merged pagination', async () => {
@@ -185,6 +286,7 @@ test('GET /integrations/jobs/exports fetches offset + limit rows per source for 
         employeeMasterArgs = args;
         return [];
       },
+      'hrAttendanceExportLog.findMany': async () => [],
       'accountingIcsExportLog.findMany': async () => [],
     },
     async () => {
@@ -294,6 +396,104 @@ test('POST /integrations/jobs/exports/:kind/:id/redispatch creates a linked empl
   );
 
   assert.equal(createArgs?.data?.reexportOfId, 'employee-log-source');
+  assert.equal(createArgs?.data?.message, 'redispatched');
+});
+
+test('POST /integrations/jobs/exports/:kind/:id/redispatch creates a linked HR attendance rerun', async () => {
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+
+  const payload = {
+    schemaVersion: 'rakuda_attendance_v1',
+    exportedAt: '2026-03-17T00:00:00.000Z',
+    exportedUntil: '2026-03-17T00:00:00.000Z',
+    periodKey: '2026-03',
+    closingId: 'attendance-close-source',
+    closingVersion: 4,
+    exportedCount: 1,
+    headers: ['employeeCode'],
+    items: [{ employeeCode: 'EMP-001' }],
+  };
+  let createArgs = null;
+
+  await withPrismaStubs(
+    {
+      'hrAttendanceExportLog.findUnique': async (args) => {
+        if (args?.where?.id === 'attendance-log-source') {
+          return {
+            id: 'attendance-log-source',
+            idempotencyKey: 'attendance-source-key',
+            requestHash: 'attendance-request-hash',
+            reexportOfId: null,
+            periodKey: '2026-03',
+            closingPeriodId: 'attendance-close-source',
+            closingVersion: 4,
+            exportedUntil: new Date('2026-03-17T00:00:00.000Z'),
+            status: 'success',
+            exportedCount: 1,
+            payload,
+            message: 'exported',
+            startedAt: new Date('2026-03-17T00:00:00.000Z'),
+            finishedAt: new Date('2026-03-17T00:00:05.000Z'),
+          };
+        }
+        if (args?.where?.idempotencyKey === 'attendance-redispatch-key') {
+          return null;
+        }
+        return null;
+      },
+      'hrAttendanceExportLog.create': async (args) => {
+        createArgs = args;
+        return {
+          id: 'attendance-log-rerun',
+          idempotencyKey: args.data.idempotencyKey,
+          requestHash: args.data.requestHash,
+          reexportOfId: args.data.reexportOfId,
+          periodKey: args.data.periodKey,
+          closingPeriodId: args.data.closingPeriodId,
+          closingVersion: args.data.closingVersion,
+          exportedUntil: args.data.exportedUntil,
+          status: args.data.status,
+          exportedCount: args.data.exportedCount,
+          payload: args.data.payload,
+          message: args.data.message,
+          startedAt: args.data.startedAt,
+          finishedAt: args.data.finishedAt,
+        };
+      },
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/integrations/jobs/exports/hr_attendance_export/attendance-log-source/redispatch',
+          headers: {
+            'x-user-id': 'admin-user',
+            'x-roles': 'admin',
+          },
+          payload: {
+            idempotencyKey: 'attendance-redispatch-key',
+          },
+        });
+        assert.equal(res.statusCode, 200, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body.replayed, false);
+        assert.equal(body.log.id, 'attendance-log-rerun');
+        assert.equal(body.log.reexportOfId, 'attendance-log-source');
+        assert.equal(body.log.periodKey, '2026-03');
+        assert.equal(body.log.closingVersion, 4);
+        assert.deepEqual(body.payload, payload);
+      } finally {
+        await server.close();
+      }
+    },
+  );
+
+  assert.equal(createArgs?.data?.reexportOfId, 'attendance-log-source');
+  assert.equal(createArgs?.data?.periodKey, '2026-03');
+  assert.equal(createArgs?.data?.closingPeriodId, 'attendance-close-source');
+  assert.equal(createArgs?.data?.closingVersion, 4);
   assert.equal(createArgs?.data?.message, 'redispatched');
 });
 

--- a/packages/frontend/src/sections/admin-settings/IntegrationExportJobsCard.test.tsx
+++ b/packages/frontend/src/sections/admin-settings/IntegrationExportJobsCard.test.tsx
@@ -91,10 +91,14 @@ describe('IntegrationExportJobsCard', () => {
     expect(screen.getByText('ジョブなし')).toBeInTheDocument();
     expect(screen.getByText('ready')).toBeInTheDocument();
 
+    expect(
+      screen.getByRole('option', { name: '勤怠確定CSV' }),
+    ).toBeInTheDocument();
+
     fireEvent.change(screen.getByLabelText('連携ジョブ種別'), {
-      target: { value: 'accounting_ics_export' },
+      target: { value: 'hr_attendance_export' },
     });
-    expect(setKindFilter).toHaveBeenCalledWith('accounting_ics_export');
+    expect(setKindFilter).toHaveBeenCalledWith('hr_attendance_export');
 
     fireEvent.change(screen.getByLabelText('連携ジョブステータス'), {
       target: { value: 'failed' },
@@ -144,8 +148,17 @@ describe('IntegrationExportJobsCard', () => {
         updatedSince: '2026-03-01T00:00:00.000Z',
       },
     });
+    const thirdItem = createItem({
+      id: 'job-3',
+      kind: 'hr_attendance_export',
+      scope: {
+        periodKey: '2026-03',
+        closingVersion: 4,
+        closingPeriodId: 'attendance-close-004',
+      },
+    });
     const { onRedispatch, formatDateTime } = renderCard({
-      items: [firstItem, secondItem],
+      items: [firstItem, secondItem, thirdItem],
       redispatchingId: 'job-2',
     });
 
@@ -172,6 +185,16 @@ describe('IntegrationExportJobsCard', () => {
     expect(
       secondCard.getByRole('button', { name: '再出力中...' }),
     ).toBeDisabled();
+
+    const thirdCard = within(
+      screen.getByTestId('integration-export-job-job-3'),
+    );
+    expect(thirdCard.getByText('勤怠確定CSV')).toBeInTheDocument();
+    expect(
+      thirdCard.getByText(
+        /scope: periodKey=2026-03 \/ closingVersion=4 \/ closingPeriodId=attendance-close-004/,
+      ),
+    ).toBeInTheDocument();
 
     expect(formatDateTime).toHaveBeenCalledWith('2026-03-26T00:00:00.000Z');
     expect(formatDateTime).toHaveBeenCalledWith('2026-03-26T01:00:00.000Z');

--- a/packages/frontend/src/sections/admin-settings/IntegrationExportJobsCard.tsx
+++ b/packages/frontend/src/sections/admin-settings/IntegrationExportJobsCard.tsx
@@ -4,6 +4,7 @@ export type IntegrationExportJobKind =
   | 'hr_leave_export_attendance'
   | 'hr_leave_export_payroll'
   | 'hr_employee_master_export'
+  | 'hr_attendance_export'
   | 'accounting_ics_export';
 
 export type IntegrationExportJobStatus = 'running' | 'success' | 'failed';
@@ -22,6 +23,8 @@ export type IntegrationExportJobItem = {
     target?: string | null;
     updatedSince?: string | null;
     periodKey?: string | null;
+    closingPeriodId?: string | null;
+    closingVersion?: number | null;
   } | null;
 };
 
@@ -47,6 +50,7 @@ const kindOptions: Array<{ value: string; label: string }> = [
   { value: 'hr_leave_export_attendance', label: '休暇CSV（勤怠）' },
   { value: 'hr_leave_export_payroll', label: '休暇CSV（給与）' },
   { value: 'hr_employee_master_export', label: '社員マスタCSV' },
+  { value: 'hr_attendance_export', label: '勤怠確定CSV' },
   { value: 'accounting_ics_export', label: 'ICS仕訳CSV' },
 ];
 
@@ -63,7 +67,16 @@ function formatKindLabel(kind: IntegrationExportJobKind) {
 
 function formatScope(scope?: IntegrationExportJobItem['scope']) {
   if (!scope) return '-';
-  if (scope.periodKey) return `periodKey=${scope.periodKey}`;
+  if (scope.periodKey) {
+    const parts = [`periodKey=${scope.periodKey}`];
+    if (scope.closingVersion !== undefined && scope.closingVersion !== null) {
+      parts.push(`closingVersion=${scope.closingVersion}`);
+    }
+    if (scope.closingPeriodId) {
+      parts.push(`closingPeriodId=${scope.closingPeriodId}`);
+    }
+    return parts.join(' / ');
+  }
   const parts = [];
   if (scope.target) parts.push(`target=${scope.target}`);
   if (scope.updatedSince) parts.push(`updatedSince=${scope.updatedSince}`);


### PR DESCRIPTION
## Summary
- Add `hr_attendance_export` to the cross-adapter integration export job list and redispatch endpoint.
- Surface HR attendance export logs in the admin integration job UI with period / closing metadata.
- Add backend/frontend/OpenAPI regression coverage, and update the common external CSV integration spec from 3 to 4 export-log families.

## Why
Issue #1741 tracks the follow-up from #1430 item 5: `HrAttendanceExportLog` existed as a dedicated dispatch log, but it was not fully integrated into the 横断ジョブ一覧/UI and redispatch flow.

## Validation
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public npx --prefix packages/backend prisma generate --config packages/backend/prisma.config.ts`
- `npm run build --prefix packages/backend`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public npm run test:ci --prefix packages/backend -- test/integrationExportJobsRoutes.test.js`
- `npm run typecheck --prefix packages/frontend`
- `npm run test --prefix packages/frontend -- IntegrationExportJobsCard.test.tsx`
- `npm run lint --prefix packages/backend`
- `npm run format:check --prefix packages/backend`
- `npm run lint --prefix packages/frontend`
- `npm run format:check --prefix packages/frontend`
- `node scripts/export-openapi.mjs --out tmp/openapi.json`
- `diff -u docs/api/openapi.json tmp/openapi.json`

Note: backend route tests emitted non-fatal audit-log DB connectivity warnings for unstubbed `auditLog.create`, consistent with this test style; all targeted tests passed.

Closes #1741