### PR TITLE
[codex] Add management accounting department breakdown

### DIFF
--- a/docs/manual/reporting-guide.md
+++ b/docs/manual/reporting-guide.md
@@ -30,7 +30,8 @@
 
 - from/to は `YYYY-MM-DD` 形式で入力する（UI/Api仕様に合わせる）
 - 管理会計サマリで複数通貨が混在する場合、金額系 KPI は通貨別表示になる
-- 管理会計サマリ CSV は summary / currency_breakdown / top_red_project の各行で出力する
+- 管理会計サマリは `Project.orgUnitId` を暫定部門キーにした部門別損益を表示する
+- 管理会計サマリ CSV は summary / currency_breakdown / department_breakdown / top_red_project の各行で出力する
 
 ## ダッシュボード（インサイト/アラート）
 

--- a/docs/manual/ui-manual-admin.md
+++ b/docs/manual/ui-manual-admin.md
@@ -181,16 +181,17 @@
 7. `グループ別工数` では userIds を指定して取得する
 8. `個人別残業` では userId を指定して取得する
 9. `管理会計サマリ` で全社KPIの初期値を取得する
-10. `管理会計サマリCSV` で summary / currency_breakdown / top_red_project を CSV 出力する
-11. ベースラインを選択し `バーンダウン` を取得する
-12. `EVM` を取得する
+10. 管理会計サマリ内の `部門別損益` で、暫定部門キー（初期は `Project.orgUnitId`）別の売上・原価・粗利を確認する
+11. `管理会計サマリCSV` で summary / currency_breakdown / department_breakdown / top_red_project を CSV 出力する
+12. ベースラインを選択し `バーンダウン` を取得する
+13. `EVM` を取得する
 
 ### 入力項目/制約
 
 - `from/to` は YYYY-MM-DD 形式
 - バーンダウンはベースラインが必須
 - 管理会計サマリは複数通貨が混在する場合、金額系 KPI を通貨別表示に切り替える
-- 管理会計サマリ CSV は複数通貨時でも通貨別 breakdown を行単位で出力する
+- 管理会計サマリ CSV は複数通貨時でも通貨別 breakdown と部門別 breakdown を行単位で出力する
 
 ![レポート](../test-results/2026-03-16-frontend-e2e-r4/08-reports.png)
 

--- a/docs/requirements/management-accounting-report-requirements.md
+++ b/docs/requirements/management-accounting-report-requirements.md
@@ -117,8 +117,9 @@
   - `department code` と `project -> department` の正規ルールが必要
   - `#1434`, `#1439`, `#1441` に依存
 - フェーズ:
-  - 初期フェーズでは要件定義のみ
-  - 実装は後続
+  - `#1744` の最小実装では `Project.orgUnitId` を暫定部門キーとして `management-accounting/summary` に `departmentBreakdown[]` を追加する
+  - 正規部門マスタ/外部連携コードとの接続は `#1748` で扱う
+  - `UserAccount.department` の自由入力値は暫定集計の正本にはしない
 
 ### R4. 月次 KPI ダッシュボード
 
@@ -146,8 +147,9 @@
   - `GET /reports/management-accounting/summary?from=YYYY-MM-DD&to=YYYY-MM-DD&format=csv`
   - ERP4 内の売上、直接原価、粗利、納期未請求、残業、赤字案件件数を 1 API で返す
   - 複数通貨が混在する場合は、金額系 KPI の top-level 合算値は返さず、`currencyBreakdown[]` で通貨別内訳を返す
-  - CSV は `summary` / `currency_breakdown` / `top_red_project` の 3 section で flatten して出力する
-  - UI は `Reports` セクションの管理会計サマリ表示と CSV 出力を初期導線とし、案件単位の確認には既存 `project-profit` を併用する
+  - `departmentBreakdown[]` は暫定部門キー（初期は `Project.orgUnitId`、未設定は `null`）と通貨単位で、売上・直接原価・労務原価・外注/仕入・経費・粗利・粗利率・工数・赤字案件数を返す
+  - CSV は `summary` / `currency_breakdown` / `department_breakdown` / `top_red_project` の 4 section で flatten して出力する
+  - UI は `Reports` セクションの管理会計サマリ表示、部門別損益の初期表示、CSV 出力を初期導線とし、案件単位の確認には既存 `project-profit` を併用する
 
 ### R5. 管理部向け締め前照合レポート
 
@@ -183,6 +185,7 @@
 - 補足:
   - 労務原価は給与原価ではなく、管理単価ベース
   - 給与連携完成後は「給与確定値ベース原価」と「管理単価ベース原価」を併存させる可能性がある
+  - 給与確定値ベース原価の反映は `#1749` で、締め条件・配賦・表示切替を含めて扱う
 
 ### 部門
 
@@ -242,6 +245,7 @@
 | 残業時間       | `reportOvertime` の時間合計           | `overtime`                        | 実装済みだが定義見直し余地あり |
 | 納期未請求件数 | `delivery-due` 件数                   | `delivery-due`                    | 実装済み                       |
 | 赤字案件数     | 粗利 < 0 の案件数                     | `project-profit` の横断集計が必要 | 未実装                         |
+| 部門別損益     | 暫定部門キーごとの売上・原価・粗利    | `management-accounting/summary`   | 初期実装済み                   |
 
 ## 初期フェーズの境界
 
@@ -251,14 +255,15 @@
 - 案件別採算のユーザ別 / グループ別内訳
 - 工数予実、納期未請求、残業
 - 管理会計ダッシュボードに必要な KPI 要件定義
+- `Project.orgUnitId` 暫定キーによる部門別損益の初期表示
 
 ### 初期フェーズで要件化のみ行い、実装を後続に回す
 
-- 部門別損益
 - 給与確定値ベースの人件費
 - 勘定科目別集計
 - 間接費の全社配賦
 - 月次締めスナップショット
+- 制度会計実績戻し import と管理会計照合（`#1750`）
 
 ## 後続 issue への接続
 
@@ -269,10 +274,24 @@
 - `#1440`: 勤怠確定データ整備
 - `#1441`: 会計イベント・仕訳変換ルール整備
 - `#1447`: 本書で定義した初期レポートの実装
+- `#1748`: 管理会計 `departmentBreakdown` の正規部門マスタ連携
+- `#1749`: 給与確定値ベース労務原価の管理会計反映
+- `#1750`: 制度会計実績戻し import と管理会計照合
+
+## `#1744` での再確認結果とテスト方針
+
+- 現行 summary report のデータソースは `Invoice`（売上）、`VendorInvoice` / `Expense` / `TimeEntry * RateCard`（直接原価）、`ProjectMilestone`（納期未請求）、`TimeEntry`（残業・工数）である。
+- 部門別損益の最小実装単位は、既存 `Project.orgUnitId` を暫定部門キーとして summary API / CSV / Reports UI に `departmentBreakdown` を追加することとする。
+- 給与確定値ベース原価は、勤怠締め・給与確定値の正本と月次配賦ルールが未確定のため、`#1749` で管理単価ベース原価との併存仕様を定義してから実装する。
+- 制度会計実績戻しは、取り込み方式と粒度（部門・勘定科目・PJ）が未確定のため、`#1750` で import/staging と差分照合を設計する。
+- 最小実装のテスト方針:
+  - backend route test で `departmentBreakdown[]` の集計、赤字案件数、CSV `department_breakdown` section を検証する。
+  - frontend test で Reports 画面の部門別損益表示を検証する。
+  - 正規部門マスタ連携、給与確定値原価、制度会計実績戻しは各子 Issue で API / CSV / UI / import validation の回帰テストを追加する。
 
 ## repo ベースで判明している未決事項
 
-- 部門別損益の `department` 正本を `Project` 起点に持つか、`User` / `Group` 起点に持つか
+- 部門別損益の初期表示は `Project.orgUnitId` 起点とするが、正規部門マスタ/外部連携コードとしての正本化は未完了
 - 労務原価を管理単価ベースと給与確定ベースのどちらで表示するか
 - PM 向け閲覧権限を route / dashboard / subscription でどう分けるか
 - 月次締め後の再現性を `PeriodLock` のみで足りるとみなすか、snapshot を追加するか

--- a/packages/backend/src/routes/reports.ts
+++ b/packages/backend/src/routes/reports.ts
@@ -90,7 +90,7 @@ function buildManagementAccountingSummaryCsv(
   const rows: Array<Array<string | number>> = [
     [
       'summary',
-      summary.currency ?? '',
+      sanitizeCsvCell(summary.currency ?? ''),
       '',
       '',
       '',
@@ -114,7 +114,7 @@ function buildManagementAccountingSummaryCsv(
   for (const item of summary.currencyBreakdown) {
     rows.push([
       'currency_breakdown',
-      item.currency ?? '',
+      sanitizeCsvCell(item.currency ?? ''),
       '',
       '',
       '',
@@ -138,7 +138,7 @@ function buildManagementAccountingSummaryCsv(
   for (const item of summary.departmentBreakdown) {
     rows.push([
       'department_breakdown',
-      item.currency ?? '',
+      sanitizeCsvCell(item.currency ?? ''),
       sanitizeCsvCell(item.departmentKey ?? ''),
       '',
       '',

--- a/packages/backend/src/routes/reports.ts
+++ b/packages/backend/src/routes/reports.ts
@@ -69,6 +69,7 @@ function buildManagementAccountingSummaryCsv(
   const headers = [
     'section',
     'currency',
+    'departmentKey',
     'projectId',
     'projectCode',
     'projectName',
@@ -90,6 +91,7 @@ function buildManagementAccountingSummaryCsv(
     [
       'summary',
       summary.currency ?? '',
+      '',
       '',
       '',
       '',
@@ -116,6 +118,7 @@ function buildManagementAccountingSummaryCsv(
       '',
       '',
       '',
+      '',
       item.projectCount,
       item.revenue,
       item.directCost,
@@ -130,10 +133,38 @@ function buildManagementAccountingSummaryCsv(
       item.deliveryDueAmount,
       item.redProjectCount,
     ]);
+  }
+
+  for (const item of summary.departmentBreakdown) {
+    rows.push([
+      'department_breakdown',
+      item.currency ?? '',
+      sanitizeCsvCell(item.departmentKey ?? ''),
+      '',
+      '',
+      '',
+      item.projectCount,
+      item.revenue,
+      item.directCost,
+      item.laborCost,
+      item.vendorCost,
+      item.expenseCost,
+      item.grossProfit,
+      item.grossMargin,
+      item.totalMinutes,
+      '',
+      '',
+      '',
+      item.redProjectCount,
+    ]);
+  }
+
+  for (const item of summary.currencyBreakdown) {
     for (const project of item.topRedProjects) {
       rows.push([
         'top_red_project',
         sanitizeCsvCell(project.currency ?? item.currency ?? ''),
+        sanitizeCsvCell(project.departmentKey ?? ''),
         sanitizeCsvCell(project.projectId),
         sanitizeCsvCell(project.projectCode ?? ''),
         sanitizeCsvCell(project.projectName ?? ''),

--- a/packages/backend/src/services/reports.ts
+++ b/packages/backend/src/services/reports.ts
@@ -9,6 +9,7 @@ type ManagementAccountingProjectBucket = {
   projectId: string;
   projectCode?: string | null;
   projectName?: string | null;
+  departmentKey?: string | null;
   currency: string | null;
   revenue: number;
   directCost: number;
@@ -37,13 +38,40 @@ type ManagementAccountingCurrencyBreakdown = {
   topRedProjects: ManagementAccountingProjectBucket[];
 };
 
+type ManagementAccountingDepartmentBreakdown = {
+  departmentKey: string | null;
+  currency: string | null;
+  projectCount: number;
+  revenue: number;
+  directCost: number;
+  laborCost: number;
+  vendorCost: number;
+  expenseCost: number;
+  grossProfit: number;
+  grossMargin: number;
+  totalMinutes: number;
+  redProjectCount: number;
+};
+
 function normalizeWorkType(workType?: string | null) {
   const trimmed = workType?.trim();
   return trimmed || null;
 }
 
+function normalizeReportingKey(value?: string | null) {
+  const trimmed = value?.trim();
+  return trimmed || null;
+}
+
 function buildProjectCurrencyKey(projectId: string, currency: string | null) {
   return `${projectId}|${currency ?? ''}`;
+}
+
+function buildDepartmentCurrencyKey(
+  departmentKey: string | null,
+  currency: string | null,
+) {
+  return `${departmentKey ?? ''}|${currency ?? ''}`;
 }
 
 function preloadRateCardKey(match: {
@@ -384,7 +412,13 @@ export async function reportOvertime(userId: string, from?: Date, to?: Date) {
 export async function reportManagementAccountingSummary(from: Date, to: Date) {
   const projects = await prisma.project.findMany({
     where: { deletedAt: null },
-    select: { id: true, code: true, name: true, currency: true },
+    select: {
+      id: true,
+      code: true,
+      name: true,
+      currency: true,
+      orgUnitId: true,
+    },
     orderBy: [{ code: 'asc' }, { id: 'asc' }],
   });
   const projectIds = projects.map((project) => project.id);
@@ -581,6 +615,7 @@ export async function reportManagementAccountingSummary(from: Date, to: Date) {
         projectId,
         projectCode: project?.code ?? null,
         projectName: project?.name ?? null,
+        departmentKey: normalizeReportingKey(project?.orgUnitId),
         currency,
         revenue,
         directCost,
@@ -646,6 +681,58 @@ export async function reportManagementAccountingSummary(from: Date, to: Date) {
     }))
     .sort((a, b) => (a.currency ?? '').localeCompare(b.currency ?? ''));
 
+  const departmentBreakdownMap = new Map<
+    string,
+    ManagementAccountingDepartmentBreakdown
+  >();
+  for (const item of items) {
+    const key = buildDepartmentCurrencyKey(
+      item.departmentKey ?? null,
+      item.currency,
+    );
+    if (!departmentBreakdownMap.has(key)) {
+      departmentBreakdownMap.set(key, {
+        departmentKey: item.departmentKey ?? null,
+        currency: item.currency,
+        projectCount: 0,
+        revenue: 0,
+        directCost: 0,
+        laborCost: 0,
+        vendorCost: 0,
+        expenseCost: 0,
+        grossProfit: 0,
+        grossMargin: 0,
+        totalMinutes: 0,
+        redProjectCount: 0,
+      });
+    }
+    const bucket = departmentBreakdownMap.get(key);
+    if (!bucket) continue;
+    bucket.projectCount += 1;
+    bucket.revenue += item.revenue;
+    bucket.directCost += item.directCost;
+    bucket.laborCost += item.laborCost;
+    bucket.vendorCost += item.vendorCost;
+    bucket.expenseCost += item.expenseCost;
+    bucket.grossProfit += item.grossProfit;
+    bucket.totalMinutes += item.totalMinutes;
+    if (item.grossProfit < 0) bucket.redProjectCount += 1;
+  }
+
+  const departmentBreakdown = Array.from(departmentBreakdownMap.values())
+    .map((bucket) => ({
+      ...bucket,
+      grossMargin: bucket.revenue > 0 ? bucket.grossProfit / bucket.revenue : 0,
+    }))
+    .sort((a, b) => {
+      const departmentCompare = (a.departmentKey ?? '').localeCompare(
+        b.departmentKey ?? '',
+      );
+      return departmentCompare !== 0
+        ? departmentCompare
+        : (a.currency ?? '').localeCompare(b.currency ?? '');
+    });
+
   const totals = currencyBreakdown.reduce(
     (acc, item) => {
       acc.revenue += item.revenue;
@@ -683,6 +770,7 @@ export async function reportManagementAccountingSummary(from: Date, to: Date) {
     currency: singleCurrencyBucket?.currency ?? null,
     mixedCurrency,
     currencyBreakdown,
+    departmentBreakdown,
     revenue: singleCurrencyBucket ? totals.revenue : null,
     directCost: singleCurrencyBucket ? totals.directCost : null,
     laborCost: singleCurrencyBucket ? totals.laborCost : null,

--- a/packages/backend/test/managementAccountingSummaryRoutes.test.js
+++ b/packages/backend/test/managementAccountingSummaryRoutes.test.js
@@ -39,12 +39,14 @@ test('GET /reports/management-accounting/summary returns aggregate management ac
           code: 'PRJ-001',
           name: 'Project 1',
           currency: 'JPY',
+          orgUnitId: 'D001',
         },
         {
           id: 'project-2',
           code: '=PRJ-002',
           name: '@Project 2',
           currency: 'JPY',
+          orgUnitId: 'D002',
         },
       ],
       'invoice.groupBy': async () => [
@@ -152,6 +154,19 @@ test('GET /reports/management-accounting/summary returns aggregate management ac
         assert.equal(body.topRedProjects.length, 1);
         assert.equal(body.topRedProjects[0].projectId, 'project-2');
         assert.equal(body.topRedProjects[0].grossProfit, -1050);
+        assert.equal(body.departmentBreakdown.length, 2);
+        const departmentD001 = body.departmentBreakdown.find(
+          (item) => item.departmentKey === 'D001',
+        );
+        const departmentD002 = body.departmentBreakdown.find(
+          (item) => item.departmentKey === 'D002',
+        );
+        assert.ok(departmentD001);
+        assert.ok(departmentD002);
+        assert.equal(departmentD001.revenue, 10000);
+        assert.equal(departmentD001.directCost, 4500);
+        assert.equal(departmentD001.grossProfit, 5500);
+        assert.equal(departmentD002.redProjectCount, 1);
       } finally {
         await server.close();
       }
@@ -168,12 +183,14 @@ test('GET /reports/management-accounting/summary returns csv export', async () =
           code: 'PRJ-001',
           name: 'Project 1',
           currency: 'JPY',
+          orgUnitId: 'D001',
         },
         {
           id: 'project-2',
           code: '=PRJ-002',
           name: '@Project 2',
           currency: 'JPY',
+          orgUnitId: 'D002',
         },
       ],
       'invoice.groupBy': async () => [
@@ -268,12 +285,13 @@ test('GET /reports/management-accounting/summary returns csv export', async () =
         );
         assert.match(
           res.body,
-          /^section,currency,projectId,projectCode,projectName,projectCount,revenue,directCost,laborCost,vendorCost,expenseCost,grossProfit,grossMargin,totalMinutes,overtimeTotalMinutes,deliveryDueCount,deliveryDueAmount,redProjectCount/m,
+          /^section,currency,departmentKey,projectId,projectCode,projectName,projectCount,revenue,directCost,laborCost,vendorCost,expenseCost,grossProfit,grossMargin,totalMinutes,overtimeTotalMinutes,deliveryDueCount,deliveryDueAmount,redProjectCount/m,
         );
-        assert.match(res.body, /summary,JPY,,,/, res.body);
+        assert.match(res.body, /summary,JPY,,,,/, res.body);
+        assert.match(res.body, /department_breakdown,JPY,D001,,,,1,10000,4500/);
         assert.match(
           res.body,
-          /top_red_project,JPY,project-2,'=PRJ-002,'@Project 2/,
+          /top_red_project,JPY,D002,project-2,'=PRJ-002,'@Project 2/,
         );
       } finally {
         await server.close();

--- a/packages/backend/test/managementAccountingSummaryRoutes.test.js
+++ b/packages/backend/test/managementAccountingSummaryRoutes.test.js
@@ -182,35 +182,39 @@ test('GET /reports/management-accounting/summary returns csv export', async () =
           id: 'project-1',
           code: 'PRJ-001',
           name: 'Project 1',
-          currency: 'JPY',
+          currency: '=JPY',
           orgUnitId: 'D001',
         },
         {
           id: 'project-2',
           code: '=PRJ-002',
           name: '@Project 2',
-          currency: 'JPY',
+          currency: '=JPY',
           orgUnitId: 'D002',
         },
       ],
       'invoice.groupBy': async () => [
         {
           projectId: 'project-1',
-          currency: 'JPY',
+          currency: '=JPY',
           _sum: { totalAmount: 10000 },
         },
-        { projectId: 'project-2', currency: 'JPY', _sum: { totalAmount: 500 } },
+        {
+          projectId: 'project-2',
+          currency: '=JPY',
+          _sum: { totalAmount: 500 },
+        },
       ],
       'vendorInvoice.groupBy': async () => [
         {
           projectId: 'project-1',
-          currency: 'JPY',
+          currency: '=JPY',
           _sum: { totalAmount: 3000 },
         },
       ],
       'expense.groupBy': async () => [
-        { projectId: 'project-1', currency: 'JPY', _sum: { amount: 500 } },
-        { projectId: 'project-2', currency: 'JPY', _sum: { amount: 700 } },
+        { projectId: 'project-1', currency: '=JPY', _sum: { amount: 500 } },
+        { projectId: 'project-2', currency: '=JPY', _sum: { amount: 700 } },
       ],
       'timeEntry.findMany': async () => [
         {
@@ -243,7 +247,7 @@ test('GET /reports/management-accounting/summary returns csv export', async () =
           validFrom: new Date('2026-01-01T00:00:00.000Z'),
           validTo: null,
           unitPrice: 100,
-          currency: 'JPY',
+          currency: '=JPY',
         },
         {
           id: 'rate-2',
@@ -252,7 +256,7 @@ test('GET /reports/management-accounting/summary returns csv export', async () =
           validFrom: new Date('2026-01-01T00:00:00.000Z'),
           validTo: null,
           unitPrice: 50,
-          currency: 'JPY',
+          currency: '=JPY',
         },
       ],
       'projectMilestone.findMany': async () => [
@@ -262,7 +266,7 @@ test('GET /reports/management-accounting/summary returns csv export', async () =
           name: '請求待ち',
           amount: 2000,
           dueDate: new Date('2026-03-20T00:00:00.000Z'),
-          project: { code: 'PRJ-001', name: 'Project 1', currency: 'JPY' },
+          project: { code: 'PRJ-001', name: 'Project 1', currency: '=JPY' },
           invoices: [],
         },
       ],
@@ -287,11 +291,15 @@ test('GET /reports/management-accounting/summary returns csv export', async () =
           res.body,
           /^section,currency,departmentKey,projectId,projectCode,projectName,projectCount,revenue,directCost,laborCost,vendorCost,expenseCost,grossProfit,grossMargin,totalMinutes,overtimeTotalMinutes,deliveryDueCount,deliveryDueAmount,redProjectCount/m,
         );
-        assert.match(res.body, /summary,JPY,,,,/, res.body);
-        assert.match(res.body, /department_breakdown,JPY,D001,,,,1,10000,4500/);
+        assert.match(res.body, /summary,'=JPY,,,,/, res.body);
+        assert.match(res.body, /currency_breakdown,'=JPY,,,,,2,10500,6050/);
         assert.match(
           res.body,
-          /top_red_project,JPY,D002,project-2,'=PRJ-002,'@Project 2/,
+          /department_breakdown,'=JPY,D001,,,,1,10000,4500/,
+        );
+        assert.match(
+          res.body,
+          /top_red_project,'=JPY,D002,project-2,'=PRJ-002,'@Project 2/,
         );
       } finally {
         await server.close();

--- a/packages/frontend/src/sections/Reports.test.tsx
+++ b/packages/frontend/src/sections/Reports.test.tsx
@@ -306,11 +306,13 @@ describe('Reports', () => {
       0,
     );
     expect(screen.getByText('部門別損益')).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        /Department: D001 \/ Currency: JPY \/ Projects: 1 \/ Revenue: 10,000 \/ Direct Cost: 3,000 \/ Gross Profit: 7,000 \/ Margin: 70\.00% \/ Red projects: 1/,
-      ),
-    ).toBeInTheDocument();
+    const expectedDepartmentLine =
+      `Department: D001 / Currency: JPY / Projects: 1 / ` +
+      `Revenue: ${(10000).toLocaleString()} / ` +
+      `Direct Cost: ${(3000).toLocaleString()} / ` +
+      `Gross Profit: ${(7000).toLocaleString()} / ` +
+      `Margin: ${(0.7 * 100).toFixed(2)}% / Red projects: 1`;
+    expect(screen.getByText(expectedDepartmentLine)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: '管理会計サマリCSV' }));
 

--- a/packages/frontend/src/sections/Reports.test.tsx
+++ b/packages/frontend/src/sections/Reports.test.tsx
@@ -238,10 +238,27 @@ describe('Reports', () => {
                   projectId: 'proj-1',
                   projectCode: 'P001',
                   projectName: 'Project One',
+                  departmentKey: 'D001',
                   grossProfit: -500,
                   grossMargin: -0.05,
                 },
               ],
+            },
+          ],
+          departmentBreakdown: [
+            {
+              departmentKey: 'D001',
+              currency: 'JPY',
+              projectCount: 1,
+              revenue: 10000,
+              directCost: 3000,
+              laborCost: 1200,
+              vendorCost: 1000,
+              expenseCost: 800,
+              grossProfit: 7000,
+              grossMargin: 0.7,
+              totalMinutes: 400,
+              redProjectCount: 1,
             },
           ],
           revenue: null,
@@ -288,6 +305,12 @@ describe('Reports', () => {
     expect(screen.getAllByText(/P001 \/ Project One/).length).toBeGreaterThan(
       0,
     );
+    expect(screen.getByText('部門別損益')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Department: D001 \/ Currency: JPY \/ Projects: 1 \/ Revenue: 10,000 \/ Direct Cost: 3,000 \/ Gross Profit: 7,000 \/ Margin: 70\.00% \/ Red projects: 1/,
+      ),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: '管理会計サマリCSV' }));
 

--- a/packages/frontend/src/sections/Reports.tsx
+++ b/packages/frontend/src/sections/Reports.tsx
@@ -145,6 +145,7 @@ type ManagementAccountingSummary = {
       projectId: string;
       projectCode?: string | null;
       projectName?: string | null;
+      departmentKey?: string | null;
       currency?: string | null;
       revenue: number;
       directCost: number;
@@ -155,6 +156,20 @@ type ManagementAccountingSummary = {
       grossMargin: number;
       totalMinutes: number;
     }>;
+  }>;
+  departmentBreakdown?: Array<{
+    departmentKey?: string | null;
+    currency?: string | null;
+    projectCount: number;
+    revenue: number;
+    directCost: number;
+    laborCost: number;
+    vendorCost: number;
+    expenseCost: number;
+    grossProfit: number;
+    grossMargin: number;
+    totalMinutes: number;
+    redProjectCount: number;
   }>;
   revenue: number | null;
   directCost: number | null;
@@ -172,6 +187,7 @@ type ManagementAccountingSummary = {
     projectId: string;
     projectCode?: string | null;
     projectName?: string | null;
+    departmentKey?: string | null;
     currency?: string | null;
     revenue: number;
     directCost: number;
@@ -893,6 +909,26 @@ export const Reports: React.FC = () => {
                 </div>
               </>
             )}
+            {managementReport.departmentBreakdown &&
+              managementReport.departmentBreakdown.length > 0 && (
+                <div style={{ marginTop: 8 }}>
+                  <strong>部門別損益</strong>
+                  {managementReport.departmentBreakdown.map((item) => (
+                    <div
+                      key={`${item.departmentKey || 'unassigned'}:${item.currency || 'none'}`}
+                    >
+                      Department: {item.departmentKey || '未設定'} / Currency:{' '}
+                      {item.currency || '未設定'} / Projects:{' '}
+                      {item.projectCount} / Revenue:{' '}
+                      {item.revenue.toLocaleString()} / Direct Cost:{' '}
+                      {item.directCost.toLocaleString()} / Gross Profit:{' '}
+                      {item.grossProfit.toLocaleString()} / Margin:{' '}
+                      {(item.grossMargin * 100).toFixed(2)}% / Red projects:{' '}
+                      {item.redProjectCount}
+                    </div>
+                  ))}
+                </div>
+              )}
             <div>
               Minutes: {managementReport.totalMinutes} / Overtime:{' '}
               {managementReport.overtimeTotalMinutes}


### PR DESCRIPTION
## Summary
- Add `departmentBreakdown[]` to `GET /reports/management-accounting/summary`, using `Project.orgUnitId` as the initial department key for department-level revenue, direct cost, gross profit, margin, effort, and red-project counts.
- Extend management-accounting CSV output with `departmentKey` and a `department_breakdown` section, and show department profit/loss in the Reports UI.
- Reconfirm #1744 scope, document child implementation issues #1748 / #1749 / #1750, and update reporting manuals.

## Validation
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public npx --prefix packages/backend prisma generate --config packages/backend/prisma.config.ts`
- `npm run build --prefix packages/backend`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public npm run test:ci --prefix packages/backend -- test/managementAccountingSummaryRoutes.test.js`
- `npm run lint --prefix packages/backend`
- `npm run format:check --prefix packages/backend`
- `npm run typecheck --prefix packages/frontend`
- `npm run test --prefix packages/frontend -- Reports.test.tsx`
- `npm run lint --prefix packages/frontend`
- `npm run format:check --prefix packages/frontend`
- `npm run build --prefix packages/frontend`

Closes #1744