### PR TITLE
feat(integrations): add statutory actual reconciliation

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -11510,6 +11510,143 @@
         }
       }
     },
+    "/integrations/accounting/statutory-actuals/import": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "accountingSystem": {
+                    "maxLength": 100,
+                    "minLength": 1,
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "importBatchKey": {
+                    "maxLength": 200,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "periodKey": {
+                    "pattern": "^\\d{4}-(0[1-9]|1[0-2])$",
+                    "type": "string"
+                  },
+                  "rows": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "accountCode": {
+                          "maxLength": 100,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "accountName": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "amount": {
+                          "anyOf": [
+                            {
+                              "exclusiveMinimum": true,
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            {
+                              "maxLength": 100,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "amountType": {
+                          "anyOf": [
+                            {
+                              "enum": [
+                                "revenue"
+                              ],
+                              "type": "string"
+                            },
+                            {
+                              "enum": [
+                                "direct_cost"
+                              ],
+                              "type": "string"
+                            },
+                            {
+                              "enum": [
+                                "labor_cost"
+                              ],
+                              "type": "string"
+                            },
+                            {
+                              "enum": [
+                                "vendor_cost"
+                              ],
+                              "type": "string"
+                            },
+                            {
+                              "enum": [
+                                "expense_cost"
+                              ],
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "currency": {
+                          "pattern": "^[A-Z]{3}$",
+                          "type": "string"
+                        },
+                        "departmentCode": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "projectCode": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "rowNo": {
+                          "maximum": 100000,
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "sourceRef": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "accountCode",
+                        "amountType",
+                        "currency",
+                        "amount"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 1000,
+                    "minItems": 1,
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "periodKey",
+                  "importBatchKey",
+                  "rows"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
     "/integrations/crm/exports/contacts": {
       "get": {
         "responses": {
@@ -12320,6 +12457,27 @@
             "schema": {
               "pattern": "^\\d{4}-(0[1-9]|1[0-2])$",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "json"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "enum": [
+                    "csv"
+                  ],
+                  "type": "string"
+                }
+              ]
             }
           }
         ],

--- a/docs/manual/reporting-guide.md
+++ b/docs/manual/reporting-guide.md
@@ -33,6 +33,7 @@
 - 管理会計サマリは `DepartmentMaster` を正規部門マスタとして照合した部門別損益を表示する。`Project.orgUnitId` は `DepartmentMaster.id` / `code` / `externalCode` のいずれかへ照合され、未照合の旧データは `legacy_org_unit` として区別される
 - 管理会計サマリは管理単価ベースの `laborCost` と、給与締め後に取り込まれた `PayrollConfirmedLaborCost` の `payrollConfirmedLaborCost` を併記する。差分は `laborCostVariance`、未締め・未取込の月は `payrollConfirmedStatus` / `payrollMissingPeriodKeys` で確認する。部分月の期間指定では、月次締め単位の給与確定値は金額集計に含めず missing として表示する
 - 管理会計サマリ CSV は summary / currency_breakdown / department_breakdown / top_red_project の各行で出力する。部門列には `departmentKey` / `departmentName` / `departmentExternalCode` / `departmentSource`、給与確定値列には `payrollConfirmedLaborCost` / `laborCostVariance` / `payrollConfirmedStatus` が含まれる
+- 制度会計確定後の外部実績は Admin Settings の `POST /integrations/accounting/statutory-actuals/import` API で戻し、`連携照合サマリ` と `GET /integrations/reconciliation/details?format=csv` で ERP4 内部 ready amount との差異を確認する。照合詳細の `statutory actual` / `variance` は PJ別・部門別の説明資料に利用できる
 
 ## ダッシュボード（インサイト/アラート）
 

--- a/docs/manual/reporting-guide.md
+++ b/docs/manual/reporting-guide.md
@@ -33,7 +33,7 @@
 - 管理会計サマリは `DepartmentMaster` を正規部門マスタとして照合した部門別損益を表示する。`Project.orgUnitId` は `DepartmentMaster.id` / `code` / `externalCode` のいずれかへ照合され、未照合の旧データは `legacy_org_unit` として区別される
 - 管理会計サマリは管理単価ベースの `laborCost` と、給与締め後に取り込まれた `PayrollConfirmedLaborCost` の `payrollConfirmedLaborCost` を併記する。差分は `laborCostVariance`、未締め・未取込の月は `payrollConfirmedStatus` / `payrollMissingPeriodKeys` で確認する。部分月の期間指定では、月次締め単位の給与確定値は金額集計に含めず missing として表示する
 - 管理会計サマリ CSV は summary / currency_breakdown / department_breakdown / top_red_project の各行で出力する。部門列には `departmentKey` / `departmentName` / `departmentExternalCode` / `departmentSource`、給与確定値列には `payrollConfirmedLaborCost` / `laborCostVariance` / `payrollConfirmedStatus` が含まれる
-- 制度会計確定後の外部実績は Admin Settings の `POST /integrations/accounting/statutory-actuals/import` API で戻し、`連携照合サマリ` と `GET /integrations/reconciliation/details?format=csv` で ERP4 内部 ready amount との差異を確認する。照合詳細の `statutory actual` / `variance` は PJ別・部門別の説明資料に利用できる
+- 制度会計確定後の外部実績は Admin Settings の `POST /integrations/accounting/statutory-actuals/import` API で戻し、`連携照合サマリ` と `GET /integrations/reconciliation/details?format=csv` で ERP4 内部 ready amount との差異を通貨別に確認する。照合詳細の `statutory actual` / `variance` は PJ別・部門別・通貨別の説明資料に利用できる
 
 ## ダッシュボード（インサイト/アラート）
 

--- a/docs/manual/ui-manual-admin.md
+++ b/docs/manual/ui-manual-admin.md
@@ -433,8 +433,8 @@
 3. 一覧の `実行` / `履歴表示` を実行する
 4. `照合対象月` を入力し `照合サマリ取得` を実行する
 5. 給与連携照合の `comparisonStatus` と社員コード差分を確認する
-6. 会計連携照合の `comparisonStatus` と `ready / pending_mapping / blocked` を確認し、制度会計実績戻しがある場合は `statutoryActuals` の `comparisonStatus` / `amount` / `variance` で ERP4 内部 ready debit total との差異を確認する
-7. 差分の全件確認が必要な場合は同カードの `照合詳細取得` を実行し、社員コード差分全件と `PJ別 / 部門別` breakdown、`statutory actual` / `variance`、`pending_mapping / blocked / invalid ready` の sample 行を確認する
+6. 会計連携照合の `comparisonStatus` と `ready / pending_mapping / blocked` を確認し、制度会計実績戻しがある場合は `statutoryActuals` の `comparisonStatus` / `currency` / `amount` / `variance` で ERP4 内部 ready debit total との差異を確認する
+7. 差分の全件確認が必要な場合は同カードの `照合詳細取得` を実行し、社員コード差分全件と `PJ別 / 部門別` の通貨別 breakdown、`statutory actual` / `variance`、`pending_mapping / blocked / invalid ready` の sample 行を確認する
 8. `連携ジョブ一覧` で種別 / ステータス / limit / offset を設定し `連携ジョブ取得` を実行する
 9. 成功済みジョブは `再出力` で payload を再送し、`reexportOfId` で lineage を確認する
 10. `会計マッピングルール` で `mappingKey / debitAccountCode / debitAccountName / creditAccountCode / creditAccountName / taxCode` を入力し `作成` を実行する
@@ -457,8 +457,8 @@
 - チャットルーム設定は admin/mgmt のみ
 - `連携照合サマリ` カードは aggregate summary と `照合詳細取得` による drilldown を表示します
 - 制度会計実績戻しは API `POST /integrations/accounting/statutory-actuals/import` で月次・PJ・部門・勘定科目・通貨・金額の粒度で取り込みます。UI では取り込み済みの結果を `statutoryActuals` と `照合詳細` の差異列として確認します
-- `照合詳細` では給与連携の社員コード差分、会計連携の `PJ別 / 部門別` breakdown、`statutory actual` / `variance`、`pending_mapping / blocked / invalid ready` sample 行を確認します
-- 全件の証跡が必要な場合は `GET /integrations/reconciliation/details?periodKey=YYYY-MM&format=csv` を利用し、PJ別 / 部門別の制度会計実績差異を CSV で保存します
+- `照合詳細` では給与連携の社員コード差分、会計連携の `PJ別 / 部門別` 通貨別 breakdown、`statutory actual` / `variance`、`pending_mapping / blocked / invalid ready` sample 行を確認します
+- 全件の証跡が必要な場合は `GET /integrations/reconciliation/details?periodKey=YYYY-MM&format=csv` を利用し、PJ別 / 部門別 / 通貨別の制度会計実績差異を CSV で保存します
 - `認証方式移行` は `system_admin` 専用です
 - rollback API は未実装のため、UI からの rollback 実行はできません
 

--- a/docs/manual/ui-manual-admin.md
+++ b/docs/manual/ui-manual-admin.md
@@ -433,8 +433,8 @@
 3. 一覧の `実行` / `履歴表示` を実行する
 4. `照合対象月` を入力し `照合サマリ取得` を実行する
 5. 給与連携照合の `comparisonStatus` と社員コード差分を確認する
-6. 会計連携照合の `comparisonStatus` と `ready / pending_mapping / blocked` を確認する
-7. 差分の全件確認が必要な場合は同カードの `照合詳細取得` を実行し、社員コード差分全件と `PJ別 / 部門別` breakdown、`pending_mapping / blocked / invalid ready` の sample 行を確認する
+6. 会計連携照合の `comparisonStatus` と `ready / pending_mapping / blocked` を確認し、制度会計実績戻しがある場合は `statutoryActuals` の `comparisonStatus` / `amount` / `variance` で ERP4 内部 ready debit total との差異を確認する
+7. 差分の全件確認が必要な場合は同カードの `照合詳細取得` を実行し、社員コード差分全件と `PJ別 / 部門別` breakdown、`statutory actual` / `variance`、`pending_mapping / blocked / invalid ready` の sample 行を確認する
 8. `連携ジョブ一覧` で種別 / ステータス / limit / offset を設定し `連携ジョブ取得` を実行する
 9. 成功済みジョブは `再出力` で payload を再送し、`reexportOfId` で lineage を確認する
 10. `会計マッピングルール` で `mappingKey / debitAccountCode / debitAccountName / creditAccountCode / creditAccountName / taxCode` を入力し `作成` を実行する
@@ -456,7 +456,9 @@
 - JSON 入力が不正な場合は保存されません
 - チャットルーム設定は admin/mgmt のみ
 - `連携照合サマリ` カードは aggregate summary と `照合詳細取得` による drilldown を表示します
-- `照合詳細` では給与連携の社員コード差分、会計連携の `PJ別 / 部門別` breakdown、`pending_mapping / blocked / invalid ready` sample 行を確認します
+- 制度会計実績戻しは API `POST /integrations/accounting/statutory-actuals/import` で月次・PJ・部門・勘定科目・通貨・金額の粒度で取り込みます。UI では取り込み済みの結果を `statutoryActuals` と `照合詳細` の差異列として確認します
+- `照合詳細` では給与連携の社員コード差分、会計連携の `PJ別 / 部門別` breakdown、`statutory actual` / `variance`、`pending_mapping / blocked / invalid ready` sample 行を確認します
+- 全件の証跡が必要な場合は `GET /integrations/reconciliation/details?periodKey=YYYY-MM&format=csv` を利用し、PJ別 / 部門別の制度会計実績差異を CSV で保存します
 - `認証方式移行` は `system_admin` 専用です
 - rollback API は未実装のため、UI からの rollback 実行はできません
 

--- a/docs/requirements/management-accounting-report-requirements.md
+++ b/docs/requirements/management-accounting-report-requirements.md
@@ -156,6 +156,9 @@
   - `Project.orgUnitId` が複数の照合候補に一致する場合は `DepartmentMaster.id`、`DepartmentMaster.code`、`DepartmentMaster.externalCode` の順で決定する
   - 未設定の `Project.orgUnitId` は `departmentKey: null` / `departmentSource: unassigned`、正規部門マスタに未照合の旧データは `departmentSource: legacy_org_unit` として旧 `Project.orgUnitId` を `departmentKey` に保持する
   - CSV は `summary` / `currency_breakdown` / `department_breakdown` / `top_red_project` の 4 section で flatten し、部門列として `departmentKey` / `departmentName` / `departmentExternalCode` / `departmentSource`、給与確定値列として `payrollConfirmedLaborCost` / `laborCostVariance` / `payrollConfirmedStatus` を出力する
+  - 制度会計実績戻しは `StatutoryAccountingActual` に月次 `periodKey` / import batch / 会計システム / PJ / 部門 / 勘定科目 / amount type / 通貨 / 金額の粒度で取り込み、`POST /integrations/accounting/statutory-actuals/import` で最大 1,000 行単位の JSON import を受け付ける。`importBatchKey + rowNo` を一意キーとし、同一 batch の再投入は 409 とする
+  - `GET /integrations/reconciliation/summary` は制度会計実績合計と ERP4 内部の ready debit total を照合し、`statutoryActuals.comparisonStatus`（`not_imported` / `ok` / `amount_mismatch`）と `varianceAmount` を返す
+  - `GET /integrations/reconciliation/details?periodKey=YYYY-MM&format=csv` は PJ別 / 部門別 breakdown に `statutoryActualAmountTotal` と `varianceAmount` を含め、管理会計側の ready amount と制度会計実績戻しとの差異を CSV で再現できるようにする
   - UI は `Reports` セクションの管理会計サマリ表示、部門別損益の初期表示、CSV 出力を初期導線とし、案件単位の確認には既存 `project-profit` を併用する
 
 ### R5. 管理部向け締め前照合レポート
@@ -265,13 +268,13 @@
 - 管理会計ダッシュボードに必要な KPI 要件定義
 - `Project.orgUnitId` 暫定キーによる部門別損益の初期表示
 - 給与確定値ベースの人件費（`#1749` で管理会計サマリへの併記と差分検知を実装。給与データ import 自体は連携仕様に従う）
+- 制度会計実績戻し import と管理会計照合（`#1750` で JSON import / staging model / summary・details 照合 / CSV 出力を実装）
 
 ### 初期フェーズで要件化のみ行い、実装を後続に回す
 
 - 勘定科目別集計
 - 間接費の全社配賦
 - 月次締めスナップショット
-- 制度会計実績戻し import と管理会計照合（`#1750`）
 
 ## 後続 issue への接続
 
@@ -291,11 +294,11 @@
 - 現行 summary report のデータソースは `Invoice`（売上）、`VendorInvoice` / `Expense` / `TimeEntry * RateCard`（直接原価）、`ProjectMilestone`（納期未請求）、`TimeEntry`（残業・工数）である。
 - 部門別損益の最小実装単位は、既存 `Project.orgUnitId` を暫定部門キーとして summary API / CSV / Reports UI に `departmentBreakdown` を追加することとする。
 - 給与確定値ベース原価は、`#1749` で月次 `PayrollConfirmedLaborCost` を管理単価ベース `laborCost` と併記し、`laborCostVariance` と `payrollConfirmedStatus` で差分・未締め月を検知する。
-- 制度会計実績戻しは、取り込み方式と粒度（部門・勘定科目・PJ）が未確定のため、`#1750` で import/staging と差分照合を設計する。
+- 制度会計実績戻しは、`#1750` で `StatutoryAccountingActual` を月次・PJ・部門・勘定科目・amount type・通貨・金額の import/staging とし、summary の `statutoryActuals` と details/CSV の `statutoryActualAmountTotal` / `varianceAmount` で差分照合する。
 - 最小実装のテスト方針:
   - backend route test で `departmentBreakdown[]` の集計、赤字案件数、CSV `department_breakdown` section を検証する。
   - frontend test で Reports 画面の部門別損益表示を検証する。
-  - 正規部門マスタ連携、給与確定値原価、制度会計実績戻しは各子 Issue で API / CSV / UI / import validation の回帰テストを追加する。
+  - 正規部門マスタ連携、給与確定値原価、制度会計実績戻しは各子 Issue で API / CSV / UI / import validation の回帰テストを追加する。`#1750` では制度会計実績 import validation、summary の金額差異、details CSV、Admin Settings の表示を検証する。
 
 ## repo ベースで判明している未決事項
 

--- a/docs/requirements/management-accounting-report-requirements.md
+++ b/docs/requirements/management-accounting-report-requirements.md
@@ -157,8 +157,8 @@
   - 未設定の `Project.orgUnitId` は `departmentKey: null` / `departmentSource: unassigned`、正規部門マスタに未照合の旧データは `departmentSource: legacy_org_unit` として旧 `Project.orgUnitId` を `departmentKey` に保持する
   - CSV は `summary` / `currency_breakdown` / `department_breakdown` / `top_red_project` の 4 section で flatten し、部門列として `departmentKey` / `departmentName` / `departmentExternalCode` / `departmentSource`、給与確定値列として `payrollConfirmedLaborCost` / `laborCostVariance` / `payrollConfirmedStatus` を出力する
   - 制度会計実績戻しは `StatutoryAccountingActual` に月次 `periodKey` / import batch / 会計システム / PJ / 部門 / 勘定科目 / amount type / 通貨 / 金額の粒度で取り込み、`POST /integrations/accounting/statutory-actuals/import` で最大 1,000 行単位の JSON import を受け付ける。`importBatchKey + rowNo` を一意キーとし、同一 batch の再投入は 409 とする
-  - `GET /integrations/reconciliation/summary` は制度会計実績合計と ERP4 内部の ready debit total を照合し、`statutoryActuals.comparisonStatus`（`not_imported` / `ok` / `amount_mismatch`）と `varianceAmount` を返す
-  - `GET /integrations/reconciliation/details?periodKey=YYYY-MM&format=csv` は PJ別 / 部門別 breakdown に `statutoryActualAmountTotal` と `varianceAmount` を含め、管理会計側の ready amount と制度会計実績戻しとの差異を CSV で再現できるようにする
+  - `GET /integrations/reconciliation/summary` は制度会計実績合計と ERP4 内部の ready debit total を通貨単位で照合し、`statutoryActuals.comparisonStatus`（`not_imported` / `ok` / `amount_mismatch` / `currency_mixed`）と `currency` / `varianceAmount` を返す。制度会計実績が未取込の `not_imported` は警告情報として扱い、金額不一致または複数通貨混在時のみ blocking とする
+  - `GET /integrations/reconciliation/details?periodKey=YYYY-MM&format=csv` は PJ別 / 部門別 / 通貨別 breakdown に `statutoryActualAmountTotal` と `varianceAmount` を含め、管理会計側の ready amount と制度会計実績戻しとの差異を CSV で再現できるようにする
   - UI は `Reports` セクションの管理会計サマリ表示、部門別損益の初期表示、CSV 出力を初期導線とし、案件単位の確認には既存 `project-profit` を併用する
 
 ### R5. 管理部向け締め前照合レポート
@@ -294,7 +294,7 @@
 - 現行 summary report のデータソースは `Invoice`（売上）、`VendorInvoice` / `Expense` / `TimeEntry * RateCard`（直接原価）、`ProjectMilestone`（納期未請求）、`TimeEntry`（残業・工数）である。
 - 部門別損益の最小実装単位は、既存 `Project.orgUnitId` を暫定部門キーとして summary API / CSV / Reports UI に `departmentBreakdown` を追加することとする。
 - 給与確定値ベース原価は、`#1749` で月次 `PayrollConfirmedLaborCost` を管理単価ベース `laborCost` と併記し、`laborCostVariance` と `payrollConfirmedStatus` で差分・未締め月を検知する。
-- 制度会計実績戻しは、`#1750` で `StatutoryAccountingActual` を月次・PJ・部門・勘定科目・amount type・通貨・金額の import/staging とし、summary の `statutoryActuals` と details/CSV の `statutoryActualAmountTotal` / `varianceAmount` で差分照合する。
+- 制度会計実績戻しは、`#1750` で `StatutoryAccountingActual` を月次・PJ・部門・勘定科目・amount type・通貨・金額の import/staging とし、`StatutoryAccountingActualImportBatch` で import batch 単位の一意性を担保する。summary の `statutoryActuals` と details/CSV の通貨別 `statutoryActualAmountTotal` / `varianceAmount` で差分照合する。
 - 最小実装のテスト方針:
   - backend route test で `departmentBreakdown[]` の集計、赤字案件数、CSV `department_breakdown` section を検証する。
   - frontend test で Reports 画面の部門別損益表示を検証する。

--- a/packages/backend/prisma/migrations/20260508100000_add_statutory_accounting_actual/migration.sql
+++ b/packages/backend/prisma/migrations/20260508100000_add_statutory_accounting_actual/migration.sql
@@ -1,0 +1,28 @@
+CREATE TABLE "StatutoryAccountingActual" (
+    "id" TEXT NOT NULL,
+    "periodKey" TEXT NOT NULL,
+    "importBatchKey" TEXT NOT NULL,
+    "rowNo" INTEGER NOT NULL,
+    "accountingSystem" TEXT NOT NULL,
+    "sourceRef" TEXT,
+    "projectCode" TEXT,
+    "departmentCode" TEXT,
+    "accountCode" TEXT NOT NULL,
+    "accountName" TEXT,
+    "amountType" TEXT NOT NULL,
+    "currency" TEXT NOT NULL,
+    "amount" DECIMAL(65,30) NOT NULL,
+    "importedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdBy" TEXT,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "updatedBy" TEXT,
+
+    CONSTRAINT "StatutoryAccountingActual_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "StatutoryAccountingActual_importBatchKey_rowNo_key" ON "StatutoryAccountingActual"("importBatchKey", "rowNo");
+CREATE INDEX "StatutoryAccountingActual_periodKey_amountType_currency_idx" ON "StatutoryAccountingActual"("periodKey", "amountType", "currency");
+CREATE INDEX "StatutoryAccountingActual_periodKey_projectCode_currency_idx" ON "StatutoryAccountingActual"("periodKey", "projectCode", "currency");
+CREATE INDEX "StatutoryAccountingActual_periodKey_departmentCode_currency_idx" ON "StatutoryAccountingActual"("periodKey", "departmentCode", "currency");
+CREATE INDEX "StatutoryAccountingActual_importBatchKey_importedAt_idx" ON "StatutoryAccountingActual"("importBatchKey", "importedAt");

--- a/packages/backend/prisma/migrations/20260508100000_add_statutory_accounting_actual/migration.sql
+++ b/packages/backend/prisma/migrations/20260508100000_add_statutory_accounting_actual/migration.sql
@@ -1,3 +1,16 @@
+CREATE TABLE "StatutoryAccountingActualImportBatch" (
+    "importBatchKey" TEXT NOT NULL,
+    "periodKey" TEXT NOT NULL,
+    "accountingSystem" TEXT NOT NULL,
+    "importedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "importedCount" INTEGER NOT NULL DEFAULT 0,
+    "createdBy" TEXT,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "updatedBy" TEXT,
+
+    CONSTRAINT "StatutoryAccountingActualImportBatch_pkey" PRIMARY KEY ("importBatchKey")
+);
+
 CREATE TABLE "StatutoryAccountingActual" (
     "id" TEXT NOT NULL,
     "periodKey" TEXT NOT NULL,
@@ -21,8 +34,13 @@ CREATE TABLE "StatutoryAccountingActual" (
     CONSTRAINT "StatutoryAccountingActual_pkey" PRIMARY KEY ("id")
 );
 
+CREATE INDEX "StatutoryAccountingActualImportBatch_periodKey_importedAt_idx" ON "StatutoryAccountingActualImportBatch"("periodKey", "importedAt");
+
 CREATE UNIQUE INDEX "StatutoryAccountingActual_importBatchKey_rowNo_key" ON "StatutoryAccountingActual"("importBatchKey", "rowNo");
 CREATE INDEX "StatutoryAccountingActual_periodKey_amountType_currency_idx" ON "StatutoryAccountingActual"("periodKey", "amountType", "currency");
+CREATE INDEX "StatutoryAccountingActual_periodKey_currency_idx" ON "StatutoryAccountingActual"("periodKey", "currency");
 CREATE INDEX "StatutoryAccountingActual_periodKey_projectCode_currency_idx" ON "StatutoryAccountingActual"("periodKey", "projectCode", "currency");
 CREATE INDEX "StatutoryAccountingActual_periodKey_departmentCode_currency_idx" ON "StatutoryAccountingActual"("periodKey", "departmentCode", "currency");
 CREATE INDEX "StatutoryAccountingActual_importBatchKey_importedAt_idx" ON "StatutoryAccountingActual"("importBatchKey", "importedAt");
+
+ALTER TABLE "StatutoryAccountingActual" ADD CONSTRAINT "StatutoryAccountingActual_importBatchKey_fkey" FOREIGN KEY ("importBatchKey") REFERENCES "StatutoryAccountingActualImportBatch"("importBatchKey") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -1731,8 +1731,23 @@ model AccountingJournalStaging {
   @@index([mappingKey, status])
 }
 
+model StatutoryAccountingActualImportBatch {
+  importBatchKey  String   @id
+  periodKey        String
+  accountingSystem String
+  importedAt       DateTime @default(now())
+  importedCount    Int      @default(0)
+  createdBy        String?
+  updatedAt        DateTime @updatedAt
+  updatedBy        String?
+  actuals          StatutoryAccountingActual[]
+
+  @@index([periodKey, importedAt])
+}
+
 model StatutoryAccountingActual {
   id               String   @id @default(uuid())
+  importBatch      StatutoryAccountingActualImportBatch @relation(fields: [importBatchKey], references: [importBatchKey], onDelete: Cascade)
   periodKey        String
   importBatchKey   String
   rowNo            Int
@@ -1753,6 +1768,7 @@ model StatutoryAccountingActual {
 
   @@unique([importBatchKey, rowNo])
   @@index([periodKey, amountType, currency])
+  @@index([periodKey, currency])
   @@index([periodKey, projectCode, currency])
   @@index([periodKey, departmentCode, currency])
   @@index([importBatchKey, importedAt])

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -1731,6 +1731,33 @@ model AccountingJournalStaging {
   @@index([mappingKey, status])
 }
 
+model StatutoryAccountingActual {
+  id               String   @id @default(uuid())
+  periodKey        String
+  importBatchKey   String
+  rowNo            Int
+  accountingSystem String
+  sourceRef        String?
+  projectCode      String?
+  departmentCode   String?
+  accountCode      String
+  accountName      String?
+  amountType       String
+  currency         String
+  amount           Decimal
+  importedAt       DateTime @default(now())
+  createdAt        DateTime @default(now())
+  createdBy        String?
+  updatedAt        DateTime @updatedAt
+  updatedBy        String?
+
+  @@unique([importBatchKey, rowNo])
+  @@index([periodKey, amountType, currency])
+  @@index([periodKey, projectCode, currency])
+  @@index([periodKey, departmentCode, currency])
+  @@index([importBatchKey, importedAt])
+}
+
 model AccountingMappingRule {
   id                          String   @id @default(uuid())
   mappingKey                  String   @unique

--- a/packages/backend/src/routes/integrations.ts
+++ b/packages/backend/src/routes/integrations.ts
@@ -993,6 +993,12 @@ function statutoryAccountingActualImportStatusCode(code: string) {
   }
 }
 
+function sanitizeSpreadsheetCsvCell(value: unknown) {
+  if (value === null || value === undefined) return '';
+  const text = String(value);
+  return /^[=+\-@]/.test(text) ? `'${text}` : text;
+}
+
 function buildAccountingIcsExportLogResponse(item: {
   id: string;
   idempotencyKey: string;
@@ -1029,6 +1035,7 @@ function buildIntegrationReconciliationDetailsCsv(
   const headers = [
     'section',
     'key',
+    'currency',
     'totalCount',
     'readyCount',
     'pendingMappingCount',
@@ -1041,7 +1048,8 @@ function buildIntegrationReconciliationDetailsCsv(
   const rows = [
     ...details.accounting.byProject.map((row) => [
       'project',
-      row.key,
+      sanitizeSpreadsheetCsvCell(row.key),
+      sanitizeSpreadsheetCsvCell(row.currency),
       row.totalCount,
       row.readyCount,
       row.pendingMappingCount,
@@ -1053,7 +1061,8 @@ function buildIntegrationReconciliationDetailsCsv(
     ]),
     ...details.accounting.byDepartment.map((row) => [
       'department',
-      row.key,
+      sanitizeSpreadsheetCsvCell(row.key),
+      sanitizeSpreadsheetCsvCell(row.currency),
       row.totalCount,
       row.readyCount,
       row.pendingMappingCount,

--- a/packages/backend/src/routes/integrations.ts
+++ b/packages/backend/src/routes/integrations.ts
@@ -23,6 +23,11 @@ import {
   buildIntegrationReconciliationSummary,
 } from '../services/integrationReconciliation.js';
 import {
+  StatutoryAccountingActualImportError,
+  importStatutoryAccountingActuals,
+  type StatutoryAccountingActualImportPayload,
+} from '../services/statutoryAccountingActuals.js';
+import {
   AccountingIcsExportError,
   type AccountingIcsTemplateOptions,
   type AccountingIcsExportPayload,
@@ -62,6 +67,7 @@ import {
   integrationRunMetricsQuerySchema,
   integrationSettingPatchSchema,
   integrationSettingSchema,
+  integrationStatutoryAccountingActualImportSchema,
 } from './validators.js';
 
 type IntegrationSettingBody = {
@@ -976,6 +982,17 @@ function accountingIcsExportStatusCode(code: string) {
   }
 }
 
+function statutoryAccountingActualImportStatusCode(code: string) {
+  switch (code) {
+    case 'invalid_statutory_accounting_actual_import':
+      return 400;
+    case 'statutory_accounting_actual_import_batch_conflict':
+      return 409;
+    default:
+      return 400;
+  }
+}
+
 function buildAccountingIcsExportLogResponse(item: {
   id: string;
   idempotencyKey: string;
@@ -1000,6 +1017,54 @@ function buildAccountingIcsExportLogResponse(item: {
     finishedAt: item.finishedAt,
     message: item.message,
   };
+}
+
+type IntegrationReconciliationDetailsResponse = Awaited<
+  ReturnType<typeof buildIntegrationReconciliationDetails>
+>;
+
+function buildIntegrationReconciliationDetailsCsv(
+  details: IntegrationReconciliationDetailsResponse,
+) {
+  const headers = [
+    'section',
+    'key',
+    'totalCount',
+    'readyCount',
+    'pendingMappingCount',
+    'blockedCount',
+    'invalidReadyCount',
+    'readyAmountTotal',
+    'statutoryActualAmountTotal',
+    'varianceAmount',
+  ];
+  const rows = [
+    ...details.accounting.byProject.map((row) => [
+      'project',
+      row.key,
+      row.totalCount,
+      row.readyCount,
+      row.pendingMappingCount,
+      row.blockedCount,
+      row.invalidReadyCount,
+      row.readyAmountTotal,
+      row.statutoryActualAmountTotal,
+      row.varianceAmount,
+    ]),
+    ...details.accounting.byDepartment.map((row) => [
+      'department',
+      row.key,
+      row.totalCount,
+      row.readyCount,
+      row.pendingMappingCount,
+      row.blockedCount,
+      row.invalidReadyCount,
+      row.readyAmountTotal,
+      row.statutoryActualAmountTotal,
+      row.varianceAmount,
+    ]),
+  ];
+  return toCsv(headers, rows);
 }
 
 function buildAccountingMappingRuleResponse(item: {
@@ -4344,6 +4409,54 @@ export async function registerIntegrationRoutes(app: FastifyInstance) {
     },
   );
 
+  app.post(
+    '/integrations/accounting/statutory-actuals/import',
+    {
+      preHandler: requireRole(['admin', 'mgmt']),
+      schema: integrationStatutoryAccountingActualImportSchema,
+    },
+    async (req, reply) => {
+      try {
+        const result = await importStatutoryAccountingActuals({
+          payload: req.body as StatutoryAccountingActualImportPayload,
+          actorUserId: req.user?.userId ?? null,
+        });
+        await logAudit({
+          ...auditContextFromRequest(req),
+          action: 'integration_statutory_accounting_actual_imported',
+          targetTable: 'StatutoryAccountingActual',
+          targetId: result.importBatchKey,
+          metadata: {
+            periodKey: result.periodKey,
+            importBatchKey: result.importBatchKey,
+            accountingSystem: result.accountingSystem,
+            importedCount: result.importedCount,
+            importedAt: result.importedAt,
+          } as Prisma.InputJsonValue,
+        });
+        return reply.code(201).send(result);
+      } catch (error) {
+        if (error instanceof StatutoryAccountingActualImportError) {
+          return reply
+            .code(statutoryAccountingActualImportStatusCode(error.code))
+            .send({
+              error: error.code,
+              message: error.message,
+              details: error.details,
+            });
+        }
+        if (error instanceof AttendanceClosingError) {
+          return reply.code(attendanceClosingStatusCode(error.code)).send({
+            error: error.code,
+            message: error.message,
+            details: error.details,
+          });
+        }
+        throw error;
+      }
+    },
+  );
+
   app.get(
     '/integrations/reconciliation/summary',
     {
@@ -4400,6 +4513,7 @@ export async function registerIntegrationRoutes(app: FastifyInstance) {
             countsAligned: summary.accounting.countsAligned,
             mappingComplete: summary.accounting.mappingComplete,
             staging: summary.accounting.staging,
+            statutoryActuals: summary.accounting.statutoryActuals,
           },
           hasBlockingDifferences: summary.hasBlockingDifferences,
         };
@@ -4423,11 +4537,22 @@ export async function registerIntegrationRoutes(app: FastifyInstance) {
       schema: integrationReconciliationDetailsQuerySchema,
     },
     async (req, reply) => {
-      const { periodKey } = req.query as {
+      const { periodKey, format } = req.query as {
         periodKey: string;
+        format?: 'json' | 'csv';
       };
       try {
-        return await buildIntegrationReconciliationDetails({ periodKey });
+        const details = await buildIntegrationReconciliationDetails({
+          periodKey,
+        });
+        if (format === 'csv') {
+          return sendCsv(
+            reply,
+            `integration-reconciliation-details-${details.periodKey}.csv`,
+            buildIntegrationReconciliationDetailsCsv(details),
+          );
+        }
+        return details;
       } catch (error) {
         if (error instanceof AttendanceClosingError) {
           return reply.code(attendanceClosingStatusCode(error.code)).send({

--- a/packages/backend/src/routes/validators.ts
+++ b/packages/backend/src/routes/validators.ts
@@ -1945,6 +1945,11 @@ const accountingIcsExportFormatSchema = Type.Union([
   Type.Literal('ics_template'),
 ]);
 
+const integrationReconciliationDetailsFormatSchema = Type.Union([
+  Type.Literal('json'),
+  Type.Literal('csv'),
+]);
+
 const accountingPeriodKeyLooseSchema = Type.String({
   minLength: 1,
   maxLength: 7,
@@ -1977,6 +1982,32 @@ const accountingMappingRuleBodySchema = Type.Object(
     requireDepartmentCode: Type.Optional(Type.Boolean()),
     taxCode: Type.String({ minLength: 1, maxLength: 100 }),
     isActive: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false },
+);
+
+const statutoryAccountingActualAmountTypeSchema = Type.Union([
+  Type.Literal('revenue'),
+  Type.Literal('direct_cost'),
+  Type.Literal('labor_cost'),
+  Type.Literal('vendor_cost'),
+  Type.Literal('expense_cost'),
+]);
+
+const statutoryAccountingActualImportRowSchema = Type.Object(
+  {
+    rowNo: Type.Optional(Type.Integer({ minimum: 1, maximum: 100000 })),
+    sourceRef: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    projectCode: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    departmentCode: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    accountCode: Type.String({ minLength: 1, maxLength: 100 }),
+    accountName: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    amountType: statutoryAccountingActualAmountTypeSchema,
+    currency: Type.String({ pattern: '^[A-Z]{3}$' }),
+    amount: Type.Union([
+      Type.Number({ exclusiveMinimum: 0 }),
+      Type.String({ minLength: 1, maxLength: 100 }),
+    ]),
   },
   { additionalProperties: false },
 );
@@ -2195,6 +2226,26 @@ export const integrationAccountingMappingRuleReapplySchema = {
   ),
 };
 
+export const integrationStatutoryAccountingActualImportSchema = {
+  body: Type.Object(
+    {
+      periodKey: attendanceClosingPeriodKeySchema,
+      importBatchKey: Type.String({ minLength: 1, maxLength: 200 }),
+      accountingSystem: Type.Optional(
+        Type.Union([
+          Type.String({ minLength: 1, maxLength: 100 }),
+          Type.Null(),
+        ]),
+      ),
+      rows: Type.Array(statutoryAccountingActualImportRowSchema, {
+        minItems: 1,
+        maxItems: 1000,
+      }),
+    },
+    { additionalProperties: false },
+  ),
+};
+
 export const integrationExportJobListQuerySchema = {
   querystring: Type.Object(
     {
@@ -2279,6 +2330,7 @@ export const integrationReconciliationDetailsQuerySchema = {
   querystring: Type.Object(
     {
       periodKey: attendanceClosingPeriodKeySchema,
+      format: Type.Optional(integrationReconciliationDetailsFormatSchema),
     },
     { additionalProperties: false },
   ),

--- a/packages/backend/src/services/integrationReconciliation.ts
+++ b/packages/backend/src/services/integrationReconciliation.ts
@@ -49,6 +49,12 @@ type AccountingExportSnapshot = {
   message: string | null;
 };
 
+type AmountByCurrency = {
+  currency: string;
+  amountTotal: string;
+  count: number;
+};
+
 type ReconciliationBaseData = {
   periodKey: string;
   latestClosing: AttendanceClosingSnapshot | null;
@@ -60,6 +66,7 @@ type ReconciliationBaseData = {
   readyAmountTotal: string;
   readyDebitTotal: string;
   readyCreditTotal: string;
+  readyDebitTotalsByCurrency: AmountByCurrency[];
   invalidReadyCount: number;
   latestStatutoryActualImport: {
     importBatchKey: string;
@@ -67,7 +74,7 @@ type ReconciliationBaseData = {
     importedAt: Date;
   } | null;
   statutoryActualImportedCount: number;
-  statutoryActualAmountTotal: string;
+  statutoryActualTotalsByCurrency: AmountByCurrency[];
 };
 
 type ReconciliationSummary = {
@@ -120,23 +127,35 @@ type ReconciliationSummary = {
       latestAccountingSystem: string | null;
       latestImportedAt: Date | null;
       importedCount: number;
+      currency: string | null;
+      currencyCount: number;
       amountTotal: string;
       internalReadyDebitTotal: string;
       varianceAmount: string | null;
-      comparisonStatus: 'not_imported' | 'ok' | 'amount_mismatch';
+      actualTotalsByCurrency: AmountByCurrency[];
+      readyDebitTotalsByCurrency: AmountByCurrency[];
+      comparisonStatus:
+        | 'not_imported'
+        | 'ok'
+        | 'amount_mismatch'
+        | 'currency_mixed';
     };
   };
   hasBlockingDifferences: boolean;
 };
 
-type ReconciliationBreakdownRow = {
+type InternalReconciliationBreakdownRow = {
   key: string;
+  currency: string;
   totalCount: number;
   readyCount: number;
   pendingMappingCount: number;
   blockedCount: number;
   invalidReadyCount: number;
   readyAmountTotal: string;
+};
+
+type ReconciliationBreakdownRow = InternalReconciliationBreakdownRow & {
   statutoryActualAmountTotal: string;
   varianceAmount: string;
 };
@@ -246,16 +265,8 @@ function normalizeBreakdownKey(value: string | null | undefined) {
 }
 
 function withStatutoryActualBreakdownDefaults(
-  row: Omit<
-    ReconciliationBreakdownRow,
-    'statutoryActualAmountTotal' | 'varianceAmount'
-  > &
-    Partial<
-      Pick<
-        ReconciliationBreakdownRow,
-        'statutoryActualAmountTotal' | 'varianceAmount'
-      >
-    >,
+  row: InternalReconciliationBreakdownRow &
+    Partial<Pick<ReconciliationBreakdownRow, 'statutoryActualAmountTotal'>>,
 ): ReconciliationBreakdownRow {
   const statutoryActualAmountTotal = row.statutoryActualAmountTotal ?? '0';
   return {
@@ -265,46 +276,40 @@ function withStatutoryActualBreakdownDefaults(
     pendingMappingCount: Number(row.pendingMappingCount ?? 0),
     blockedCount: Number(row.blockedCount ?? 0),
     invalidReadyCount: Number(row.invalidReadyCount ?? 0),
+    currency: row.currency,
     readyAmountTotal: toStringAmount(row.readyAmountTotal),
     statutoryActualAmountTotal,
-    varianceAmount:
-      row.varianceAmount ??
-      subtractAmounts(
-        statutoryActualAmountTotal,
-        toStringAmount(row.readyAmountTotal),
-      ),
+    varianceAmount: subtractAmounts(
+      statutoryActualAmountTotal,
+      toStringAmount(row.readyAmountTotal),
+    ),
   };
 }
 
 function buildActualBreakdownRows(
-  internalRows: Array<
-    Omit<
-      ReconciliationBreakdownRow,
-      'statutoryActualAmountTotal' | 'varianceAmount'
-    > &
-      Partial<
-        Pick<
-          ReconciliationBreakdownRow,
-          'statutoryActualAmountTotal' | 'varianceAmount'
-        >
-      >
-  >,
+  internalRows: InternalReconciliationBreakdownRow[],
   actualRows: Array<{
     key: string;
+    currency: string;
     amountTotal: string;
   }>,
 ) {
   const rowsByKey = new Map<string, ReconciliationBreakdownRow>();
   for (const row of internalRows) {
-    rowsByKey.set(row.key, withStatutoryActualBreakdownDefaults(row));
+    rowsByKey.set(
+      `${row.key}\0${row.currency}`,
+      withStatutoryActualBreakdownDefaults(row),
+    );
   }
 
   for (const actual of actualRows) {
     const key = normalizeBreakdownKey(actual.key);
+    const mapKey = `${key}\0${actual.currency}`;
     const existing =
-      rowsByKey.get(key) ??
+      rowsByKey.get(mapKey) ??
       withStatutoryActualBreakdownDefaults({
         key,
+        currency: actual.currency,
         totalCount: 0,
         readyCount: 0,
         pendingMappingCount: 0,
@@ -320,11 +325,13 @@ function buildActualBreakdownRows(
       existing.statutoryActualAmountTotal,
       existing.readyAmountTotal,
     );
-    rowsByKey.set(key, existing);
+    rowsByKey.set(mapKey, existing);
   }
 
-  return Array.from(rowsByKey.values()).sort((left, right) =>
-    left.key.localeCompare(right.key),
+  return Array.from(rowsByKey.values()).sort(
+    (left, right) =>
+      left.key.localeCompare(right.key) ||
+      left.currency.localeCompare(right.currency),
   );
 }
 
@@ -410,16 +417,34 @@ function buildIntegrationReconciliationSummaryFromBaseData(
   const debitCreditBalanced =
     base.invalidReadyCount === 0 &&
     areAmountsEqual(base.readyDebitTotal, base.readyCreditTotal);
+  const statutoryActualCurrencyCount =
+    base.statutoryActualTotalsByCurrency.length;
+  const statutoryActualCurrency =
+    statutoryActualCurrencyCount === 1
+      ? base.statutoryActualTotalsByCurrency[0].currency
+      : null;
+  const statutoryActualAmountTotal = statutoryActualCurrency
+    ? base.statutoryActualTotalsByCurrency[0].amountTotal
+    : '0';
+  const statutoryReadyDebitTotal = statutoryActualCurrency
+    ? (base.readyDebitTotalsByCurrency.find(
+        (item) => item.currency === statutoryActualCurrency,
+      )?.amountTotal ?? '0')
+    : '0';
   const statutoryActualComparisonStatus =
     base.statutoryActualImportedCount === 0
       ? 'not_imported'
-      : areAmountsEqual(base.statutoryActualAmountTotal, base.readyDebitTotal)
-        ? 'ok'
-        : 'amount_mismatch';
+      : statutoryActualCurrencyCount !== 1
+        ? 'currency_mixed'
+        : areAmountsEqual(statutoryActualAmountTotal, statutoryReadyDebitTotal)
+          ? 'ok'
+          : 'amount_mismatch';
   const statutoryActualVariance =
     base.statutoryActualImportedCount === 0
       ? null
-      : subtractAmounts(base.statutoryActualAmountTotal, base.readyDebitTotal);
+      : statutoryActualCurrencyCount !== 1
+        ? null
+        : subtractAmounts(statutoryActualAmountTotal, statutoryReadyDebitTotal);
 
   let accountingComparisonStatus: ReconciliationSummary['accounting']['comparisonStatus'];
   let accountingCountsAligned: boolean | null;
@@ -445,7 +470,8 @@ function buildIntegrationReconciliationSummaryFromBaseData(
   const hasBlockingDifferences =
     payrollComparisonStatus !== 'ok' ||
     accountingComparisonStatus !== 'ok' ||
-    statutoryActualComparisonStatus !== 'ok';
+    statutoryActualComparisonStatus === 'amount_mismatch' ||
+    statutoryActualComparisonStatus === 'currency_mixed';
 
   return {
     periodKey: base.periodKey,
@@ -502,9 +528,13 @@ function buildIntegrationReconciliationSummaryFromBaseData(
           base.latestStatutoryActualImport?.accountingSystem ?? null,
         latestImportedAt: base.latestStatutoryActualImport?.importedAt ?? null,
         importedCount: base.statutoryActualImportedCount,
-        amountTotal: base.statutoryActualAmountTotal,
-        internalReadyDebitTotal: base.readyDebitTotal,
+        currency: statutoryActualCurrency,
+        currencyCount: statutoryActualCurrencyCount,
+        amountTotal: statutoryActualAmountTotal,
+        internalReadyDebitTotal: statutoryReadyDebitTotal,
         varianceAmount: statutoryActualVariance,
+        actualTotalsByCurrency: base.statutoryActualTotalsByCurrency,
+        readyDebitTotalsByCurrency: base.readyDebitTotalsByCurrency,
         comparisonStatus: statutoryActualComparisonStatus,
       },
     },
@@ -549,8 +579,9 @@ async function fetchIntegrationReconciliationBaseData(options: {
     latestIcsExport,
     stagingCounts,
     readyTotalsRows,
+    readyDebitCurrencyRows,
     invalidReadyCountRows,
-    statutoryActualTotals,
+    statutoryActualTotalsByCurrency,
     latestStatutoryActualImport,
   ] = await Promise.all([
     latestClosing
@@ -646,6 +677,35 @@ async function fetchIntegrationReconciliationBaseData(options: {
       INNER JOIN "AccountingEvent" ae ON ae."id" = ajs."eventId"
       WHERE ae."periodKey" = ${periodKey}
     `),
+    client.$queryRaw<
+      Array<{
+        currency: string;
+        count: bigint | number;
+        amountTotal: string | Prisma.Decimal | number | null;
+      }>
+    >(Prisma.sql`
+      SELECT
+        ajs."currency" AS "currency",
+        COUNT(*) FILTER (
+          WHERE ajs."status" = 'ready'
+            AND ajs."debitAccountCode" IS NOT NULL
+            AND BTRIM(ajs."debitAccountCode") <> ''
+        )::int AS "count",
+        COALESCE(SUM(
+          CASE
+            WHEN ajs."status" = 'ready'
+              AND ajs."debitAccountCode" IS NOT NULL
+              AND BTRIM(ajs."debitAccountCode") <> ''
+            THEN ajs."amount"
+            ELSE 0
+          END
+        ), 0)::text AS "amountTotal"
+      FROM "AccountingJournalStaging" ajs
+      INNER JOIN "AccountingEvent" ae ON ae."id" = ajs."eventId"
+      WHERE ae."periodKey" = ${periodKey}
+      GROUP BY ajs."currency"
+      ORDER BY ajs."currency" ASC
+    `),
     client.$queryRaw<Array<{ count: bigint | number }>>(Prisma.sql`
       SELECT COUNT(*)::int AS "count"
       FROM "AccountingJournalStaging" ajs
@@ -661,19 +721,21 @@ async function fetchIntegrationReconciliationBaseData(options: {
           OR ajs."amount" <= 0
         )
     `),
-    client.statutoryAccountingActual.aggregate({
+    client.statutoryAccountingActual.groupBy({
+      by: ['currency'],
       where: { periodKey },
       _count: { _all: true },
       _sum: { amount: true },
+      orderBy: { currency: 'asc' },
     }),
-    client.statutoryAccountingActual.findFirst({
+    client.statutoryAccountingActualImportBatch.findFirst({
       where: { periodKey },
       select: {
         importBatchKey: true,
         accountingSystem: true,
         importedAt: true,
       },
-      orderBy: [{ importedAt: 'desc' }, { id: 'desc' }],
+      orderBy: [{ importedAt: 'desc' }, { importBatchKey: 'desc' }],
     }),
   ]);
 
@@ -689,13 +751,23 @@ async function fetchIntegrationReconciliationBaseData(options: {
     readyAmountTotal: toStringAmount(readyTotalsRows[0]?.readyAmountTotal),
     readyDebitTotal: toStringAmount(readyTotalsRows[0]?.readyDebitTotal),
     readyCreditTotal: toStringAmount(readyTotalsRows[0]?.readyCreditTotal),
+    readyDebitTotalsByCurrency: readyDebitCurrencyRows.map((row) => ({
+      currency: row.currency,
+      amountTotal: toStringAmount(row.amountTotal),
+      count: Number(row.count ?? 0),
+    })),
     invalidReadyCount: Number(invalidReadyCountRows[0]?.count ?? 0),
     latestStatutoryActualImport,
-    statutoryActualImportedCount: Number(
-      statutoryActualTotals._count._all ?? 0,
+    statutoryActualImportedCount: statutoryActualTotalsByCurrency.reduce(
+      (sum, row) => sum + Number(row._count._all ?? 0),
+      0,
     ),
-    statutoryActualAmountTotal: toStringAmount(
-      statutoryActualTotals._sum.amount,
+    statutoryActualTotalsByCurrency: statutoryActualTotalsByCurrency.map(
+      (row) => ({
+        currency: row.currency,
+        amountTotal: toStringAmount(row._sum.amount),
+        count: Number(row._count._all ?? 0),
+      }),
     ),
   };
 }
@@ -738,9 +810,10 @@ export async function buildIntegrationReconciliationDetails(options: {
     statutoryActualsByProject,
     statutoryActualsByDepartment,
   ] = await Promise.all([
-    client.$queryRaw<Array<ReconciliationBreakdownRow>>(Prisma.sql`
+    client.$queryRaw<Array<InternalReconciliationBreakdownRow>>(Prisma.sql`
       SELECT
         COALESCE(NULLIF(BTRIM(ae."projectCode"), ''), '(unassigned)') AS "key",
+        ajs."currency" AS "currency",
         COUNT(*)::int AS "totalCount",
         COUNT(*) FILTER (WHERE ajs."status" = 'ready')::int AS "readyCount",
         COUNT(*) FILTER (WHERE ajs."status" = 'pending_mapping')::int AS "pendingMappingCount",
@@ -760,15 +833,16 @@ export async function buildIntegrationReconciliationDetails(options: {
       FROM "AccountingJournalStaging" ajs
       INNER JOIN "AccountingEvent" ae ON ae."id" = ajs."eventId"
       WHERE ae."periodKey" = ${summary.periodKey}
-      GROUP BY 1
-      ORDER BY 1 ASC
+      GROUP BY 1, 2
+      ORDER BY 1 ASC, 2 ASC
     `),
-    client.$queryRaw<Array<ReconciliationBreakdownRow>>(Prisma.sql`
+    client.$queryRaw<Array<InternalReconciliationBreakdownRow>>(Prisma.sql`
       SELECT
         COALESCE(
           NULLIF(BTRIM(COALESCE(ajs."departmentCode", ae."departmentCode")), ''),
           '(unassigned)'
         ) AS "key",
+        ajs."currency" AS "currency",
         COUNT(*)::int AS "totalCount",
         COUNT(*) FILTER (WHERE ajs."status" = 'ready')::int AS "readyCount",
         COUNT(*) FILTER (WHERE ajs."status" = 'pending_mapping')::int AS "pendingMappingCount",
@@ -788,8 +862,8 @@ export async function buildIntegrationReconciliationDetails(options: {
       FROM "AccountingJournalStaging" ajs
       INNER JOIN "AccountingEvent" ae ON ae."id" = ajs."eventId"
       WHERE ae."periodKey" = ${summary.periodKey}
-      GROUP BY 1
-      ORDER BY 1 ASC
+      GROUP BY 1, 2
+      ORDER BY 1 ASC, 2 ASC
     `),
     client.accountingJournalStaging.findMany({
       where: {
@@ -862,18 +936,18 @@ export async function buildIntegrationReconciliationDetails(options: {
       LIMIT ${MAX_RECONCILIATION_DETAIL_SAMPLE}
     `),
     client.statutoryAccountingActual.groupBy({
-      by: ['projectCode'],
+      by: ['projectCode', 'currency'],
       where: { periodKey: summary.periodKey },
       _sum: { amount: true },
       _count: { _all: true },
-      orderBy: { projectCode: 'asc' },
+      orderBy: [{ projectCode: 'asc' }, { currency: 'asc' }],
     }),
     client.statutoryAccountingActual.groupBy({
-      by: ['departmentCode'],
+      by: ['departmentCode', 'currency'],
       where: { periodKey: summary.periodKey },
       _sum: { amount: true },
       _count: { _all: true },
-      orderBy: { departmentCode: 'asc' },
+      orderBy: [{ departmentCode: 'asc' }, { currency: 'asc' }],
     }),
   ]);
 
@@ -923,6 +997,7 @@ export async function buildIntegrationReconciliationDetails(options: {
         byProject,
         statutoryActualsByProject.map((row) => ({
           key: row.projectCode ?? '(unassigned)',
+          currency: row.currency,
           amountTotal: toStringAmount(row._sum.amount),
         })),
       ),
@@ -930,6 +1005,7 @@ export async function buildIntegrationReconciliationDetails(options: {
         byDepartment,
         statutoryActualsByDepartment.map((row) => ({
           key: row.departmentCode ?? '(unassigned)',
+          currency: row.currency,
           amountTotal: toStringAmount(row._sum.amount),
         })),
       ),

--- a/packages/backend/src/services/integrationReconciliation.ts
+++ b/packages/backend/src/services/integrationReconciliation.ts
@@ -61,6 +61,13 @@ type ReconciliationBaseData = {
   readyDebitTotal: string;
   readyCreditTotal: string;
   invalidReadyCount: number;
+  latestStatutoryActualImport: {
+    importBatchKey: string;
+    accountingSystem: string;
+    importedAt: Date;
+  } | null;
+  statutoryActualImportedCount: number;
+  statutoryActualAmountTotal: string;
 };
 
 type ReconciliationSummary = {
@@ -108,6 +115,16 @@ type ReconciliationSummary = {
       readyCreditTotal: string;
       debitCreditBalanced: boolean;
     };
+    statutoryActuals: {
+      latestImportBatchKey: string | null;
+      latestAccountingSystem: string | null;
+      latestImportedAt: Date | null;
+      importedCount: number;
+      amountTotal: string;
+      internalReadyDebitTotal: string;
+      varianceAmount: string | null;
+      comparisonStatus: 'not_imported' | 'ok' | 'amount_mismatch';
+    };
   };
   hasBlockingDifferences: boolean;
 };
@@ -120,6 +137,8 @@ type ReconciliationBreakdownRow = {
   blockedCount: number;
   invalidReadyCount: number;
   readyAmountTotal: string;
+  statutoryActualAmountTotal: string;
+  varianceAmount: string;
 };
 
 type ReconciliationSampleRow = {
@@ -205,6 +224,110 @@ function areAmountsEqual(left: string, right: string) {
   }
 }
 
+function addAmounts(left: string, right: string) {
+  try {
+    return new Prisma.Decimal(left).plus(new Prisma.Decimal(right)).toString();
+  } catch {
+    return String(Number(left || 0) + Number(right || 0));
+  }
+}
+
+function subtractAmounts(left: string, right: string) {
+  try {
+    return new Prisma.Decimal(left).minus(new Prisma.Decimal(right)).toString();
+  } catch {
+    return String(Number(left || 0) - Number(right || 0));
+  }
+}
+
+function normalizeBreakdownKey(value: string | null | undefined) {
+  const normalized = value?.trim();
+  return normalized || '(unassigned)';
+}
+
+function withStatutoryActualBreakdownDefaults(
+  row: Omit<
+    ReconciliationBreakdownRow,
+    'statutoryActualAmountTotal' | 'varianceAmount'
+  > &
+    Partial<
+      Pick<
+        ReconciliationBreakdownRow,
+        'statutoryActualAmountTotal' | 'varianceAmount'
+      >
+    >,
+): ReconciliationBreakdownRow {
+  const statutoryActualAmountTotal = row.statutoryActualAmountTotal ?? '0';
+  return {
+    key: row.key,
+    totalCount: Number(row.totalCount ?? 0),
+    readyCount: Number(row.readyCount ?? 0),
+    pendingMappingCount: Number(row.pendingMappingCount ?? 0),
+    blockedCount: Number(row.blockedCount ?? 0),
+    invalidReadyCount: Number(row.invalidReadyCount ?? 0),
+    readyAmountTotal: toStringAmount(row.readyAmountTotal),
+    statutoryActualAmountTotal,
+    varianceAmount:
+      row.varianceAmount ??
+      subtractAmounts(
+        statutoryActualAmountTotal,
+        toStringAmount(row.readyAmountTotal),
+      ),
+  };
+}
+
+function buildActualBreakdownRows(
+  internalRows: Array<
+    Omit<
+      ReconciliationBreakdownRow,
+      'statutoryActualAmountTotal' | 'varianceAmount'
+    > &
+      Partial<
+        Pick<
+          ReconciliationBreakdownRow,
+          'statutoryActualAmountTotal' | 'varianceAmount'
+        >
+      >
+  >,
+  actualRows: Array<{
+    key: string;
+    amountTotal: string;
+  }>,
+) {
+  const rowsByKey = new Map<string, ReconciliationBreakdownRow>();
+  for (const row of internalRows) {
+    rowsByKey.set(row.key, withStatutoryActualBreakdownDefaults(row));
+  }
+
+  for (const actual of actualRows) {
+    const key = normalizeBreakdownKey(actual.key);
+    const existing =
+      rowsByKey.get(key) ??
+      withStatutoryActualBreakdownDefaults({
+        key,
+        totalCount: 0,
+        readyCount: 0,
+        pendingMappingCount: 0,
+        blockedCount: 0,
+        invalidReadyCount: 0,
+        readyAmountTotal: '0',
+      });
+    existing.statutoryActualAmountTotal = addAmounts(
+      existing.statutoryActualAmountTotal,
+      actual.amountTotal,
+    );
+    existing.varianceAmount = subtractAmounts(
+      existing.statutoryActualAmountTotal,
+      existing.readyAmountTotal,
+    );
+    rowsByKey.set(key, existing);
+  }
+
+  return Array.from(rowsByKey.values()).sort((left, right) =>
+    left.key.localeCompare(right.key),
+  );
+}
+
 function buildReconciliationSampleRow(row: {
   id: string;
   eventId: string;
@@ -287,6 +410,16 @@ function buildIntegrationReconciliationSummaryFromBaseData(
   const debitCreditBalanced =
     base.invalidReadyCount === 0 &&
     areAmountsEqual(base.readyDebitTotal, base.readyCreditTotal);
+  const statutoryActualComparisonStatus =
+    base.statutoryActualImportedCount === 0
+      ? 'not_imported'
+      : areAmountsEqual(base.statutoryActualAmountTotal, base.readyDebitTotal)
+        ? 'ok'
+        : 'amount_mismatch';
+  const statutoryActualVariance =
+    base.statutoryActualImportedCount === 0
+      ? null
+      : subtractAmounts(base.statutoryActualAmountTotal, base.readyDebitTotal);
 
   let accountingComparisonStatus: ReconciliationSummary['accounting']['comparisonStatus'];
   let accountingCountsAligned: boolean | null;
@@ -310,7 +443,9 @@ function buildIntegrationReconciliationSummaryFromBaseData(
   }
 
   const hasBlockingDifferences =
-    payrollComparisonStatus !== 'ok' || accountingComparisonStatus !== 'ok';
+    payrollComparisonStatus !== 'ok' ||
+    accountingComparisonStatus !== 'ok' ||
+    statutoryActualComparisonStatus !== 'ok';
 
   return {
     periodKey: base.periodKey,
@@ -360,6 +495,18 @@ function buildIntegrationReconciliationSummaryFromBaseData(
         readyCreditTotal: base.readyCreditTotal,
         debitCreditBalanced,
       },
+      statutoryActuals: {
+        latestImportBatchKey:
+          base.latestStatutoryActualImport?.importBatchKey ?? null,
+        latestAccountingSystem:
+          base.latestStatutoryActualImport?.accountingSystem ?? null,
+        latestImportedAt: base.latestStatutoryActualImport?.importedAt ?? null,
+        importedCount: base.statutoryActualImportedCount,
+        amountTotal: base.statutoryActualAmountTotal,
+        internalReadyDebitTotal: base.readyDebitTotal,
+        varianceAmount: statutoryActualVariance,
+        comparisonStatus: statutoryActualComparisonStatus,
+      },
     },
     hasBlockingDifferences,
   };
@@ -403,6 +550,8 @@ async function fetchIntegrationReconciliationBaseData(options: {
     stagingCounts,
     readyTotalsRows,
     invalidReadyCountRows,
+    statutoryActualTotals,
+    latestStatutoryActualImport,
   ] = await Promise.all([
     latestClosing
       ? client.attendanceMonthlySummary.findMany({
@@ -512,6 +661,20 @@ async function fetchIntegrationReconciliationBaseData(options: {
           OR ajs."amount" <= 0
         )
     `),
+    client.statutoryAccountingActual.aggregate({
+      where: { periodKey },
+      _count: { _all: true },
+      _sum: { amount: true },
+    }),
+    client.statutoryAccountingActual.findFirst({
+      where: { periodKey },
+      select: {
+        importBatchKey: true,
+        accountingSystem: true,
+        importedAt: true,
+      },
+      orderBy: [{ importedAt: 'desc' }, { id: 'desc' }],
+    }),
   ]);
 
   return {
@@ -527,6 +690,13 @@ async function fetchIntegrationReconciliationBaseData(options: {
     readyDebitTotal: toStringAmount(readyTotalsRows[0]?.readyDebitTotal),
     readyCreditTotal: toStringAmount(readyTotalsRows[0]?.readyCreditTotal),
     invalidReadyCount: Number(invalidReadyCountRows[0]?.count ?? 0),
+    latestStatutoryActualImport,
+    statutoryActualImportedCount: Number(
+      statutoryActualTotals._count._all ?? 0,
+    ),
+    statutoryActualAmountTotal: toStringAmount(
+      statutoryActualTotals._sum.amount,
+    ),
   };
 }
 
@@ -565,6 +735,8 @@ export async function buildIntegrationReconciliationDetails(options: {
     pendingMappingRows,
     blockedRows,
     invalidReadyIds,
+    statutoryActualsByProject,
+    statutoryActualsByDepartment,
   ] = await Promise.all([
     client.$queryRaw<Array<ReconciliationBreakdownRow>>(Prisma.sql`
       SELECT
@@ -689,6 +861,20 @@ export async function buildIntegrationReconciliationDetails(options: {
       ORDER BY ajs."entryDate" ASC, ajs."id" ASC
       LIMIT ${MAX_RECONCILIATION_DETAIL_SAMPLE}
     `),
+    client.statutoryAccountingActual.groupBy({
+      by: ['projectCode'],
+      where: { periodKey: summary.periodKey },
+      _sum: { amount: true },
+      _count: { _all: true },
+      orderBy: { projectCode: 'asc' },
+    }),
+    client.statutoryAccountingActual.groupBy({
+      by: ['departmentCode'],
+      where: { periodKey: summary.periodKey },
+      _sum: { amount: true },
+      _count: { _all: true },
+      orderBy: { departmentCode: 'asc' },
+    }),
   ]);
 
   const invalidReadyRows =
@@ -733,8 +919,20 @@ export async function buildIntegrationReconciliationDetails(options: {
       ),
     },
     accounting: {
-      byProject,
-      byDepartment,
+      byProject: buildActualBreakdownRows(
+        byProject,
+        statutoryActualsByProject.map((row) => ({
+          key: row.projectCode ?? '(unassigned)',
+          amountTotal: toStringAmount(row._sum.amount),
+        })),
+      ),
+      byDepartment: buildActualBreakdownRows(
+        byDepartment,
+        statutoryActualsByDepartment.map((row) => ({
+          key: row.departmentCode ?? '(unassigned)',
+          amountTotal: toStringAmount(row._sum.amount),
+        })),
+      ),
       pendingMappingSamples: pendingMappingRows.map(
         buildReconciliationSampleRow,
       ),

--- a/packages/backend/src/services/statutoryAccountingActuals.ts
+++ b/packages/backend/src/services/statutoryAccountingActuals.ts
@@ -1,0 +1,252 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from './db.js';
+import { parseAttendancePeriodKey } from './attendanceClosings.js';
+
+const STATUTORY_ACCOUNTING_AMOUNT_TYPES = [
+  'revenue',
+  'direct_cost',
+  'labor_cost',
+  'vendor_cost',
+  'expense_cost',
+] as const;
+
+type StatutoryAccountingAmountType =
+  (typeof STATUTORY_ACCOUNTING_AMOUNT_TYPES)[number];
+
+type StatutoryAccountingActualImportRow = {
+  rowNo?: number;
+  sourceRef?: string | null;
+  projectCode?: string | null;
+  departmentCode?: string | null;
+  accountCode?: string | null;
+  accountName?: string | null;
+  amountType?: string | null;
+  currency?: string | null;
+  amount?: string | number | null;
+};
+
+export type StatutoryAccountingActualImportPayload = {
+  periodKey: string;
+  importBatchKey: string;
+  accountingSystem?: string | null;
+  rows: StatutoryAccountingActualImportRow[];
+};
+
+type StatutoryAccountingActualClient = Prisma.TransactionClient | typeof prisma;
+
+export class StatutoryAccountingActualImportError extends Error {
+  constructor(
+    public readonly code:
+      | 'invalid_statutory_accounting_actual_import'
+      | 'statutory_accounting_actual_import_batch_conflict',
+    message: string,
+    public readonly details?: unknown,
+  ) {
+    super(message);
+  }
+}
+
+function normalizeText(value: unknown) {
+  const normalized = typeof value === 'string' ? value.trim() : '';
+  return normalized || null;
+}
+
+function normalizeRequiredText(
+  value: unknown,
+  field: string,
+  rowNo: number,
+  errors: Array<Record<string, unknown>>,
+) {
+  const normalized = normalizeText(value);
+  if (!normalized) {
+    errors.push({ rowNo, field, message: `${field} is required` });
+  }
+  return normalized;
+}
+
+function normalizeAmountType(
+  value: unknown,
+  rowNo: number,
+  errors: Array<Record<string, unknown>>,
+): StatutoryAccountingAmountType | null {
+  const normalized = normalizeText(value);
+  if (
+    !normalized ||
+    !STATUTORY_ACCOUNTING_AMOUNT_TYPES.includes(
+      normalized as StatutoryAccountingAmountType,
+    )
+  ) {
+    errors.push({
+      rowNo,
+      field: 'amountType',
+      message: `amountType must be one of ${STATUTORY_ACCOUNTING_AMOUNT_TYPES.join(', ')}`,
+    });
+    return null;
+  }
+  return normalized as StatutoryAccountingAmountType;
+}
+
+function normalizeCurrency(
+  value: unknown,
+  rowNo: number,
+  errors: Array<Record<string, unknown>>,
+) {
+  const normalized = normalizeRequiredText(value, 'currency', rowNo, errors);
+  if (normalized && !/^[A-Z]{3}$/.test(normalized)) {
+    errors.push({
+      rowNo,
+      field: 'currency',
+      message: 'currency must be an ISO 4217 uppercase code',
+    });
+  }
+  return normalized;
+}
+
+function normalizeAmount(
+  value: unknown,
+  rowNo: number,
+  errors: Array<Record<string, unknown>>,
+) {
+  if (value === null || value === undefined || value === '') {
+    errors.push({ rowNo, field: 'amount', message: 'amount is required' });
+    return null;
+  }
+  try {
+    const amount = new Prisma.Decimal(String(value));
+    if (!amount.isFinite() || amount.lte(0)) {
+      errors.push({
+        rowNo,
+        field: 'amount',
+        message: 'amount must be a positive number',
+      });
+      return null;
+    }
+    return amount;
+  } catch {
+    errors.push({
+      rowNo,
+      field: 'amount',
+      message: 'amount must be a valid number',
+    });
+    return null;
+  }
+}
+
+export async function importStatutoryAccountingActuals(options: {
+  payload: StatutoryAccountingActualImportPayload;
+  actorUserId?: string | null;
+  client?: StatutoryAccountingActualClient;
+}) {
+  const client = options.client ?? prisma;
+  const periodKey = parseAttendancePeriodKey(
+    options.payload.periodKey,
+  ).periodKey;
+  const importBatchKey = normalizeText(options.payload.importBatchKey);
+  const accountingSystem =
+    normalizeText(options.payload.accountingSystem) ?? 'statutory_accounting';
+  const rows = Array.isArray(options.payload.rows) ? options.payload.rows : [];
+  const errors: Array<Record<string, unknown>> = [];
+
+  if (!importBatchKey) {
+    throw new StatutoryAccountingActualImportError(
+      'invalid_statutory_accounting_actual_import',
+      'importBatchKey is required',
+      [{ field: 'importBatchKey', message: 'importBatchKey is required' }],
+    );
+  }
+  if (rows.length === 0 || rows.length > 1000) {
+    throw new StatutoryAccountingActualImportError(
+      'invalid_statutory_accounting_actual_import',
+      'rows must contain 1..1000 items',
+      [{ field: 'rows', message: 'rows must contain 1..1000 items' }],
+    );
+  }
+
+  const usedRowNos = new Set<number>();
+  const importedAt = new Date();
+  const data = rows.map((row, index) => {
+    const rowNo = row.rowNo ?? index + 1;
+    if (!Number.isInteger(rowNo) || rowNo <= 0) {
+      errors.push({
+        rowNo,
+        field: 'rowNo',
+        message: 'rowNo must be a positive integer',
+      });
+    } else if (usedRowNos.has(rowNo)) {
+      errors.push({
+        rowNo,
+        field: 'rowNo',
+        message: 'rowNo must be unique within an import batch',
+      });
+    } else {
+      usedRowNos.add(rowNo);
+    }
+
+    const projectCode = normalizeText(row.projectCode);
+    const departmentCode = normalizeText(row.departmentCode);
+    if (!projectCode && !departmentCode) {
+      errors.push({
+        rowNo,
+        field: 'projectCode',
+        message: 'projectCode or departmentCode is required',
+      });
+    }
+    const accountCode = normalizeRequiredText(
+      row.accountCode,
+      'accountCode',
+      rowNo,
+      errors,
+    );
+    const amountType = normalizeAmountType(row.amountType, rowNo, errors);
+    const currency = normalizeCurrency(row.currency, rowNo, errors);
+    const amount = normalizeAmount(row.amount, rowNo, errors);
+
+    return {
+      periodKey,
+      importBatchKey,
+      rowNo,
+      accountingSystem,
+      sourceRef: normalizeText(row.sourceRef),
+      projectCode,
+      departmentCode,
+      accountCode: accountCode ?? '',
+      accountName: normalizeText(row.accountName),
+      amountType: amountType ?? 'direct_cost',
+      currency: currency ?? '',
+      amount: amount ?? new Prisma.Decimal(0),
+      importedAt,
+      createdBy: options.actorUserId ?? null,
+      updatedBy: options.actorUserId ?? null,
+    };
+  });
+
+  if (errors.length > 0) {
+    throw new StatutoryAccountingActualImportError(
+      'invalid_statutory_accounting_actual_import',
+      'statutory accounting actual import rows are invalid',
+      errors,
+    );
+  }
+
+  const existingBatch = await client.statutoryAccountingActual.findFirst({
+    where: { importBatchKey },
+    select: { id: true },
+  });
+  if (existingBatch) {
+    throw new StatutoryAccountingActualImportError(
+      'statutory_accounting_actual_import_batch_conflict',
+      'importBatchKey already exists',
+      { importBatchKey },
+    );
+  }
+
+  await client.statutoryAccountingActual.createMany({ data });
+
+  return {
+    periodKey,
+    importBatchKey,
+    accountingSystem,
+    importedCount: data.length,
+    importedAt: importedAt.toISOString(),
+  };
+}

--- a/packages/backend/src/services/statutoryAccountingActuals.ts
+++ b/packages/backend/src/services/statutoryAccountingActuals.ts
@@ -228,19 +228,40 @@ export async function importStatutoryAccountingActuals(options: {
     );
   }
 
-  const existingBatch = await client.statutoryAccountingActual.findFirst({
-    where: { importBatchKey },
-    select: { id: true },
-  });
-  if (existingBatch) {
-    throw new StatutoryAccountingActualImportError(
-      'statutory_accounting_actual_import_batch_conflict',
-      'importBatchKey already exists',
-      { importBatchKey },
-    );
-  }
+  const persist = async (tx: StatutoryAccountingActualClient) => {
+    await tx.statutoryAccountingActualImportBatch.create({
+      data: {
+        importBatchKey,
+        periodKey,
+        accountingSystem,
+        importedAt,
+        importedCount: data.length,
+        createdBy: options.actorUserId ?? null,
+        updatedBy: options.actorUserId ?? null,
+      },
+    });
+    await tx.statutoryAccountingActual.createMany({ data });
+  };
 
-  await client.statutoryAccountingActual.createMany({ data });
+  try {
+    if (options.client) {
+      await persist(client);
+    } else {
+      await prisma.$transaction((tx) => persist(tx));
+    }
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    ) {
+      throw new StatutoryAccountingActualImportError(
+        'statutory_accounting_actual_import_batch_conflict',
+        'importBatchKey already exists',
+        { importBatchKey },
+      );
+    }
+    throw error;
+  }
 
   return {
     periodKey,

--- a/packages/backend/test/integrationReconciliationRoutes.test.js
+++ b/packages/backend/test/integrationReconciliationRoutes.test.js
@@ -12,7 +12,8 @@ const { prisma } = await import('../dist/services/db.js');
 function withPrismaStubs(stubs, fn) {
   const restores = [];
   const defaultStubs = {
-    'statutoryAccountingActual.findFirst': async () => null,
+    'statutoryAccountingActualImportBatch.findFirst': async () => null,
+    'statutoryAccountingActualImportBatch.create': async () => ({}),
     'statutoryAccountingActual.aggregate': async () => ({
       _count: { _all: 0 },
       _sum: { amount: null },
@@ -21,6 +22,7 @@ function withPrismaStubs(stubs, fn) {
     'statutoryAccountingActual.createMany': async (args) => ({
       count: Array.isArray(args?.data) ? args.data.length : 0,
     }),
+    $transaction: async (fn) => fn(prisma),
   };
   for (const [path, stub] of Object.entries({ ...defaultStubs, ...stubs })) {
     const [model, method] = path.split('.');
@@ -144,6 +146,9 @@ test('GET /integrations/reconciliation/summary returns aggregate reconciliation 
             },
           ];
         }
+        if (sql.includes('GROUP BY ajs."currency"')) {
+          return [{ currency: 'JPY', count: 3, amountTotal: '12345' }];
+        }
         if (sql.includes('SELECT COUNT(*)::int AS "count"')) {
           return [{ count: 0 }];
         }
@@ -241,6 +246,9 @@ test('GET /integrations/reconciliation/summary treats missing prerequisites as b
             },
           ];
         }
+        if (sql.includes('GROUP BY ajs."currency"')) {
+          return [];
+        }
         if (sql.includes('SELECT COUNT(*)::int AS "count"')) {
           return [{ count: 0 }];
         }
@@ -333,6 +341,9 @@ test('GET /integrations/reconciliation/summary reports missing full export and e
             },
           ];
         }
+        if (sql.includes('GROUP BY ajs."currency"')) {
+          return [{ currency: 'JPY', count: 2, amountTotal: '2500' }];
+        }
         if (sql.includes('SELECT COUNT(*)::int AS "count"')) {
           return [{ count: 1 }];
         }
@@ -403,6 +414,9 @@ test('GET /integrations/reconciliation/summary reports true debit and credit tot
               readyCreditTotal: '2500',
             },
           ];
+        }
+        if (sql.includes('GROUP BY ajs."currency"')) {
+          return [{ currency: 'JPY', count: 1, amountTotal: '3000' }];
         }
         if (sql.includes('SELECT COUNT(*)::int AS "count"')) {
           return [{ count: 0 }];
@@ -493,11 +507,19 @@ test('GET /integrations/reconciliation/summary compares statutory actuals with i
       'accountingJournalStaging.groupBy': async () => [
         { status: 'ready', _count: { _all: 1 } },
       ],
-      'statutoryAccountingActual.aggregate': async () => ({
-        _count: { _all: 2 },
-        _sum: { amount: '5300' },
-      }),
-      'statutoryAccountingActual.findFirst': async () => ({
+      'statutoryAccountingActual.groupBy': async (args) => {
+        if (args?.by?.includes('currency')) {
+          return [
+            {
+              currency: 'JPY',
+              _count: { _all: 2 },
+              _sum: { amount: '5300' },
+            },
+          ];
+        }
+        return [];
+      },
+      'statutoryAccountingActualImportBatch.findFirst': async () => ({
         importBatchKey: 'statutory-actual-2026-06-v1',
         accountingSystem: 'keiri-jokun-alpha',
         importedAt: new Date('2026-07-01T01:00:00.000Z'),
@@ -514,6 +536,9 @@ test('GET /integrations/reconciliation/summary compares statutory actuals with i
               readyCreditTotal: '5000',
             },
           ];
+        }
+        if (sql.includes('GROUP BY ajs."currency"')) {
+          return [{ currency: 'JPY', count: 1, amountTotal: '5000' }];
         }
         if (sql.includes('SELECT COUNT(*)::int AS "count"')) {
           return [{ count: 0 }];
@@ -540,6 +565,7 @@ test('GET /integrations/reconciliation/summary compares statutory actuals with i
           'amount_mismatch',
         );
         assert.equal(body.accounting.statutoryActuals.importedCount, 2);
+        assert.equal(body.accounting.statutoryActuals.currency, 'JPY');
         assert.equal(body.accounting.statutoryActuals.amountTotal, '5300');
         assert.equal(
           body.accounting.statutoryActuals.internalReadyDebitTotal,
@@ -551,6 +577,108 @@ test('GET /integrations/reconciliation/summary compares statutory actuals with i
           'statutory-actual-2026-06-v1',
         );
         assert.equal(body.hasBlockingDifferences, true);
+      } finally {
+        await server.close();
+      }
+    },
+  );
+});
+
+test('GET /integrations/reconciliation/summary treats missing statutory actuals as non-blocking when other checks pass', async () => {
+  await withPrismaStubs(
+    {
+      'attendanceClosingPeriod.findFirst': async () => ({
+        id: 'closing-no-statutory',
+        periodKey: '2026-09',
+        version: 1,
+        status: 'closed',
+        closedAt: new Date('2026-09-30T15:00:00.000Z'),
+        summaryCount: 1,
+        workedDayCountTotal: 20,
+        scheduledWorkMinutesTotal: 9600,
+        approvedWorkMinutesTotal: 9600,
+        overtimeTotalMinutesTotal: 0,
+        paidLeaveMinutesTotal: 0,
+        unpaidLeaveMinutesTotal: 0,
+        totalLeaveMinutesTotal: 0,
+        sourceTimeEntryCount: 20,
+        sourceLeaveRequestCount: 0,
+      }),
+      'attendanceMonthlySummary.findMany': async () => [
+        { employeeCode: 'EMP-090' },
+      ],
+      'hrEmployeeMasterExportLog.findFirst': async () => ({
+        id: 'emp-full-no-statutory',
+        idempotencyKey: 'emp-full-no-statutory-key',
+        reexportOfId: null,
+        status: 'success',
+        updatedSince: null,
+        exportedUntil: new Date('2026-09-30T15:10:00.000Z'),
+        exportedCount: 1,
+        startedAt: new Date('2026-09-30T15:10:00.000Z'),
+        finishedAt: new Date('2026-09-30T15:10:05.000Z'),
+        message: 'exported',
+        payload: {
+          items: [{ employeeCode: 'EMP-090' }],
+        },
+      }),
+      'accountingIcsExportLog.findFirst': async () => ({
+        id: 'ics-no-statutory',
+        idempotencyKey: 'ics-no-statutory-key',
+        reexportOfId: null,
+        periodKey: '2026-09',
+        status: 'success',
+        exportedUntil: new Date('2026-09-30T15:30:00.000Z'),
+        exportedCount: 1,
+        startedAt: new Date('2026-09-30T15:30:00.000Z'),
+        finishedAt: new Date('2026-09-30T15:30:05.000Z'),
+        message: 'exported',
+      }),
+      'accountingJournalStaging.groupBy': async () => [
+        { status: 'ready', _count: { _all: 1 } },
+      ],
+      $queryRaw: async (query) => {
+        const sql = Array.isArray(query?.strings)
+          ? query.strings.join(' ')
+          : String(query);
+        if (sql.includes('"readyDebitTotal"')) {
+          return [
+            {
+              readyAmountTotal: '1000',
+              readyDebitTotal: '1000',
+              readyCreditTotal: '1000',
+            },
+          ];
+        }
+        if (sql.includes('GROUP BY ajs."currency"')) {
+          return [{ currency: 'JPY', count: 1, amountTotal: '1000' }];
+        }
+        if (sql.includes('SELECT COUNT(*)::int AS "count"')) {
+          return [{ count: 0 }];
+        }
+        throw new Error(`unexpected $queryRaw: ${sql}`);
+      },
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'GET',
+          url: '/integrations/reconciliation/summary?periodKey=2026-09',
+          headers: {
+            'x-user-id': 'admin-user',
+            'x-roles': 'admin',
+          },
+        });
+        assert.equal(res.statusCode, 200, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body.payroll.comparisonStatus, 'ok');
+        assert.equal(body.accounting.comparisonStatus, 'ok');
+        assert.equal(
+          body.accounting.statutoryActuals.comparisonStatus,
+          'not_imported',
+        );
+        assert.equal(body.hasBlockingDifferences, false);
       } finally {
         await server.close();
       }
@@ -632,11 +760,13 @@ test('GET /integrations/reconciliation/details returns payroll diffs and account
           return [
             {
               projectCode: 'PRJ-001',
+              currency: 'JPY',
               _count: { _all: 1 },
               _sum: { amount: '2100' },
             },
             {
               projectCode: 'PRJ-003',
+              currency: 'JPY',
               _count: { _all: 1 },
               _sum: { amount: '500' },
             },
@@ -646,11 +776,13 @@ test('GET /integrations/reconciliation/details returns payroll diffs and account
           return [
             {
               departmentCode: 'DEP-A',
+              currency: 'JPY',
               _count: { _all: 1 },
               _sum: { amount: '1800' },
             },
             {
               departmentCode: 'DEP-C',
+              currency: 'JPY',
               _count: { _all: 1 },
               _sum: { amount: '750' },
             },
@@ -675,6 +807,9 @@ test('GET /integrations/reconciliation/details returns payroll diffs and account
             },
           ];
         }
+        if (sql.includes('GROUP BY ajs."currency"')) {
+          return [{ currency: 'JPY', count: 2, amountTotal: '5000' }];
+        }
         if (sql.includes('SELECT ajs."id"')) {
           return [{ id: 'stg-004' }];
         }
@@ -682,6 +817,7 @@ test('GET /integrations/reconciliation/details returns payroll diffs and account
           return [
             {
               key: '(unassigned)',
+              currency: 'JPY',
               totalCount: 1,
               readyCount: 1,
               pendingMappingCount: 0,
@@ -691,6 +827,7 @@ test('GET /integrations/reconciliation/details returns payroll diffs and account
             },
             {
               key: 'PRJ-001',
+              currency: 'JPY',
               totalCount: 2,
               readyCount: 1,
               pendingMappingCount: 1,
@@ -700,6 +837,7 @@ test('GET /integrations/reconciliation/details returns payroll diffs and account
             },
             {
               key: 'PRJ-002',
+              currency: 'JPY',
               totalCount: 1,
               readyCount: 0,
               pendingMappingCount: 0,
@@ -712,6 +850,7 @@ test('GET /integrations/reconciliation/details returns payroll diffs and account
         return [
           {
             key: '(unassigned)',
+            currency: 'JPY',
             totalCount: 1,
             readyCount: 0,
             pendingMappingCount: 0,
@@ -721,6 +860,7 @@ test('GET /integrations/reconciliation/details returns payroll diffs and account
           },
           {
             key: 'DEP-A',
+            currency: 'JPY',
             totalCount: 2,
             readyCount: 1,
             pendingMappingCount: 1,
@@ -730,6 +870,7 @@ test('GET /integrations/reconciliation/details returns payroll diffs and account
           },
           {
             key: 'DEP-B',
+            currency: 'JPY',
             totalCount: 1,
             readyCount: 1,
             pendingMappingCount: 0,
@@ -969,7 +1110,8 @@ test('GET /integrations/reconciliation/details exports statutory actual reconcil
         if (args?.by?.includes('projectCode')) {
           return [
             {
-              projectCode: 'PRJ-CSV',
+              projectCode: '=PRJ-CSV',
+              currency: 'JPY',
               _count: { _all: 1 },
               _sum: { amount: '123' },
             },
@@ -979,6 +1121,7 @@ test('GET /integrations/reconciliation/details exports statutory actual reconcil
           return [
             {
               departmentCode: 'DEP-CSV',
+              currency: 'JPY',
               _count: { _all: 1 },
               _sum: { amount: '456' },
             },
@@ -998,6 +1141,9 @@ test('GET /integrations/reconciliation/details exports statutory actual reconcil
               readyCreditTotal: '0',
             },
           ];
+        }
+        if (sql.includes('GROUP BY ajs."currency"')) {
+          return [];
         }
         if (
           sql.includes('SELECT COUNT(*)::int AS "count"') ||
@@ -1031,10 +1177,10 @@ test('GET /integrations/reconciliation/details exports statutory actual reconcil
         );
         assert.match(
           res.body,
-          /section,key,totalCount,readyCount,pendingMappingCount,blockedCount,invalidReadyCount,readyAmountTotal,statutoryActualAmountTotal,varianceAmount/,
+          /section,key,currency,totalCount,readyCount,pendingMappingCount,blockedCount,invalidReadyCount,readyAmountTotal,statutoryActualAmountTotal,varianceAmount/,
         );
-        assert.match(res.body, /project,PRJ-CSV,0,0,0,0,0,0,123,123/);
-        assert.match(res.body, /department,DEP-CSV,0,0,0,0,0,0,456,456/);
+        assert.match(res.body, /project,'=PRJ-CSV,JPY,0,0,0,0,0,0,123,123/);
+        assert.match(res.body, /department,DEP-CSV,JPY,0,0,0,0,0,0,456,456/);
       } finally {
         await server.close();
       }
@@ -1045,12 +1191,14 @@ test('GET /integrations/reconciliation/details exports statutory actual reconcil
 test('POST /integrations/accounting/statutory-actuals/import validates and persists rows', async () => {
   await withPrismaStubs(
     {
-      'statutoryAccountingActual.findFirst': async (args) => {
-        assert.equal(
-          args?.where?.importBatchKey,
-          'statutory-actual-2026-06-v1',
-        );
-        return null;
+      'statutoryAccountingActualImportBatch.create': async (args) => {
+        assert.equal(args?.data?.importBatchKey, 'statutory-actual-2026-06-v1');
+        assert.equal(args.data.periodKey, '2026-06');
+        assert.equal(args.data.accountingSystem, 'keiri-jokun-alpha');
+        assert.equal(args.data.importedCount, 2);
+        assert.equal(args.data.createdBy, 'admin-user');
+        assert.equal(args.data.updatedBy, 'admin-user');
+        return {};
       },
       'statutoryAccountingActual.createMany': async (args) => {
         assert.equal(args?.data?.length, 2);

--- a/packages/backend/test/integrationReconciliationRoutes.test.js
+++ b/packages/backend/test/integrationReconciliationRoutes.test.js
@@ -11,7 +11,18 @@ const { prisma } = await import('../dist/services/db.js');
 
 function withPrismaStubs(stubs, fn) {
   const restores = [];
-  for (const [path, stub] of Object.entries(stubs)) {
+  const defaultStubs = {
+    'statutoryAccountingActual.findFirst': async () => null,
+    'statutoryAccountingActual.aggregate': async () => ({
+      _count: { _all: 0 },
+      _sum: { amount: null },
+    }),
+    'statutoryAccountingActual.groupBy': async () => [],
+    'statutoryAccountingActual.createMany': async (args) => ({
+      count: Array.isArray(args?.data) ? args.data.length : 0,
+    }),
+  };
+  for (const [path, stub] of Object.entries({ ...defaultStubs, ...stubs })) {
     const [model, method] = path.split('.');
     const target = method ? prisma[model] : prisma;
     const key = method ?? model;
@@ -429,6 +440,124 @@ test('GET /integrations/reconciliation/summary reports true debit and credit tot
   );
 });
 
+test('GET /integrations/reconciliation/summary compares statutory actuals with internal ready debit total', async () => {
+  await withPrismaStubs(
+    {
+      'attendanceClosingPeriod.findFirst': async () => ({
+        id: 'closing-statutory-001',
+        periodKey: '2026-06',
+        version: 1,
+        status: 'closed',
+        closedAt: new Date('2026-06-30T15:00:00.000Z'),
+        summaryCount: 1,
+        workedDayCountTotal: 20,
+        scheduledWorkMinutesTotal: 9600,
+        approvedWorkMinutesTotal: 9600,
+        overtimeTotalMinutesTotal: 0,
+        paidLeaveMinutesTotal: 0,
+        unpaidLeaveMinutesTotal: 0,
+        totalLeaveMinutesTotal: 0,
+        sourceTimeEntryCount: 20,
+        sourceLeaveRequestCount: 0,
+      }),
+      'attendanceMonthlySummary.findMany': async () => [
+        { employeeCode: 'EMP-020' },
+      ],
+      'hrEmployeeMasterExportLog.findFirst': async () => ({
+        id: 'emp-full-statutory-001',
+        idempotencyKey: 'emp-full-statutory-key',
+        reexportOfId: null,
+        status: 'success',
+        updatedSince: null,
+        exportedUntil: new Date('2026-06-30T15:10:00.000Z'),
+        exportedCount: 1,
+        startedAt: new Date('2026-06-30T15:10:00.000Z'),
+        finishedAt: new Date('2026-06-30T15:10:05.000Z'),
+        message: 'exported',
+        payload: {
+          items: [{ employeeCode: 'EMP-020' }],
+        },
+      }),
+      'accountingIcsExportLog.findFirst': async () => ({
+        id: 'ics-statutory-001',
+        idempotencyKey: 'ics-statutory-key',
+        reexportOfId: null,
+        periodKey: '2026-06',
+        status: 'success',
+        exportedUntil: new Date('2026-06-30T15:30:00.000Z'),
+        exportedCount: 1,
+        startedAt: new Date('2026-06-30T15:30:00.000Z'),
+        finishedAt: new Date('2026-06-30T15:30:05.000Z'),
+        message: 'exported',
+      }),
+      'accountingJournalStaging.groupBy': async () => [
+        { status: 'ready', _count: { _all: 1 } },
+      ],
+      'statutoryAccountingActual.aggregate': async () => ({
+        _count: { _all: 2 },
+        _sum: { amount: '5300' },
+      }),
+      'statutoryAccountingActual.findFirst': async () => ({
+        importBatchKey: 'statutory-actual-2026-06-v1',
+        accountingSystem: 'keiri-jokun-alpha',
+        importedAt: new Date('2026-07-01T01:00:00.000Z'),
+      }),
+      $queryRaw: async (query) => {
+        const sql = Array.isArray(query?.strings)
+          ? query.strings.join(' ')
+          : String(query);
+        if (sql.includes('"readyDebitTotal"')) {
+          return [
+            {
+              readyAmountTotal: '10000',
+              readyDebitTotal: '5000',
+              readyCreditTotal: '5000',
+            },
+          ];
+        }
+        if (sql.includes('SELECT COUNT(*)::int AS "count"')) {
+          return [{ count: 0 }];
+        }
+        throw new Error(`unexpected $queryRaw: ${sql}`);
+      },
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'GET',
+          url: '/integrations/reconciliation/summary?periodKey=2026-06',
+          headers: {
+            'x-user-id': 'admin-user',
+            'x-roles': 'admin',
+          },
+        });
+        assert.equal(res.statusCode, 200, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body.accounting.comparisonStatus, 'ok');
+        assert.equal(
+          body.accounting.statutoryActuals.comparisonStatus,
+          'amount_mismatch',
+        );
+        assert.equal(body.accounting.statutoryActuals.importedCount, 2);
+        assert.equal(body.accounting.statutoryActuals.amountTotal, '5300');
+        assert.equal(
+          body.accounting.statutoryActuals.internalReadyDebitTotal,
+          '5000',
+        );
+        assert.equal(body.accounting.statutoryActuals.varianceAmount, '300');
+        assert.equal(
+          body.accounting.statutoryActuals.latestImportBatchKey,
+          'statutory-actual-2026-06-v1',
+        );
+        assert.equal(body.hasBlockingDifferences, true);
+      } finally {
+        await server.close();
+      }
+    },
+  );
+});
+
 test('GET /integrations/reconciliation/details returns payroll diffs and accounting breakdowns', async () => {
   await withPrismaStubs(
     {
@@ -498,6 +627,37 @@ test('GET /integrations/reconciliation/details returns payroll diffs and account
         { status: 'pending_mapping', _count: { _all: 1 } },
         { status: 'blocked', _count: { _all: 1 } },
       ],
+      'statutoryAccountingActual.groupBy': async (args) => {
+        if (args?.by?.includes('projectCode')) {
+          return [
+            {
+              projectCode: 'PRJ-001',
+              _count: { _all: 1 },
+              _sum: { amount: '2100' },
+            },
+            {
+              projectCode: 'PRJ-003',
+              _count: { _all: 1 },
+              _sum: { amount: '500' },
+            },
+          ];
+        }
+        if (args?.by?.includes('departmentCode')) {
+          return [
+            {
+              departmentCode: 'DEP-A',
+              _count: { _all: 1 },
+              _sum: { amount: '1800' },
+            },
+            {
+              departmentCode: 'DEP-C',
+              _count: { _all: 1 },
+              _sum: { amount: '750' },
+            },
+          ];
+        }
+        return [];
+      },
       'accountingJournalStaging.aggregate': async () => ({
         _sum: { amount: '5000' },
       }),
@@ -691,15 +851,35 @@ test('GET /integrations/reconciliation/details returns payroll diffs and account
         ]);
         assert.deepEqual(
           body.accounting.byProject.map((item) => item.key),
-          ['(unassigned)', 'PRJ-001', 'PRJ-002'],
+          ['(unassigned)', 'PRJ-001', 'PRJ-002', 'PRJ-003'],
         );
         assert.equal(body.accounting.byProject[1].pendingMappingCount, 1);
         assert.equal(body.accounting.byProject[2].blockedCount, 1);
         assert.equal(body.accounting.byProject[0].invalidReadyCount, 1);
+        assert.equal(
+          body.accounting.byProject[1].statutoryActualAmountTotal,
+          '2100',
+        );
+        assert.equal(body.accounting.byProject[1].varianceAmount, '100');
+        assert.equal(
+          body.accounting.byProject[3].statutoryActualAmountTotal,
+          '500',
+        );
+        assert.equal(body.accounting.byProject[3].varianceAmount, '500');
         assert.deepEqual(
           body.accounting.byDepartment.map((item) => item.key),
-          ['(unassigned)', 'DEP-A', 'DEP-B'],
+          ['(unassigned)', 'DEP-A', 'DEP-B', 'DEP-C'],
         );
+        assert.equal(
+          body.accounting.byDepartment[1].statutoryActualAmountTotal,
+          '1800',
+        );
+        assert.equal(body.accounting.byDepartment[1].varianceAmount, '-200');
+        assert.equal(
+          body.accounting.byDepartment[3].statutoryActualAmountTotal,
+          '750',
+        );
+        assert.equal(body.accounting.byDepartment[3].varianceAmount, '750');
         assert.equal(body.accounting.pendingMappingSamples[0].id, 'stg-002');
         assert.equal(body.accounting.blockedSamples[0].id, 'stg-003');
         assert.equal(body.accounting.invalidReadySamples[0].id, 'stg-004');
@@ -774,4 +954,231 @@ test('GET /integrations/reconciliation/details returns empty details when prereq
       }
     },
   );
+});
+
+test('GET /integrations/reconciliation/details exports statutory actual reconciliation as CSV', async () => {
+  await withPrismaStubs(
+    {
+      'attendanceClosingPeriod.findFirst': async () => null,
+      'hrEmployeeMasterExportLog.findFirst': async () => null,
+      'accountingIcsExportLog.findFirst': async () => null,
+      'attendanceMonthlySummary.findMany': async () => [],
+      'accountingJournalStaging.groupBy': async () => [],
+      'accountingJournalStaging.findMany': async () => [],
+      'statutoryAccountingActual.groupBy': async (args) => {
+        if (args?.by?.includes('projectCode')) {
+          return [
+            {
+              projectCode: 'PRJ-CSV',
+              _count: { _all: 1 },
+              _sum: { amount: '123' },
+            },
+          ];
+        }
+        if (args?.by?.includes('departmentCode')) {
+          return [
+            {
+              departmentCode: 'DEP-CSV',
+              _count: { _all: 1 },
+              _sum: { amount: '456' },
+            },
+          ];
+        }
+        return [];
+      },
+      $queryRaw: async (query) => {
+        const sql = Array.isArray(query?.strings)
+          ? query.strings.join(' ')
+          : String(query);
+        if (sql.includes('"readyDebitTotal"')) {
+          return [
+            {
+              readyAmountTotal: '0',
+              readyDebitTotal: '0',
+              readyCreditTotal: '0',
+            },
+          ];
+        }
+        if (
+          sql.includes('SELECT COUNT(*)::int AS "count"') ||
+          sql.includes('SELECT ajs."id"') ||
+          sql.includes('GROUP BY 1')
+        ) {
+          return [];
+        }
+        throw new Error(`unexpected $queryRaw: ${sql}`);
+      },
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'GET',
+          url: '/integrations/reconciliation/details?periodKey=2026-08&format=csv',
+          headers: {
+            'x-user-id': 'admin-user',
+            'x-roles': 'admin',
+          },
+        });
+        assert.equal(res.statusCode, 200, res.body);
+        assert.match(
+          String(res.headers['content-type']),
+          /text\/csv; charset=utf-8/,
+        );
+        assert.match(
+          String(res.headers['content-disposition']),
+          /integration-reconciliation-details-2026-08\.csv/,
+        );
+        assert.match(
+          res.body,
+          /section,key,totalCount,readyCount,pendingMappingCount,blockedCount,invalidReadyCount,readyAmountTotal,statutoryActualAmountTotal,varianceAmount/,
+        );
+        assert.match(res.body, /project,PRJ-CSV,0,0,0,0,0,0,123,123/);
+        assert.match(res.body, /department,DEP-CSV,0,0,0,0,0,0,456,456/);
+      } finally {
+        await server.close();
+      }
+    },
+  );
+});
+
+test('POST /integrations/accounting/statutory-actuals/import validates and persists rows', async () => {
+  await withPrismaStubs(
+    {
+      'statutoryAccountingActual.findFirst': async (args) => {
+        assert.equal(
+          args?.where?.importBatchKey,
+          'statutory-actual-2026-06-v1',
+        );
+        return null;
+      },
+      'statutoryAccountingActual.createMany': async (args) => {
+        assert.equal(args?.data?.length, 2);
+        assert.equal(args.data[0].periodKey, '2026-06');
+        assert.equal(
+          args.data[0].importBatchKey,
+          'statutory-actual-2026-06-v1',
+        );
+        assert.equal(args.data[0].rowNo, 1);
+        assert.equal(args.data[0].accountingSystem, 'keiri-jokun-alpha');
+        assert.equal(args.data[0].projectCode, 'PRJ-001');
+        assert.equal(args.data[0].departmentCode, 'DEP-A');
+        assert.equal(args.data[0].accountCode, '6100');
+        assert.equal(args.data[0].amountType, 'direct_cost');
+        assert.equal(args.data[0].currency, 'JPY');
+        assert.equal(String(args.data[0].amount), '1200');
+        assert.equal(args.data[0].createdBy, 'admin-user');
+        assert.equal(args.data[0].updatedBy, 'admin-user');
+        assert.equal(args.data[1].rowNo, 2);
+        assert.equal(args.data[1].amountType, 'labor_cost');
+        return { count: 2 };
+      },
+      'auditLog.create': async () => ({}),
+    },
+    async () => {
+      const server = await buildServer({ logger: false });
+      try {
+        const res = await server.inject({
+          method: 'POST',
+          url: '/integrations/accounting/statutory-actuals/import',
+          headers: {
+            'x-user-id': 'admin-user',
+            'x-roles': 'admin',
+          },
+          payload: {
+            periodKey: '2026-06',
+            importBatchKey: 'statutory-actual-2026-06-v1',
+            accountingSystem: 'keiri-jokun-alpha',
+            rows: [
+              {
+                rowNo: 1,
+                sourceRef: 'GL-001',
+                projectCode: ' PRJ-001 ',
+                departmentCode: 'DEP-A',
+                accountCode: '6100',
+                accountName: '外注費',
+                amountType: 'direct_cost',
+                currency: 'JPY',
+                amount: '1200',
+              },
+              {
+                rowNo: 2,
+                departmentCode: 'DEP-A',
+                accountCode: '6200',
+                accountName: '労務費',
+                amountType: 'labor_cost',
+                currency: 'JPY',
+                amount: 800,
+              },
+            ],
+          },
+        });
+        assert.equal(res.statusCode, 201, res.body);
+        const body = JSON.parse(res.body);
+        assert.equal(body.periodKey, '2026-06');
+        assert.equal(body.importBatchKey, 'statutory-actual-2026-06-v1');
+        assert.equal(body.accountingSystem, 'keiri-jokun-alpha');
+        assert.equal(body.importedCount, 2);
+        assert.match(body.importedAt, /^\d{4}-\d{2}-\d{2}T/);
+      } finally {
+        await server.close();
+      }
+    },
+  );
+});
+
+test('POST /integrations/accounting/statutory-actuals/import returns 400 for invalid rows', async () => {
+  await withPrismaStubs({}, async () => {
+    const server = await buildServer({ logger: false });
+    try {
+      const res = await server.inject({
+        method: 'POST',
+        url: '/integrations/accounting/statutory-actuals/import',
+        headers: {
+          'x-user-id': 'admin-user',
+          'x-roles': 'admin',
+        },
+        payload: {
+          periodKey: '2026-06',
+          importBatchKey: 'statutory-actual-2026-06-invalid',
+          rows: [
+            {
+              rowNo: 1,
+              accountCode: '6100',
+              amountType: 'direct_cost',
+              currency: 'JPY',
+              amount: '1200',
+            },
+            {
+              rowNo: 1,
+              departmentCode: 'DEP-A',
+              accountCode: '6200',
+              amountType: 'labor_cost',
+              currency: 'JPY',
+              amount: '800',
+            },
+          ],
+        },
+      });
+      assert.equal(res.statusCode, 400, res.body);
+      const body = JSON.parse(res.body);
+      assert.equal(body.error, 'invalid_statutory_accounting_actual_import');
+      assert.ok(
+        body.details.some(
+          (item) =>
+            item.field === 'projectCode' &&
+            /projectCode or departmentCode/.test(item.message),
+        ),
+      );
+      assert.ok(
+        body.details.some(
+          (item) =>
+            item.field === 'rowNo' &&
+            /unique within an import batch/.test(item.message),
+        ),
+      );
+    } finally {
+      await server.close();
+    }
+  });
 });

--- a/packages/frontend/src/sections/admin-settings/IntegrationReconciliationCard.test.tsx
+++ b/packages/frontend/src/sections/admin-settings/IntegrationReconciliationCard.test.tsx
@@ -83,9 +83,17 @@ function createSummary(
         latestAccountingSystem: 'keiri-jokun-alpha',
         latestImportedAt: '2026-04-01T00:00:00.000Z',
         importedCount: 3,
+        currency: 'JPY',
+        currencyCount: 1,
         amountTotal: '650',
         internalReadyDebitTotal: '600',
         varianceAmount: '50',
+        actualTotalsByCurrency: [
+          { currency: 'JPY', amountTotal: '650', count: 3 },
+        ],
+        readyDebitTotalsByCurrency: [
+          { currency: 'JPY', amountTotal: '600', count: 2 },
+        ],
         comparisonStatus: 'amount_mismatch',
       },
     },
@@ -109,6 +117,7 @@ function createDetails(
       byProject: [
         {
           key: 'PRJ-001',
+          currency: 'JPY',
           totalCount: 3,
           readyCount: 1,
           pendingMappingCount: 1,
@@ -122,6 +131,7 @@ function createDetails(
       byDepartment: [
         {
           key: 'DEP-A',
+          currency: 'JPY',
           totalCount: 2,
           readyCount: 1,
           pendingMappingCount: 1,
@@ -293,7 +303,7 @@ describe('IntegrationReconciliationCard', () => {
     ).toBeInTheDocument();
     expect(
       getByTextContent(
-        'statutoryActuals: status=amount_mismatch / imported=3 / amount=650 / variance=50',
+        'statutoryActuals: status=amount_mismatch / imported=3 / currency=JPY / amount=650 / variance=50',
       ),
     ).toBeInTheDocument();
     expect(
@@ -365,7 +375,7 @@ describe('IntegrationReconciliationCard', () => {
     ).toBeInTheDocument();
     expect(
       getByTextContent(
-        'statutoryActuals: status=not_imported / imported=0 / amount=0 / variance=-',
+        'statutoryActuals: status=not_imported / imported=0 / currency=- / amount=0 / variance=-',
       ),
     ).toBeInTheDocument();
     expect(screen.getByText('latestStatutoryImport: -')).toBeInTheDocument();

--- a/packages/frontend/src/sections/admin-settings/IntegrationReconciliationCard.test.tsx
+++ b/packages/frontend/src/sections/admin-settings/IntegrationReconciliationCard.test.tsx
@@ -78,6 +78,16 @@ function createSummary(
         readyCreditTotal: '600',
         debitCreditBalanced: true,
       },
+      statutoryActuals: {
+        latestImportBatchKey: 'statutory-actual-2026-03-v1',
+        latestAccountingSystem: 'keiri-jokun-alpha',
+        latestImportedAt: '2026-04-01T00:00:00.000Z',
+        importedCount: 3,
+        amountTotal: '650',
+        internalReadyDebitTotal: '600',
+        varianceAmount: '50',
+        comparisonStatus: 'amount_mismatch',
+      },
     },
     hasBlockingDifferences: true,
     ...overrides,
@@ -105,6 +115,8 @@ function createDetails(
           blockedCount: 1,
           invalidReadyCount: 0,
           readyAmountTotal: '2000',
+          statutoryActualAmountTotal: '2100',
+          varianceAmount: '100',
         },
       ],
       byDepartment: [
@@ -116,6 +128,8 @@ function createDetails(
           blockedCount: 0,
           invalidReadyCount: 0,
           readyAmountTotal: '2000',
+          statutoryActualAmountTotal: '1800',
+          varianceAmount: '-200',
         },
       ],
       pendingMappingSamples: [
@@ -277,8 +291,19 @@ describe('IntegrationReconciliationCard', () => {
     expect(
       screen.getByText('debit=600 / credit=600 / balanced=yes'),
     ).toBeInTheDocument();
+    expect(
+      getByTextContent(
+        'statutoryActuals: status=amount_mismatch / imported=3 / amount=650 / variance=50',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'latestStatutoryImport: statutory-actual-2026-03-v1 / keiri-jokun-alpha / importedAt=fmt:2026-04-01T00:00:00.000Z',
+      ),
+    ).toBeInTheDocument();
 
     expect(formatDateTime).toHaveBeenCalledWith('2026-03-26T00:00:00.000Z');
+    expect(formatDateTime).toHaveBeenCalledWith('2026-04-01T00:00:00.000Z');
   });
 
   it('renders ok badge and fallbacks when optional values are absent', () => {
@@ -338,6 +363,12 @@ describe('IntegrationReconciliationCard', () => {
     expect(
       screen.getByText('debit=0 / credit=0 / balanced=no'),
     ).toBeInTheDocument();
+    expect(
+      getByTextContent(
+        'statutoryActuals: status=not_imported / imported=0 / amount=0 / variance=-',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('latestStatutoryImport: -')).toBeInTheDocument();
 
     expect(formatDateTime).toHaveBeenCalledWith(null);
   });
@@ -365,8 +396,12 @@ describe('IntegrationReconciliationCard', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('PJ別 breakdown')).toBeInTheDocument();
     expect(screen.getByText('部門別 breakdown')).toBeInTheDocument();
+    expect(screen.getAllByText('statutory actual')).toHaveLength(2);
+    expect(screen.getAllByText('variance')).toHaveLength(2);
     expect(screen.getByText('PRJ-001')).toBeInTheDocument();
     expect(screen.getByText('DEP-A')).toBeInTheDocument();
+    expect(screen.getByText('2100')).toBeInTheDocument();
+    expect(screen.getByText('-200')).toBeInTheDocument();
     expect(screen.getByText('pending_mapping サンプル')).toBeInTheDocument();
     expect(screen.getByText('blocked サンプル')).toBeInTheDocument();
     expect(screen.getByText('invalid ready サンプル')).toBeInTheDocument();

--- a/packages/frontend/src/sections/admin-settings/IntegrationReconciliationCard.tsx
+++ b/packages/frontend/src/sections/admin-settings/IntegrationReconciliationCard.tsx
@@ -55,6 +55,16 @@ export type IntegrationReconciliationSummary = {
       readyCreditTotal: string;
       debitCreditBalanced: boolean;
     };
+    statutoryActuals?: {
+      latestImportBatchKey?: string | null;
+      latestAccountingSystem?: string | null;
+      latestImportedAt?: string | null;
+      importedCount: number;
+      amountTotal: string;
+      internalReadyDebitTotal: string;
+      varianceAmount?: string | null;
+      comparisonStatus: string;
+    } | null;
   };
   hasBlockingDifferences: boolean;
 };
@@ -67,6 +77,8 @@ export type IntegrationReconciliationBreakdownRow = {
   blockedCount: number;
   invalidReadyCount: number;
   readyAmountTotal: string;
+  statutoryActualAmountTotal?: string;
+  varianceAmount?: string;
 };
 
 export type IntegrationReconciliationSampleRow = {
@@ -175,6 +187,8 @@ function renderBreakdownTable(
                 <th style={numericCellStyle}>blocked</th>
                 <th style={numericCellStyle}>invalid ready</th>
                 <th style={numericCellStyle}>ready amount</th>
+                <th style={numericCellStyle}>statutory actual</th>
+                <th style={numericCellStyle}>variance</th>
               </tr>
             </thead>
             <tbody>
@@ -187,6 +201,10 @@ function renderBreakdownTable(
                   <td style={numericCellStyle}>{row.blockedCount}</td>
                   <td style={numericCellStyle}>{row.invalidReadyCount}</td>
                   <td style={numericCellStyle}>{row.readyAmountTotal}</td>
+                  <td style={numericCellStyle}>
+                    {row.statutoryActualAmountTotal ?? '0'}
+                  </td>
+                  <td style={numericCellStyle}>{row.varianceAmount ?? '0'}</td>
                 </tr>
               ))}
             </tbody>
@@ -410,6 +428,24 @@ export const IntegrationReconciliationCard = ({
               debit={summary.accounting.staging.readyDebitTotal} / credit=
               {summary.accounting.staging.readyCreditTotal} / balanced=
               {summary.accounting.staging.debitCreditBalanced ? 'yes' : 'no'}
+            </div>
+            <div style={{ marginTop: 6 }}>
+              {`statutoryActuals: status=${
+                summary.accounting.statutoryActuals?.comparisonStatus ??
+                'not_imported'
+              } / imported=${
+                summary.accounting.statutoryActuals?.importedCount ?? 0
+              } / amount=${
+                summary.accounting.statutoryActuals?.amountTotal ?? '0'
+              } / variance=${
+                summary.accounting.statutoryActuals?.varianceAmount ?? '-'
+              }`}
+            </div>
+            <div style={{ fontSize: 12, color: '#475569' }}>
+              latestStatutoryImport:{' '}
+              {summary.accounting.statutoryActuals?.latestImportBatchKey
+                ? `${summary.accounting.statutoryActuals.latestImportBatchKey} / ${summary.accounting.statutoryActuals.latestAccountingSystem || '-'} / importedAt=${formatDateTime(summary.accounting.statutoryActuals.latestImportedAt || null)}`
+                : '-'}
             </div>
           </div>
         </div>

--- a/packages/frontend/src/sections/admin-settings/IntegrationReconciliationCard.tsx
+++ b/packages/frontend/src/sections/admin-settings/IntegrationReconciliationCard.tsx
@@ -60,9 +60,21 @@ export type IntegrationReconciliationSummary = {
       latestAccountingSystem?: string | null;
       latestImportedAt?: string | null;
       importedCount: number;
+      currency?: string | null;
+      currencyCount?: number;
       amountTotal: string;
       internalReadyDebitTotal: string;
       varianceAmount?: string | null;
+      actualTotalsByCurrency?: Array<{
+        currency: string;
+        amountTotal: string;
+        count: number;
+      }>;
+      readyDebitTotalsByCurrency?: Array<{
+        currency: string;
+        amountTotal: string;
+        count: number;
+      }>;
       comparisonStatus: string;
     } | null;
   };
@@ -71,6 +83,7 @@ export type IntegrationReconciliationSummary = {
 
 export type IntegrationReconciliationBreakdownRow = {
   key: string;
+  currency: string;
   totalCount: number;
   readyCount: number;
   pendingMappingCount: number;
@@ -181,6 +194,7 @@ function renderBreakdownTable(
             <thead>
               <tr>
                 <th style={{ textAlign: 'left' }}>key</th>
+                <th style={{ textAlign: 'left' }}>currency</th>
                 <th style={numericCellStyle}>total</th>
                 <th style={numericCellStyle}>ready</th>
                 <th style={numericCellStyle}>pending_mapping</th>
@@ -193,8 +207,9 @@ function renderBreakdownTable(
             </thead>
             <tbody>
               {rows.map((row) => (
-                <tr key={`${testId}:${row.key}`}>
+                <tr key={`${testId}:${row.key}:${row.currency}`}>
                   <td>{row.key}</td>
+                  <td>{row.currency}</td>
                   <td style={numericCellStyle}>{row.totalCount}</td>
                   <td style={numericCellStyle}>{row.readyCount}</td>
                   <td style={numericCellStyle}>{row.pendingMappingCount}</td>
@@ -435,6 +450,8 @@ export const IntegrationReconciliationCard = ({
                 'not_imported'
               } / imported=${
                 summary.accounting.statutoryActuals?.importedCount ?? 0
+              } / currency=${
+                summary.accounting.statutoryActuals?.currency ?? '-'
               } / amount=${
                 summary.accounting.statutoryActuals?.amountTotal ?? '0'
               } / variance=${


### PR DESCRIPTION
## Summary
- Add `StatutoryAccountingActual` import staging model and migration for monthly statutory accounting actuals by batch, PJ/department, account, amount type, currency, and amount.
- Add admin/mgmt import API `POST /integrations/accounting/statutory-actuals/import` with row validation and batch conflict handling.
- Extend reconciliation summary/details/CSV and Admin Settings UI to compare statutory actuals with ERP4 internal ready amounts.
- Update requirements/manual docs and backend/frontend regression tests.

Closes #1750

## Verification
- `npm ci --prefix packages/backend`
- `npm ci --prefix packages/frontend`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public npx --prefix packages/backend prisma generate --config packages/backend/prisma.config.ts`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public npx --prefix packages/backend prisma validate --config packages/backend/prisma.config.ts`
- `npm run build --prefix packages/backend`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public npm run test:ci --prefix packages/backend -- test/integrationReconciliationRoutes.test.js`
- `npm run test --prefix packages/frontend -- IntegrationReconciliationCard.test.tsx AdminSettings.test.tsx`
- `npm run lint --prefix packages/backend`
- `npm run lint --prefix packages/frontend`
- `npm run typecheck --prefix packages/frontend`
- `npm run format:check --prefix packages/backend`
- `npm run format:check --prefix packages/frontend`
- `npm run build --prefix packages/frontend`