### PR TITLE
[codex] Compute reconciliation debit and credit totals separately

### DIFF
--- a/docs/requirements/accounting-ics-journal-csv.md
+++ b/docs/requirements/accounting-ics-journal-csv.md
@@ -38,8 +38,7 @@
 - `AccountingJournalStaging.status='ready'` の行だけを対象にする
 - 同一 scope 内に `pending_mapping` または `blocked` が残っている場合、export は `409 accounting_journal_mapping_incomplete` で停止する
 - ready 行でも以下が未設定なら `409 accounting_journal_ready_row_incomplete` で停止する
-  - `debitAccountCode`
-  - `creditAccountCode`
+  - `debitAccountCode` または `creditAccountCode` の少なくとも一方
   - `taxCode`
   - 正の `amount`
 
@@ -219,7 +218,7 @@
 - 2026-03-18 時点の拡張では、`AccountingMappingRule` に `requireDepartmentCode` / `requireDebitSubaccountCode` / `requireCreditSubaccountCode` を持たせ、条件付き必須を rule 側で判定する
 - 2026-03-21 時点の拡張では、`AccountingMappingRule` に `debitAccountName` / `creditAccountName` を持たせ、staging 行へ snapshot した名称を ICS CSV の名称列へ反映する
 - `#1443` の baseline 実装では、`ready` 化された staging 行だけを CSV に変換する
-- 照合 summary の `readyDebitTotal` / `readyCreditTotal` は、`AccountingJournalStaging.status='ready'` の行について借方科目あり / 貸方科目ありを別々に合計し、`debitCreditBalanced` は invalid ready がなく両合計が一致する場合のみ `true` とする
+- `#1743` の照合拡張では、複合仕訳の片側明細を表現できるよう、ready 行は借方または貸方の少なくとも一方を持てば export 対象とし、両方欠落している行を invalid ready とみなす。照合 summary の `readyDebitTotal` / `readyCreditTotal` は、`AccountingJournalStaging.status='ready'` の行について借方科目あり / 貸方科目ありを別々に合計し、`debitCreditBalanced` は invalid ready がなく両合計が一致する場合のみ `true` とする
 
 ### 最低限必要な mapping
 
@@ -362,7 +361,7 @@
 | ICS-03 | invalid period             | `periodKey=2026-13`                                              | `400 invalid_period_key`                                        |
 | ICS-04 | template metadata missing  | `format=ics_template` で `companyCode` または `companyName` 欠落 | `400 accounting_ics_template_metadata_required`                 |
 | ICS-05 | incomplete scope           | `pending_mapping` または `blocked` 行が scope に残る             | `409 accounting_journal_mapping_incomplete`                     |
-| ICS-06 | incomplete ready row       | `debit/credit/taxCode/amount` のいずれか不足                     | `409 accounting_journal_ready_row_incomplete`                   |
+| ICS-06 | incomplete ready row       | 借方・貸方の両方欠落、または `taxCode/amount` のいずれか不足     | `409 accounting_journal_ready_row_incomplete`                   |
 | ICS-07 | invalid description        | 改行・タブ・`CP932` 非対応文字・120 bytes 超過                   | `409 accounting_journal_description_invalid`                    |
 | ICS-08 | idempotent dispatch replay | 同一 `idempotencyKey` + 同一条件で再実行                         | 既存成功 log を replay                                          |
 | ICS-09 | redispatch                 | 成功済み export log を指定                                       | 新規 log を作成し `reexportOfId` を保持                         |

--- a/docs/requirements/accounting-ics-journal-csv.md
+++ b/docs/requirements/accounting-ics-journal-csv.md
@@ -219,6 +219,7 @@
 - 2026-03-18 時点の拡張では、`AccountingMappingRule` に `requireDepartmentCode` / `requireDebitSubaccountCode` / `requireCreditSubaccountCode` を持たせ、条件付き必須を rule 側で判定する
 - 2026-03-21 時点の拡張では、`AccountingMappingRule` に `debitAccountName` / `creditAccountName` を持たせ、staging 行へ snapshot した名称を ICS CSV の名称列へ反映する
 - `#1443` の baseline 実装では、`ready` 化された staging 行だけを CSV に変換する
+- 照合 summary の `readyDebitTotal` / `readyCreditTotal` は、`AccountingJournalStaging.status='ready'` の行について借方科目あり / 貸方科目ありを別々に合計し、`debitCreditBalanced` は invalid ready がなく両合計が一致する場合のみ `true` とする
 
 ### 最低限必要な mapping
 

--- a/docs/requirements/external-csv-integration-common-spec.md
+++ b/docs/requirements/external-csv-integration-common-spec.md
@@ -207,7 +207,7 @@
   - attendance closing の summary count / 各種 minutes 合計
   - full 社員マスタ export と attendance closing の社員コード差分
   - accounting journal staging の `ready / pending_mapping / blocked`
-  - ready 行の借貸一致フラグ
+  - ready 行の借方合計 / 貸方合計 / 借貸一致フラグ（`readyDebitTotal` は借方科目ありの ready 金額、`readyCreditTotal` は貸方科目ありの ready 金額を個別集計する）
   - 最新 ICS export の件数と ready 件数の一致
 - 現在の details 比較項目
   - payroll: 社員コード差分の全件

--- a/docs/requirements/external-csv-integration-common-spec.md
+++ b/docs/requirements/external-csv-integration-common-spec.md
@@ -207,7 +207,7 @@
   - attendance closing の summary count / 各種 minutes 合計
   - full 社員マスタ export と attendance closing の社員コード差分
   - accounting journal staging の `ready / pending_mapping / blocked`
-  - ready 行の借方合計 / 貸方合計 / 借貸一致フラグ（`readyDebitTotal` は借方科目ありの ready 金額、`readyCreditTotal` は貸方科目ありの ready 金額を個別集計する）
+  - ready 行の借方合計 / 貸方合計 / 借貸一致フラグ（`readyDebitTotal` は借方科目ありの ready 金額、`readyCreditTotal` は貸方科目ありの ready 金額を個別集計する。複合仕訳の片側明細では借方・貸方の少なくとも一方があれば ready 行として扱い、両方欠落している行を invalid ready とする）
   - 最新 ICS export の件数と ready 件数の一致
 - 現在の details 比較項目
   - payroll: 社員コード差分の全件

--- a/packages/backend/src/services/accountingIcsExport.ts
+++ b/packages/backend/src/services/accountingIcsExport.ts
@@ -313,10 +313,10 @@ function validateReadyRow(row: {
   taxCode: string | null;
 }) {
   const missingFields: string[] = [];
-  if (!normalizeText(row.debitAccountCode)) {
+  const debitAccountCode = normalizeText(row.debitAccountCode);
+  const creditAccountCode = normalizeText(row.creditAccountCode);
+  if (!debitAccountCode && !creditAccountCode) {
     missingFields.push('debitAccountCode');
-  }
-  if (!normalizeText(row.creditAccountCode)) {
     missingFields.push('creditAccountCode');
   }
   if (!normalizeText(row.taxCode)) {

--- a/packages/backend/src/services/integrationReconciliation.ts
+++ b/packages/backend/src/services/integrationReconciliation.ts
@@ -58,6 +58,8 @@ type ReconciliationBaseData = {
   latestIcsExport: AccountingExportSnapshot | null;
   stagingCounts: Array<{ status: string; _count: { _all: number } }>;
   readyAmountTotal: string;
+  readyDebitTotal: string;
+  readyCreditTotal: string;
   invalidReadyCount: number;
 };
 
@@ -90,6 +92,7 @@ type ReconciliationSummary = {
       | 'export_missing'
       | 'mapping_incomplete'
       | 'ready_row_incomplete'
+      | 'debit_credit_unbalanced'
       | 'count_mismatch';
     latestExportedCount: number | null;
     countsAligned: boolean | null;
@@ -194,6 +197,14 @@ function toStringAmount(
   return String(value);
 }
 
+function areAmountsEqual(left: string, right: string) {
+  try {
+    return new Prisma.Decimal(left).equals(new Prisma.Decimal(right));
+  } catch {
+    return left === right;
+  }
+}
+
 function buildReconciliationSampleRow(row: {
   id: string;
   eventId: string;
@@ -273,7 +284,9 @@ function buildIntegrationReconciliationSummaryFromBaseData(
     0,
   );
   const mappingComplete = pendingMappingCount === 0 && blockedCount === 0;
-  const debitCreditBalanced = base.invalidReadyCount === 0;
+  const debitCreditBalanced =
+    base.invalidReadyCount === 0 &&
+    areAmountsEqual(base.readyDebitTotal, base.readyCreditTotal);
 
   let accountingComparisonStatus: ReconciliationSummary['accounting']['comparisonStatus'];
   let accountingCountsAligned: boolean | null;
@@ -282,6 +295,9 @@ function buildIntegrationReconciliationSummaryFromBaseData(
     accountingCountsAligned = null;
   } else if (base.invalidReadyCount > 0) {
     accountingComparisonStatus = 'ready_row_incomplete';
+    accountingCountsAligned = false;
+  } else if (!debitCreditBalanced) {
+    accountingComparisonStatus = 'debit_credit_unbalanced';
     accountingCountsAligned = false;
   } else if (!base.latestIcsExport) {
     accountingComparisonStatus = 'export_missing';
@@ -340,8 +356,8 @@ function buildIntegrationReconciliationSummaryFromBaseData(
         blockedCount,
         invalidReadyCount: base.invalidReadyCount,
         readyAmountTotal: base.readyAmountTotal,
-        readyDebitTotal: base.readyAmountTotal,
-        readyCreditTotal: base.readyAmountTotal,
+        readyDebitTotal: base.readyDebitTotal,
+        readyCreditTotal: base.readyCreditTotal,
         debitCreditBalanced,
       },
     },
@@ -385,7 +401,7 @@ async function fetchIntegrationReconciliationBaseData(options: {
     latestEmployeeMasterFullExport,
     latestIcsExport,
     stagingCounts,
-    readyAmountAggregate,
+    readyTotalsRows,
     invalidReadyCountRows,
   ] = await Promise.all([
     latestClosing
@@ -450,10 +466,37 @@ async function fetchIntegrationReconciliationBaseData(options: {
       where: { event: { periodKey } },
       _count: { _all: true },
     }),
-    client.accountingJournalStaging.aggregate({
-      where: { event: { periodKey }, status: 'ready' },
-      _sum: { amount: true },
-    }),
+    client.$queryRaw<
+      Array<{
+        readyAmountTotal: string | Prisma.Decimal | number | null;
+        readyDebitTotal: string | Prisma.Decimal | number | null;
+        readyCreditTotal: string | Prisma.Decimal | number | null;
+      }>
+    >(Prisma.sql`
+      SELECT
+        COALESCE(SUM(CASE WHEN ajs."status" = 'ready' THEN ajs."amount" ELSE 0 END), 0)::text AS "readyAmountTotal",
+        COALESCE(SUM(
+          CASE
+            WHEN ajs."status" = 'ready'
+              AND ajs."debitAccountCode" IS NOT NULL
+              AND BTRIM(ajs."debitAccountCode") <> ''
+            THEN ajs."amount"
+            ELSE 0
+          END
+        ), 0)::text AS "readyDebitTotal",
+        COALESCE(SUM(
+          CASE
+            WHEN ajs."status" = 'ready'
+              AND ajs."creditAccountCode" IS NOT NULL
+              AND BTRIM(ajs."creditAccountCode") <> ''
+            THEN ajs."amount"
+            ELSE 0
+          END
+        ), 0)::text AS "readyCreditTotal"
+      FROM "AccountingJournalStaging" ajs
+      INNER JOIN "AccountingEvent" ae ON ae."id" = ajs."eventId"
+      WHERE ae."periodKey" = ${periodKey}
+    `),
     client.$queryRaw<Array<{ count: bigint | number }>>(Prisma.sql`
       SELECT COUNT(*)::int AS "count"
       FROM "AccountingJournalStaging" ajs
@@ -478,7 +521,9 @@ async function fetchIntegrationReconciliationBaseData(options: {
     latestEmployeeMasterFullExport,
     latestIcsExport,
     stagingCounts,
-    readyAmountTotal: toStringAmount(readyAmountAggregate._sum.amount ?? 0),
+    readyAmountTotal: toStringAmount(readyTotalsRows[0]?.readyAmountTotal),
+    readyDebitTotal: toStringAmount(readyTotalsRows[0]?.readyDebitTotal),
+    readyCreditTotal: toStringAmount(readyTotalsRows[0]?.readyCreditTotal),
     invalidReadyCount: Number(invalidReadyCountRows[0]?.count ?? 0),
   };
 }

--- a/packages/backend/src/services/integrationReconciliation.ts
+++ b/packages/backend/src/services/integrationReconciliation.ts
@@ -504,8 +504,10 @@ async function fetchIntegrationReconciliationBaseData(options: {
       WHERE ae."periodKey" = ${periodKey}
         AND ajs."status" = 'ready'
         AND (
-          ajs."debitAccountCode" IS NULL OR BTRIM(ajs."debitAccountCode") = ''
-          OR ajs."creditAccountCode" IS NULL OR BTRIM(ajs."creditAccountCode") = ''
+          (
+            (ajs."debitAccountCode" IS NULL OR BTRIM(ajs."debitAccountCode") = '')
+            AND (ajs."creditAccountCode" IS NULL OR BTRIM(ajs."creditAccountCode") = '')
+          )
           OR ajs."taxCode" IS NULL OR BTRIM(ajs."taxCode") = ''
           OR ajs."amount" <= 0
         )
@@ -574,9 +576,10 @@ export async function buildIntegrationReconciliationDetails(options: {
         COUNT(*) FILTER (
           WHERE ajs."status" = 'ready'
             AND (
-              ajs."debitAccountCode" IS NULL OR ajs."debitAccountCode" = ''
-              OR BTRIM(ajs."debitAccountCode") = ''
-              OR ajs."creditAccountCode" IS NULL OR BTRIM(ajs."creditAccountCode") = ''
+              (
+                (ajs."debitAccountCode" IS NULL OR BTRIM(ajs."debitAccountCode") = '')
+                AND (ajs."creditAccountCode" IS NULL OR BTRIM(ajs."creditAccountCode") = '')
+              )
               OR ajs."taxCode" IS NULL OR BTRIM(ajs."taxCode") = ''
               OR ajs."amount" <= 0
             )
@@ -601,9 +604,10 @@ export async function buildIntegrationReconciliationDetails(options: {
         COUNT(*) FILTER (
           WHERE ajs."status" = 'ready'
             AND (
-              ajs."debitAccountCode" IS NULL OR ajs."debitAccountCode" = ''
-              OR BTRIM(ajs."debitAccountCode") = ''
-              OR ajs."creditAccountCode" IS NULL OR BTRIM(ajs."creditAccountCode") = ''
+              (
+                (ajs."debitAccountCode" IS NULL OR BTRIM(ajs."debitAccountCode") = '')
+                AND (ajs."creditAccountCode" IS NULL OR BTRIM(ajs."creditAccountCode") = '')
+              )
               OR ajs."taxCode" IS NULL OR BTRIM(ajs."taxCode") = ''
               OR ajs."amount" <= 0
             )
@@ -675,8 +679,10 @@ export async function buildIntegrationReconciliationDetails(options: {
       WHERE ae."periodKey" = ${summary.periodKey}
         AND ajs."status" = 'ready'
         AND (
-          ajs."debitAccountCode" IS NULL OR BTRIM(ajs."debitAccountCode") = ''
-          OR ajs."creditAccountCode" IS NULL OR BTRIM(ajs."creditAccountCode") = ''
+          (
+            (ajs."debitAccountCode" IS NULL OR BTRIM(ajs."debitAccountCode") = '')
+            AND (ajs."creditAccountCode" IS NULL OR BTRIM(ajs."creditAccountCode") = '')
+          )
           OR ajs."taxCode" IS NULL OR BTRIM(ajs."taxCode") = ''
           OR ajs."amount" <= 0
         )

--- a/packages/backend/test/accountingIcsExportRoutes.test.js
+++ b/packages/backend/test/accountingIcsExportRoutes.test.js
@@ -173,6 +173,124 @@ test('GET /integrations/accounting/exports/journals falls back to account codes 
   );
 });
 
+test('GET /integrations/accounting/exports/journals allows single-sided ready rows for compound vouchers', async () => {
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+
+  await withPrismaStubs(
+    {
+      'accountingJournalStaging.count': async () => 0,
+      'accountingJournalStaging.findMany': async () => [
+        {
+          id: 'stg-single-sided',
+          eventId: 'evt-single-sided',
+          mappingKey: 'compound:debit',
+          lineNo: 1,
+          entryDate: new Date('2026-02-14T00:00:00.000Z'),
+          amount: '12000',
+          description: '複合仕訳借方行',
+          debitAccountCode: '6001',
+          debitAccountName: '旅費交通費',
+          debitSubaccountCode: null,
+          creditAccountCode: null,
+          creditAccountName: null,
+          creditSubaccountCode: null,
+          departmentCode: 'D001',
+          taxCode: 'T10',
+          event: {
+            id: 'evt-single-sided',
+            sourceTable: 'manual_journal',
+            sourceId: 'journal-001',
+            periodKey: '2026-02',
+            externalRef: 'JRN-001',
+            description: '複合仕訳',
+          },
+        },
+      ],
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'GET',
+          url: '/integrations/accounting/exports/journals?periodKey=2026-02',
+          headers: {
+            'x-user-id': 'admin-user',
+            'x-roles': 'admin',
+          },
+        });
+        assert.equal(res.statusCode, 200, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body.items[0].debitAccountCode, '6001');
+        assert.equal(body.items[0].creditAccountCode, '');
+        assert.equal(body.items[0].amount, '12000');
+      } finally {
+        await server.close();
+      }
+    },
+  );
+});
+
+test('GET /integrations/accounting/exports/journals rejects ready rows with neither debit nor credit side', async () => {
+  process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
+  process.env.AUTH_MODE = 'header';
+
+  await withPrismaStubs(
+    {
+      'accountingJournalStaging.count': async () => 0,
+      'accountingJournalStaging.findMany': async () => [
+        {
+          id: 'stg-no-side',
+          eventId: 'evt-no-side',
+          mappingKey: 'compound:invalid',
+          lineNo: 1,
+          entryDate: new Date('2026-02-14T00:00:00.000Z'),
+          amount: '12000',
+          description: '科目なし',
+          debitAccountCode: null,
+          debitAccountName: null,
+          debitSubaccountCode: null,
+          creditAccountCode: ' ',
+          creditAccountName: null,
+          creditSubaccountCode: null,
+          departmentCode: 'D001',
+          taxCode: 'T10',
+          event: {
+            id: 'evt-no-side',
+            sourceTable: 'manual_journal',
+            sourceId: 'journal-invalid',
+            periodKey: '2026-02',
+            externalRef: 'JRN-INVALID',
+            description: '科目なし',
+          },
+        },
+      ],
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'GET',
+          url: '/integrations/accounting/exports/journals?periodKey=2026-02',
+          headers: {
+            'x-user-id': 'admin-user',
+            'x-roles': 'admin',
+          },
+        });
+        assert.equal(res.statusCode, 409, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body.error, 'accounting_journal_ready_row_incomplete');
+        assert.deepEqual(body.details.missingFields, [
+          'debitAccountCode',
+          'creditAccountCode',
+        ]);
+      } finally {
+        await server.close();
+      }
+    },
+  );
+});
+
 test('GET /integrations/accounting/exports/journals uses staged account names without live rule lookup', async () => {
   process.env.DATABASE_URL = process.env.DATABASE_URL || MIN_DATABASE_URL;
   process.env.AUTH_MODE = 'header';

--- a/packages/backend/test/integrationReconciliationRoutes.test.js
+++ b/packages/backend/test/integrationReconciliationRoutes.test.js
@@ -124,6 +124,15 @@ test('GET /integrations/reconciliation/summary returns aggregate reconciliation 
         const sql = Array.isArray(query?.strings)
           ? query.strings.join(' ')
           : String(query);
+        if (sql.includes('"readyDebitTotal"')) {
+          return [
+            {
+              readyAmountTotal: '12345',
+              readyDebitTotal: '12345',
+              readyCreditTotal: '12345',
+            },
+          ];
+        }
         if (sql.includes('SELECT COUNT(*)::int AS "count"')) {
           return [{ count: 0 }];
         }
@@ -212,6 +221,15 @@ test('GET /integrations/reconciliation/summary treats missing prerequisites as b
         const sql = Array.isArray(query?.strings)
           ? query.strings.join(' ')
           : String(query);
+        if (sql.includes('"readyDebitTotal"')) {
+          return [
+            {
+              readyAmountTotal: '0',
+              readyDebitTotal: '0',
+              readyCreditTotal: '0',
+            },
+          ];
+        }
         if (sql.includes('SELECT COUNT(*)::int AS "count"')) {
           return [{ count: 0 }];
         }
@@ -295,6 +313,15 @@ test('GET /integrations/reconciliation/summary reports missing full export and e
         const sql = Array.isArray(query?.strings)
           ? query.strings.join(' ')
           : String(query);
+        if (sql.includes('"readyDebitTotal"')) {
+          return [
+            {
+              readyAmountTotal: '2500',
+              readyDebitTotal: '2500',
+              readyCreditTotal: '0',
+            },
+          ];
+        }
         if (sql.includes('SELECT COUNT(*)::int AS "count"')) {
           return [{ count: 1 }];
         }
@@ -322,6 +349,77 @@ test('GET /integrations/reconciliation/summary reports missing full export and e
         assert.equal(body.accounting.comparisonStatus, 'ready_row_incomplete');
         assert.equal(body.accounting.countsAligned, false);
         assert.equal(body.accounting.staging.invalidReadyCount, 1);
+        assert.equal(body.accounting.staging.readyDebitTotal, '2500');
+        assert.equal(body.accounting.staging.readyCreditTotal, '0');
+        assert.equal(body.accounting.staging.debitCreditBalanced, false);
+        assert.equal(body.hasBlockingDifferences, true);
+      } finally {
+        await server.close();
+      }
+    },
+  );
+});
+
+test('GET /integrations/reconciliation/summary reports true debit and credit totals', async () => {
+  await withPrismaStubs(
+    {
+      'attendanceClosingPeriod.findFirst': async () => null,
+      'hrEmployeeMasterExportLog.findFirst': async () => null,
+      'accountingIcsExportLog.findFirst': async () => ({
+        id: 'ics-true-totals',
+        idempotencyKey: 'ics-key-true-totals',
+        reexportOfId: null,
+        periodKey: '2026-05',
+        status: 'success',
+        exportedUntil: new Date('2026-05-31T15:30:00.000Z'),
+        exportedCount: 2,
+        startedAt: new Date('2026-05-31T15:30:00.000Z'),
+        finishedAt: new Date('2026-05-31T15:30:05.000Z'),
+        message: 'exported',
+      }),
+      'accountingJournalStaging.groupBy': async () => [
+        { status: 'ready', _count: { _all: 2 } },
+      ],
+      $queryRaw: async (query) => {
+        const sql = Array.isArray(query?.strings)
+          ? query.strings.join(' ')
+          : String(query);
+        if (sql.includes('"readyDebitTotal"')) {
+          return [
+            {
+              readyAmountTotal: '5500',
+              readyDebitTotal: '3000',
+              readyCreditTotal: '2500',
+            },
+          ];
+        }
+        if (sql.includes('SELECT COUNT(*)::int AS "count"')) {
+          return [{ count: 0 }];
+        }
+        throw new Error(`unexpected $queryRaw: ${sql}`);
+      },
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'GET',
+          url: '/integrations/reconciliation/summary?periodKey=2026-05',
+          headers: {
+            'x-user-id': 'admin-user',
+            'x-roles': 'admin',
+          },
+        });
+        assert.equal(res.statusCode, 200, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(
+          body.accounting.comparisonStatus,
+          'debit_credit_unbalanced',
+        );
+        assert.equal(body.accounting.countsAligned, false);
+        assert.equal(body.accounting.staging.readyAmountTotal, '5500');
+        assert.equal(body.accounting.staging.readyDebitTotal, '3000');
+        assert.equal(body.accounting.staging.readyCreditTotal, '2500');
         assert.equal(body.accounting.staging.debitCreditBalanced, false);
         assert.equal(body.hasBlockingDifferences, true);
       } finally {
@@ -408,6 +506,15 @@ test('GET /integrations/reconciliation/details returns payroll diffs and account
         const sql = Array.isArray(query?.strings)
           ? query.strings.join(' ')
           : String(query);
+        if (sql.includes('"readyDebitTotal"')) {
+          return [
+            {
+              readyAmountTotal: '5000',
+              readyDebitTotal: '5000',
+              readyCreditTotal: '5000',
+            },
+          ];
+        }
         if (sql.includes('SELECT ajs."id"')) {
           return [{ id: 'stg-004' }];
         }


### PR DESCRIPTION
## Summary
- Compute `readyDebitTotal` and `readyCreditTotal` from ready staging rows independently instead of mirroring `readyAmountTotal`.
- Mark reconciliation as `debit_credit_unbalanced` when ready debit/credit totals differ while ready rows are otherwise complete.
- Extend reconciliation route tests for true debit/credit totals and update accounting integration docs.

## Validation
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public npx --prefix packages/backend prisma generate --config packages/backend/prisma.config.ts`
- `npm run build --prefix packages/backend`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public npm run test:ci --prefix packages/backend -- test/integrationReconciliationRoutes.test.js`
- `npm run lint --prefix packages/backend`
- `npm run format:check --prefix packages/backend`

Closes #1743