### PR TITLE
docs(ops): add Google Cloud and Sakura VPS deployment runbooks

### DIFF
--- a/docs/ops/google-cloud-predeployment.md
+++ b/docs/ops/google-cloud-predeployment.md
@@ -1,0 +1,290 @@
+# Google Cloud 事前設定 Runbook（さくらVPS 導入前）
+
+## 目的
+
+さくらVPS へ ERP4 を導入する前に、Google Cloud / Google Auth Platform / Google Drive で必要な設定を完了し、VPS 側の env に安全に転記できる状態を作る。
+
+この Runbook は「Google Cloud 側で先に決める値」と「VPS 導入時に検証する値」を分離する。Google OIDC ログインの詳細は [google-oidc-google-cloud-console](google-oidc-google-cloud-console.md)、チャット添付の Google Drive 連携詳細は [../requirements/chat-attachments-google-drive](../requirements/chat-attachments-google-drive.md) を参照する。
+
+## 対象構成
+
+| 項目           | 推奨                                                     | 備考                                                         |
+| -------------- | -------------------------------------------------------- | ------------------------------------------------------------ |
+| ERP4 hosting   | さくらVPS + Podman + Quadlet                             | 導入手順は [sakura-vps-deployment](sakura-vps-deployment.md) |
+| Auth           | Google OIDC + `AUTH_MODE=jwt_bff`                        | backend callback は FQDN + HTTPS                             |
+| 添付ストレージ | Google Drive または local                                | Drive は `CHAT_ATTACHMENT_PROVIDER=gdrive`                   |
+| secrets        | VPS runtime env / GitHub Secrets / Google Secret Manager | 値そのものはリポジトリへ入れない                             |
+| automation     | gcloud / GitHub Actions                                  | 可能なら keyless auth を採用                                 |
+
+## 0. 作業前に決める値
+
+| 種別                 | 値の例                                         | 使用箇所                                    |
+| -------------------- | ---------------------------------------------- | ------------------------------------------- |
+| Google Cloud project | `erp4-prod` / `erp4-stg`                       | API / OAuth / Secrets の管理単位            |
+| frontend origin      | `https://app.example.com`                      | `ALLOWED_ORIGINS`, `AUTH_FRONTEND_ORIGIN`   |
+| backend origin       | `https://api.example.com`                      | `VITE_API_BASE`, OAuth redirect URI         |
+| OIDC redirect URI    | `https://api.example.com/auth/google/callback` | Google OAuth client                         |
+| Drive folder name    | `ERP4 Chat Attachments`                        | `CHAT_ATTACHMENT_GDRIVE_FOLDER_ID` の作成元 |
+| support email        | `ops@example.com`                              | OAuth Branding / verification               |
+| ops owner            | GitHub user / Google group                     | secret owner / reviewer                     |
+
+判断基準:
+
+- production と trial/staging で Google Cloud project または OAuth client を共有しない。
+- raw IP / plain HTTP は Google OIDC の実ログイン確認に使わない。VPS 実機でも FQDN + HTTPS を前提にする。
+- OAuth client secret / refresh token / service account key は作成直後に安全な保管先へ移し、ローカルメモや Issue コメントに貼らない。
+
+## 1. Google Cloud project / IAM
+
+### 1-1. project を作成または選択する
+
+1. Google Cloud Console で ERP4 用 project を作成または選択する。
+2. billing が必要な API / Secret Manager を使う場合は billing link を確認する。
+3. staging / production の分離方針を Issue に記録する。
+
+記録項目:
+
+```text
+Google Cloud project id:
+Environment: trial | staging | production
+Billing linked: yes | no | n/a
+Primary owner:
+Backup owner:
+Created/confirmed at:
+```
+
+### 1-2. IAM を最小化する
+
+推奨ロールの考え方:
+
+| 作業                        | 必要な権限の例                                         | 備考                         |
+| --------------------------- | ------------------------------------------------------ | ---------------------------- |
+| API 有効化                  | Project Editor 相当または Service Usage 管理権限       | 恒久付与せず作業後に見直す   |
+| OAuth client 作成           | Google Auth Platform / Cloud Console の管理権限        | 組織ポリシーに依存           |
+| Secret Manager 管理         | Secret Manager Admin                                   | 値の閲覧者は分ける           |
+| secret 参照                 | Secret Manager Secret Accessor                         | runtime / CI のみ            |
+| GitHub Actions keyless auth | Workload Identity Pool / Service Account Token Creator | service account key を避ける |
+
+## 2. API 有効化
+
+最低限確認する API:
+
+| API                 | 使う条件                                                           | 確認              |
+| ------------------- | ------------------------------------------------------------------ | ----------------- |
+| Google Drive API    | `CHAT_ATTACHMENT_PROVIDER=gdrive` を使う                           | 有効化必須        |
+| Secret Manager API  | Google Cloud 側に secrets を置く                                   | 推奨              |
+| IAM Credentials API | Workload Identity Federation で service account impersonation する | CI 自動化時に必要 |
+| Service Usage API   | gcloud で API 有効化状態を扱う                                     | 自動化時に便利    |
+
+確認例:
+
+```bash
+gcloud config get-value project
+gcloud services list --enabled --filter='name:drive.googleapis.com OR name:secretmanager.googleapis.com OR name:iamcredentials.googleapis.com OR name:serviceusage.googleapis.com'
+```
+
+変更を伴う操作は、対象 project を確認してから実行する。
+
+```bash
+gcloud services enable drive.googleapis.com secretmanager.googleapis.com
+```
+
+## 3. Google OIDC ログイン設定
+
+詳細手順は [google-oidc-google-cloud-console](google-oidc-google-cloud-console.md) を正とする。この Runbook では導入前の完了条件だけを管理する。
+
+完了条件:
+
+- [ ] Google Auth Platform の Branding が設定済み
+- [ ] Audience が `Internal` / `External` のどちらかに決まっている
+- [ ] `openid`, `email`, `profile` 以外の scope を追加していない
+- [ ] OAuth client 種別は `Web application`
+- [ ] `Authorized redirect URIs` に `https://api.example.com/auth/google/callback` 相当を登録済み
+- [ ] client ID を `GOOGLE_OIDC_CLIENT_ID` / `JWT_AUDIENCE` へ反映する方針が決まっている
+- [ ] client secret の保管先が決まっている
+- [ ] secret ローテーション手順が [secrets-and-access](secrets-and-access.md) と矛盾していない
+
+ERP4 側への対応:
+
+| Google 側           | ERP4 env                                  |
+| ------------------- | ----------------------------------------- |
+| OAuth client ID     | `GOOGLE_OIDC_CLIENT_ID`, `JWT_AUDIENCE`   |
+| OAuth client secret | `GOOGLE_OIDC_CLIENT_SECRET`               |
+| redirect URI        | `GOOGLE_OIDC_REDIRECT_URI`                |
+| frontend origin     | `AUTH_FRONTEND_ORIGIN`, `ALLOWED_ORIGINS` |
+| backend origin      | `VITE_API_BASE`                           |
+
+## 4. Google Drive 添付設定
+
+### 4-1. scope 方針
+
+推奨は `https://www.googleapis.com/auth/drive.file` とする。
+
+- アプリが作成・開いたファイルにアクセス範囲を寄せやすい。
+- ERP4 の添付フォルダはアプリで作成する運用にする。
+- 既存フォルダや Shared Drive を使う場合のみ、`drive` scope が必要かを個別判断する。
+
+### 4-2. OAuth client / refresh token
+
+チャット添付の Google Drive 連携は refresh token を長期鍵として扱う。
+
+完了条件:
+
+- [ ] Drive API が有効化されている
+- [ ] OAuth client が作成済み
+- [ ] `https://developers.google.com/oauthplayground` が redirect URI に登録されている（Playground を使う場合）
+- [ ] `drive.file` または採用 scope が記録されている
+- [ ] refresh token を取得済み
+- [ ] refresh token の保管先・閲覧者・ローテーション手順が決まっている
+- [ ] token revoke 手順を確認済み
+
+ERP4 側への対応:
+
+| Google 側           | ERP4 env                               |
+| ------------------- | -------------------------------------- |
+| OAuth client ID     | `CHAT_ATTACHMENT_GDRIVE_CLIENT_ID`     |
+| OAuth client secret | `CHAT_ATTACHMENT_GDRIVE_CLIENT_SECRET` |
+| refresh token       | `CHAT_ATTACHMENT_GDRIVE_REFRESH_TOKEN` |
+| folder ID           | `CHAT_ATTACHMENT_GDRIVE_FOLDER_ID`     |
+| provider switch     | `CHAT_ATTACHMENT_PROVIDER=gdrive`      |
+
+### 4-3. フォルダ作成/疎通確認
+
+```bash
+export CHAT_ATTACHMENT_GDRIVE_CLIENT_ID=...
+export CHAT_ATTACHMENT_GDRIVE_CLIENT_SECRET=...
+export CHAT_ATTACHMENT_GDRIVE_REFRESH_TOKEN=...
+export CHAT_ATTACHMENT_GDRIVE_FOLDER_NAME='ERP4 Chat Attachments'
+
+npx --prefix packages/backend ts-node --project packages/backend/tsconfig.json scripts/provision-chat-gdrive-folder.ts
+```
+
+取得した folder ID を設定して read/write を確認する。
+
+```bash
+export CHAT_ATTACHMENT_PROVIDER=gdrive
+export CHAT_ATTACHMENT_GDRIVE_FOLDER_ID=...
+
+npx --prefix packages/backend ts-node --project packages/backend/tsconfig.json scripts/check-chat-gdrive.ts
+GDRIVE_CHECK_MODE=write \
+  npx --prefix packages/backend ts-node --project packages/backend/tsconfig.json scripts/check-chat-gdrive.ts
+```
+
+証跡には成功/失敗と時刻だけを残し、secret 値は残さない。
+
+## 5. Secrets 保管方針
+
+### 5-1. 保管先の使い分け
+
+| 保管先                 | 用途                                 | 注意                               |
+| ---------------------- | ------------------------------------ | ---------------------------------- |
+| VPS runtime env        | systemd/Quadlet runtime が直接読む値 | file mode を `0600` に寄せる       |
+| GitHub Actions Secrets | CI/CD が使う値                       | Environment Secrets を優先         |
+| Google Secret Manager  | Google Cloud 側で管理する値          | version disable / destroy を分ける |
+| ローカル端末           | 初回作業の一時保持のみ               | 作業後に削除する                   |
+
+### 5-2. リポジトリへ入れてよいもの/いけないもの
+
+入れてよいもの:
+
+- env key 名
+- placeholder
+- secret の保管場所名
+- rotation 手順
+- 失効手順
+
+入れてはいけないもの:
+
+- OAuth client secret の実値
+- refresh token
+- service account key JSON
+- private key
+- 実DB password
+- 本番 URL と紐づく bearer token
+
+## 6. GitHub Actions / 自動化
+
+Google Cloud を GitHub Actions から操作する場合は、原則として service account key JSON を repository secret に保存しない。可能なら Workload Identity Federation を採用する。
+
+判断基準:
+
+| 方式                         | 採用条件                          | 注意                                                  |
+| ---------------------------- | --------------------------------- | ----------------------------------------------------- |
+| Workload Identity Federation | GitHub Actions から gcloud を使う | provider / audience / repository condition を絞る     |
+| service account key          | WIF が使えない例外                | 有効期限、保管先、rotation、失効日を必ず Issue に記録 |
+| 手動 gcloud                  | 初期導入や小規模運用              | 実行者と対象 project を証跡に残す                     |
+
+## 7. 導入前 Go/No-Go チェック
+
+VPS 導入へ進む前に、以下を Issue または導入証跡へ記録する。
+
+```text
+Date:
+Operator:
+Google Cloud project id:
+Environment:
+Frontend origin:
+Backend origin:
+OIDC client created: yes/no/n/a
+OIDC redirect URI verified: yes/no/n/a
+Drive API enabled: yes/no/n/a
+Drive scope:
+Drive folder id stored: yes/no/n/a
+Secrets storage:
+Refresh token stored: yes/no/n/a
+WIF configured: yes/no/n/a
+Manual exceptions:
+Next action:
+```
+
+Go 条件:
+
+- Google OIDC を使う場合、OAuth client と redirect URI が確定している。
+- Google Drive 添付を使う場合、Drive API / OAuth client / refresh token / folder ID が揃っている。
+- secret の保管先と閲覧者が明確である。
+- VPS 側へ転記する env key と値の受け渡し方法が決まっている。
+
+No-Go 条件:
+
+- refresh token や client secret を平文チャット/Issue/PR に貼る必要がある。
+- project / environment が曖昧である。
+- redirect URI が raw IP / plain HTTP 前提である。
+- scope が過大で、承認理由が記録されていない。
+
+## 8. トラブルシュート
+
+### refresh token が取得できない
+
+- 既に同じ client/scope/user で許可済みの場合、再同意が必要なことがある。
+- Google アカウント側でアプリのアクセス権を削除してから再実行する。
+- OAuth Playground で自前 OAuth credentials を使っているか確認する。
+
+### `redirect_uri_mismatch`
+
+- Google Console の redirect URI と `GOOGLE_OIDC_REDIRECT_URI` が一致していない。
+- `http` / `https`、host、path、末尾 slash を確認する。
+- 変更直後は反映待ちが必要な場合がある。
+
+### Drive read/write が失敗する
+
+- Drive API が有効か確認する。
+- refresh token の scope が不足していないか確認する。
+- `drive.file` の場合、対象フォルダがアプリで作成されたものか確認する。
+- folder の共有設定が専用アカウントに閉じているか確認する。
+
+## 関連 Runbook
+
+- さくらVPS 導入: [sakura-vps-deployment](sakura-vps-deployment.md)
+- さくらVPS Quadlet 手順: [sakura-vps-podman-trial](sakura-vps-podman-trial.md)
+- Google OIDC Console 設定: [google-oidc-google-cloud-console](google-oidc-google-cloud-console.md)
+- Google OIDC Auth Gateway: [google-oidc-auth-gateway-rollout](google-oidc-auth-gateway-rollout.md)
+- Secrets/アクセス権限: [secrets-and-access](secrets-and-access.md)
+- Google Drive 添付: [../requirements/chat-attachments-google-drive](../requirements/chat-attachments-google-drive.md)
+
+## 参考（2026-05-10 確認）
+
+- Google Drive API scopes: <https://developers.google.com/drive/api/guides/api-specific-auth>
+- Google Drive API enablement: <https://developers.google.com/drive/api/guides/enable-sdk>
+- OAuth 2.0 Playground: <https://developers.google.com/oauthplayground>
+- Workload Identity Federation: <https://cloud.google.com/iam/docs/workload-identity-federation>
+- Secret Manager best practices: <https://cloud.google.com/secret-manager/docs/best-practices>

--- a/docs/ops/index.md
+++ b/docs/ops/index.md
@@ -9,7 +9,9 @@
 ### 起動/デプロイ
 
 - ローカル/PoC 起動: [deploy-start](deploy-start.md)
-- さくらVPS（Ubuntu）+ Podman + Quadlet: [sakura-vps-podman-trial](sakura-vps-podman-trial.md)
+- さくらVPS 導入 Runbook（本番準備レベル）: [sakura-vps-deployment](sakura-vps-deployment.md)
+  - Google Cloud 事前設定: [google-cloud-predeployment](google-cloud-predeployment.md)
+  - Quadlet 詳細手順: [sakura-vps-podman-trial](sakura-vps-podman-trial.md)
   - env チェックリスト: [sakura-vps-env-checklist](sakura-vps-env-checklist.md)
   - 試験稼働 Go/No-Go チェックリスト: [sakura-vps-trial-checklist](sakura-vps-trial-checklist.md)
   - 試験稼働記録テンプレート: [../test-results/sakura-vps-trial-template.md](../test-results/sakura-vps-trial-template.md)

--- a/docs/ops/sakura-vps-deployment.md
+++ b/docs/ops/sakura-vps-deployment.md
@@ -1,0 +1,397 @@
+# さくらVPS 導入 Runbook（本番準備レベル）
+
+## 目的
+
+ERP4 を 1 台のさくらVPSで小規模本番相当または長期試験稼働するための導入順序、チェックポイント、証跡を定義する。
+
+この Runbook は入口であり、実際の Quadlet 操作は [sakura-vps-podman-trial](sakura-vps-podman-trial.md)、HTTPS reverse proxy は [sakura-vps-https-proxy](sakura-vps-https-proxy.md)、env は [sakura-vps-env-checklist](sakura-vps-env-checklist.md) を参照する。
+
+## 全体フロー
+
+```text
+1. Google Cloud 事前設定
+2. VPS 契約/OS/SSH/packet filter
+3. OS hardening
+4. Podman/Node.js/repo 配置
+5. frontend build-time env
+6. Quadlet unit install
+7. runtime/proxy/maintenance env
+8. build/migrate/start
+9. HTTPS / OIDC / Drive 疎通
+10. backup / monitoring / rollback 確認
+11. Go/No-Go 記録
+```
+
+## 0. 導入前提
+
+| 項目          | 推奨値                    | 備考                                            |
+| ------------- | ------------------------- | ----------------------------------------------- |
+| OS            | Ubuntu 24.04 LTS          | 22.04 からの流用時も手順差分を記録              |
+| memory        | 2GB 以上推奨              | 1GB 以下は build / DB / ClamAV 等で余裕が少ない |
+| user          | `deploy`                  | sudo 可能、rootless Podman 実行主体             |
+| repo          | `/opt/itdo/ITDO_ERP4`     | scripts / Quadlet の例と揃える                  |
+| runtime       | rootless Podman + Quadlet | user systemd で自動復帰                         |
+| reverse proxy | Caddy                     | 既存テンプレートあり                            |
+| auth          | `AUTH_MODE=jwt_bff`       | 公開環境で `AUTH_MODE=header` は使わない        |
+| DB            | Podman PostgreSQL         | 単一VPSのSPOFであることを明示                   |
+
+単一VPS構成の制約:
+
+- VPS障害はアプリ/DB同時停止になる。
+- PostgreSQLを同一ホストに置くため、backup/restore手順の実地確認が必須。
+- 高可用性やDB分離が必要になったら別設計へ移行する。
+
+## 1. Google Cloud 事前設定
+
+先に [google-cloud-predeployment](google-cloud-predeployment.md) を完了する。
+
+Go 条件:
+
+- [ ] frontend/backend の FQDN が決まっている
+- [ ] Google OIDC を使う場合、OAuth client と redirect URI が確定している
+- [ ] Google Drive 添付を使う場合、Drive API / refresh token / folder ID が揃っている
+- [ ] secret の保管先と転記方法が決まっている
+- [ ] 本番secretを Issue / PR / docs に貼らない運用が合意されている
+
+## 2. さくらVPS 契約/OS/SSH/packet filter
+
+### 2-1. コントロールパネル作業
+
+記録する値:
+
+```text
+VPS name:
+Plan:
+OS image:
+Global IPv4:
+Global IPv6:
+Initial admin user:
+SSH public key id/name:
+Packet filter profile:
+```
+
+推奨:
+
+- SSH公開鍵を事前登録し、鍵認証で初期ログインする。
+- OS再インストールは破壊的操作として扱い、backup要否を確認してから実施する。
+- packet filter は SSH と Web（80/443）だけを許可する。DB port は公開しない。
+- Google OIDC を使う場合、raw IP ではなく DNS + HTTPS の準備を前提にする。
+
+### 2-2. 初回ログイン
+
+Ubuntu 標準OSでは初期ユーザーが `ubuntu` になる構成がある。実際のユーザー名はさくらVPS側のOS/インストール方式に従う。
+
+```bash
+ssh ubuntu@<VPS_IP>
+```
+
+`deploy` ユーザーを作る例:
+
+```bash
+sudo adduser deploy
+sudo usermod -aG sudo deploy
+sudo install -d -m 700 -o deploy -g deploy /home/deploy/.ssh
+sudo cp ~/.ssh/authorized_keys /home/deploy/.ssh/authorized_keys
+sudo chown deploy:deploy /home/deploy/.ssh/authorized_keys
+sudo chmod 600 /home/deploy/.ssh/authorized_keys
+```
+
+以後は `deploy` で作業する。
+
+## 3. OS hardening
+
+### 3-1. 基本更新
+
+```bash
+sudo apt update
+sudo apt -y upgrade
+sudo apt -y install git curl jq make ca-certificates unzip ufw fail2ban unattended-upgrades
+```
+
+### 3-2. timezone / locale / time sync
+
+```bash
+timedatectl
+sudo timedatectl set-timezone Asia/Tokyo
+systemctl status systemd-timesyncd --no-pager || true
+```
+
+### 3-3. SSH
+
+最低限の確認:
+
+```bash
+sudo sshd -T | grep -E '^(passwordauthentication|permitrootlogin|pubkeyauthentication) '
+```
+
+推奨値:
+
+```text
+PasswordAuthentication no
+PermitRootLogin no
+PubkeyAuthentication yes
+```
+
+設定変更時は新しいSSHセッションでログイン確認が終わるまで既存セッションを閉じない。
+
+### 3-4. firewall
+
+Ubuntu側の例:
+
+```bash
+sudo ufw default deny incoming
+sudo ufw default allow outgoing
+sudo ufw allow OpenSSH
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw enable
+sudo ufw status verbose
+```
+
+さくらVPS packet filter と OS firewall の両方で許可が必要な場合がある。どちらか片方だけで通らない前提で確認する。
+
+### 3-5. swap / disk
+
+```bash
+free -h
+df -h
+lsblk
+```
+
+メモリが少ない構成では build 時のOOMを避けるため、swap追加を検討する。swapを追加した場合はサイズ、ファイルパス、永続化方法を証跡に残す。
+
+## 4. runtime 前提確認
+
+詳細は [sakura-vps-podman-trial](sakura-vps-podman-trial.md) を参照する。
+
+```bash
+sudo apt -y install podman uidmap slirp4netns passt fuse-overlayfs
+podman --version
+node -v || true
+```
+
+Node.js は nvm または運用で選んだ方式で 20 LTS に固定する。
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+source ~/.nvm/nvm.sh
+nvm install 20
+nvm alias default 20
+```
+
+rootless Podman:
+
+```bash
+grep '^deploy:' /etc/subuid /etc/subgid
+sudo loginctl enable-linger deploy
+loginctl show-user deploy | grep Linger
+podman info
+```
+
+## 5. ソース配置/更新
+
+初回:
+
+```bash
+sudo mkdir -p /opt/itdo
+sudo chown deploy:deploy /opt/itdo
+cd /opt/itdo
+git clone https://github.com/itdojp/ITDO_ERP4.git
+cd ITDO_ERP4
+git checkout main
+git pull --ff-only origin main
+```
+
+更新時:
+
+```bash
+cd /opt/itdo/ITDO_ERP4
+git fetch origin main
+git checkout main
+git pull --ff-only origin main
+```
+
+証跡:
+
+```bash
+git rev-parse HEAD
+git status --short --branch
+```
+
+## 6. build-time env
+
+`deploy/quadlet/env/erp4-frontend-build.env` を用意する。
+
+```bash
+cp deploy/quadlet/env/erp4-frontend-build.env.example deploy/quadlet/env/erp4-frontend-build.env
+chmod 600 deploy/quadlet/env/erp4-frontend-build.env
+vi deploy/quadlet/env/erp4-frontend-build.env
+```
+
+最低限:
+
+```dotenv
+VITE_API_BASE=https://api.example.com
+VITE_ENABLE_SW=true
+```
+
+Google OIDC の backend redirect フローだけを使う場合、`VITE_GOOGLE_CLIENT_ID` は不要。frontend が Google Identity Services を直接使う場合だけ設定する。
+
+## 7. Quadlet unit / runtime env
+
+```bash
+./scripts/quadlet/check-env.sh --skip-runtime --frontend-build-env deploy/quadlet/env/erp4-frontend-build.env
+./scripts/quadlet/build-images.sh
+./scripts/quadlet/install-user-units.sh
+```
+
+runtime env は `~/.config/containers/systemd/` 配下で管理する。
+
+重要:
+
+- env file は `chmod 600` を基本にする。
+- `erp4-backend.env` に secret が入るため、backup/転送先も secret として扱う。
+- `DATABASE_URL` の host は Podman network の `erp4-postgres` を使う。
+- `ALLOWED_ORIGINS` は frontend の公開 origin のみに絞る。
+- `AUTH_SESSION_COOKIE_SECURE=true` は HTTPS 公開時に必須。
+
+確認:
+
+```bash
+./scripts/quadlet/check-env.sh
+./scripts/quadlet/check-proxy.sh
+```
+
+## 8. 起動/疎通
+
+proxyなしの内部確認:
+
+```bash
+./scripts/quadlet/start-stack.sh
+./scripts/quadlet/check-trial-readiness.sh
+```
+
+HTTPS proxy込み:
+
+```bash
+./scripts/quadlet/start-stack.sh --include-proxy
+./scripts/quadlet/check-trial-readiness.sh --include-proxy --resolve-ip <VPS_IP>
+```
+
+DNS反映後:
+
+```bash
+./scripts/quadlet/check-https.sh
+curl -fsS https://api.example.com/healthz
+curl -I https://app.example.com/
+```
+
+Google OIDC / Drive を使う場合:
+
+- `/auth/google/start` から Google 認証へ遷移する。
+- callback後にERP4へ戻る。
+- `scripts/check-chat-gdrive.ts` の read/write が成功する。
+- 失敗時は [google-cloud-predeployment](google-cloud-predeployment.md) のトラブルシュートへ戻る。
+
+## 9. backup / restore / rollback
+
+導入当日に最低限確認する。
+
+```bash
+systemctl --user enable --now erp4-config-backup.timer
+systemctl --user enable --now erp4-db-backup.timer
+systemctl --user list-timers 'erp4-*'
+./scripts/quadlet/run-maintenance-now.sh --include-units
+```
+
+DB restore の詳細は [quadlet-db-backup-restore](quadlet-db-backup-restore.md) と [backup-restore](backup-restore.md) を参照する。
+
+更新時のrollback候補:
+
+- 前回 commit に戻す。
+- 前回 image を再build/再起動する。
+- Quadlet config backup を `restore-latest.sh` で戻す。
+- DB migrationを伴う場合は、restore rehearsal 済みのbackupから戻せることを確認してから実行する。
+
+破壊的操作:
+
+- `scripts/podman-poc.sh reset` は試験DB初期化を伴う。導入済みVPSでは通常使わない。
+- OS再インストールは全データ消去を伴う。backup/restore可否を確認してから実施する。
+
+## 10. 監視/障害対応
+
+最低限の確認:
+
+```bash
+./scripts/quadlet/status-stack.sh --include-proxy
+./scripts/quadlet/logs-stack.sh --include-proxy --lines 100
+journalctl --user -u erp4-backend.service -n 100 --no-pager
+journalctl --user -u erp4-caddy.service -n 100 --no-pager
+```
+
+関連Runbook:
+
+- [observability](observability.md)
+- [alerting](alerting.md)
+- [incident-response](incident-response.md)
+- [slo](slo.md)
+
+## 11. Go/No-Go 記録
+
+導入完了時は、以下を Issue または `docs/test-results/` に残す。
+
+```text
+Date:
+Operator:
+VPS name/IP:
+Domain:
+Commit SHA:
+Google Cloud project:
+OIDC enabled: yes/no
+Drive enabled: yes/no
+check-env: pass/fail
+check-proxy: pass/fail/n/a
+check-trial-readiness: pass/fail
+check-https: pass/fail/n/a
+backup timer: enabled/disabled
+DB backup timer: enabled/disabled
+Rollback plan confirmed: yes/no
+Open risks:
+Go/No-Go:
+```
+
+Go 条件:
+
+- health/readiness が成功している。
+- frontend が公開URLで応答する。
+- HTTPS証明書が有効である。
+- OIDC/Driveを使う場合は各疎通確認が成功している。
+- backup取得先と復元手順が確認済みである。
+- secret がIssue/PR/docs/logへ漏れていない。
+
+No-Go 条件:
+
+- `AUTH_MODE=header` でインターネット公開しようとしている。
+- DB port を外部公開している。
+- `ALLOWED_ORIGINS` が過大である。
+- restore手順が未確認のままデータを投入しようとしている。
+- secret の保管先/ローテーション担当が未定である。
+
+## 関連 Runbook
+
+- Google Cloud 事前設定: [google-cloud-predeployment](google-cloud-predeployment.md)
+- Quadlet 詳細手順: [sakura-vps-podman-trial](sakura-vps-podman-trial.md)
+- env チェックリスト: [sakura-vps-env-checklist](sakura-vps-env-checklist.md)
+- HTTPS reverse proxy: [sakura-vps-https-proxy](sakura-vps-https-proxy.md)
+- 試験稼働 Go/No-Go: [sakura-vps-trial-checklist](sakura-vps-trial-checklist.md)
+- Secrets/アクセス権限: [secrets-and-access](secrets-and-access.md)
+- Backup/restore: [backup-restore](backup-restore.md)
+- Quadlet DB backup/restore: [quadlet-db-backup-restore](quadlet-db-backup-restore.md)
+
+## 参考（2026-05-10 確認）
+
+- さくらVPS OS再インストール: <https://manual.sakura.ad.jp/vps/os-reinstall/index.html>
+- さくらVPS SSH公開鍵: <https://manual.sakura.ad.jp/vps/controlpanel/ssh-keygen.html>
+- さくらVPS パケットフィルター: <https://manual.sakura.ad.jp/vps/network/packetfilter.html>
+- さくらVPS 管理ユーザーログイン: <https://manual.sakura.ad.jp/vps/support/info/administrative-userl-login.html>
+- Google Cloud 事前設定: [google-cloud-predeployment](google-cloud-predeployment.md)

--- a/docs/ops/sakura-vps-deployment.md
+++ b/docs/ops/sakura-vps-deployment.md
@@ -262,6 +262,20 @@ runtime env は `~/.config/containers/systemd/` 配下で管理する。
 ./scripts/quadlet/check-proxy.sh
 ```
 
+HTTPS reverse proxy で Caddy を rootless Podman から `80/443` に bind する場合は、起動前に host prerequisite も確認する。
+
+```bash
+./scripts/quadlet/check-host-prereqs.sh
+```
+
+`net.ipv4.ip_unprivileged_port_start` が 80 より大きい場合は、[sakura-vps-https-proxy](sakura-vps-https-proxy.md) の手順に従い、以下のように明示的に開放してから再確認する。
+
+```bash
+echo 'net.ipv4.ip_unprivileged_port_start=80' | sudo tee /etc/sysctl.d/90-itdo-rootless-ports.conf
+sudo sysctl --system
+./scripts/quadlet/check-host-prereqs.sh
+```
+
 ## 8. 起動/疎通
 
 proxyなしの内部確認:
@@ -295,7 +309,17 @@ Google OIDC / Drive を使う場合:
 
 ## 9. backup / restore / rollback
 
-導入当日に最低限確認する。
+導入当日に最低限確認する。backup timer を有効化する前に、`~/.config/containers/systemd/erp4-maintenance.env` の placeholder を実値へ置き換え、backup 出力先を作成・保護する。
+
+```bash
+vi ~/.config/containers/systemd/erp4-maintenance.env
+grep -n 'REPLACE_ME' ~/.config/containers/systemd/erp4-maintenance.env && echo 'replace placeholders before enabling timers' && exit 1 || true
+mkdir -p ~/.local/share/erp4/quadlet-backups ~/.local/share/erp4/db-backups
+chmod 700 ~/.local/share/erp4 ~/.local/share/erp4/quadlet-backups ~/.local/share/erp4/db-backups
+./scripts/quadlet/check-env.sh
+```
+
+そのうえで timer を有効化し、手動 backup を 1 回実行する。
 
 ```bash
 systemctl --user enable --now erp4-config-backup.timer

--- a/docs/ops/sakura-vps-env-checklist.md
+++ b/docs/ops/sakura-vps-env-checklist.md
@@ -1,45 +1,59 @@
 # さくらVPS 試験稼働 env チェックリスト
 
 ## 目的
+
 - さくらVPS 上の Quadlet 試験稼働で、どの env ファイルに何を設定するかを短時間で確認できるようにする。
 - build-time / runtime / proxy / maintenance の責務を分離して記録する。
 
 ## build-time
+
 ### `deploy/quadlet/env/erp4-frontend-build.env`
+
 用途:
+
 - frontend image build 時に `VITE_*` を焼き込む。
 
 最低限確認するキー:
+
 - `VITE_API_BASE`
 - `VITE_ENABLE_SW`
 
 必要時に設定するキー:
+
 - `VITE_PUSH_PUBLIC_KEY`
 - `VITE_GOOGLE_CLIENT_ID`（frontend が Google Identity Services を直接使う場合のみ）
 - `VITE_FEATURE_TIMESHEET_GRID`
 
 確認コマンド:
+
 ```bash
 ./scripts/quadlet/check-env.sh --skip-runtime --frontend-build-env deploy/quadlet/env/erp4-frontend-build.env
 ```
 
-Google OIDC をさくらVPS 実機で使う場合は FQDN + HTTPS の origin / redirect URI が前提です。Google 側の作業は [google-oidc-google-cloud-console](google-oidc-google-cloud-console.md) を参照してください。
+Google OIDC をさくらVPS 実機で使う場合は FQDN + HTTPS の origin / redirect URI が前提です。導入前に [google-cloud-predeployment](google-cloud-predeployment.md) を確認し、Google OIDC の詳細作業は [google-oidc-google-cloud-console](google-oidc-google-cloud-console.md) を参照してください。
 
 ## runtime
+
 ### `~/.config/containers/systemd/erp4-postgres.env`
+
 用途:
+
 - PostgreSQL コンテナ起動時の DB 初期化。
 
 最低限確認するキー:
+
 - `POSTGRES_USER`
 - `POSTGRES_PASSWORD`
 - `POSTGRES_DB`
 
 ### `~/.config/containers/systemd/erp4-backend.env`
+
 用途:
+
 - backend コンテナ起動時の本番相当設定。
 
 最低限確認するキー:
+
 - `DATABASE_URL`
 - `PORT`
 - `NODE_ENV`
@@ -56,6 +70,7 @@ Google OIDC をさくらVPS 実機で使う場合は FQDN + HTTPS の origin / r
 - `MAIL_TRANSPORT`
 
 ローカル保存系で確認するキー:
+
 - `PDF_PROVIDER`
 - `PDF_STORAGE_DIR`
 - `PDF_BASE_URL`
@@ -66,46 +81,60 @@ Google OIDC をさくらVPS 実機で使う場合は FQDN + HTTPS の origin / r
 - `REPORT_STORAGE_DIR`
 
 確認コマンド:
+
 ```bash
 ./scripts/quadlet/check-env.sh
 ```
 
 ## proxy
+
 ### `~/.config/containers/systemd/erp4-caddy.env`
+
 用途:
+
 - Caddy の公開ドメイン / ACME 設定。
 
 最低限確認するキー:
+
 - `APP_DOMAIN`
 - `API_DOMAIN`
 - `ACME_EMAIL`
 
 ### `~/.config/containers/systemd/erp4-caddy.Caddyfile`
+
 用途:
+
 - frontend / backend の reverse proxy ルーティング。
 
 確認コマンド:
+
 ```bash
 ./scripts/quadlet/check-proxy.sh
 ```
 
 ## maintenance
+
 ### `~/.config/containers/systemd/erp4-maintenance.env`
+
 用途:
+
 - config backup / prune / DB backup timer の共通設定。
 
 最低限確認するキー:
+
 - `ERP4_REPO_DIR`
 - `QUADLET_BACKUP_DIR`
 - `QUADLET_DB_BACKUP_DIR`
 
 保持方針として確認するキー:
+
 - `ERP4_BACKUP_INCLUDE_PROXY`
 - `ERP4_BACKUP_KEEP_COUNT`
 - `ERP4_BACKUP_KEEP_DAYS`
 - `ERP4_DB_BACKUP_SKIP_GLOBALS`
 
 ## 受入前の最小確認順
+
 1. `deploy/quadlet/env/erp4-frontend-build.env` を編集
 2. `./scripts/quadlet/check-env.sh --skip-runtime --frontend-build-env deploy/quadlet/env/erp4-frontend-build.env`
 3. `./scripts/quadlet/build-images.sh`
@@ -117,6 +146,7 @@ Google OIDC をさくらVPS 実機で使う場合は FQDN + HTTPS の origin / r
 9. `./scripts/quadlet/check-trial-readiness.sh`
 
 ## 関連 Runbook
+
 - 試験稼働手順: [sakura-vps-podman-trial](sakura-vps-podman-trial.md)
 - 試験稼働 Go/No-Go: [sakura-vps-trial-checklist](sakura-vps-trial-checklist.md)
 - HTTPS reverse proxy: [sakura-vps-https-proxy](sakura-vps-https-proxy.md)

--- a/docs/ops/sakura-vps-podman-trial.md
+++ b/docs/ops/sakura-vps-podman-trial.md
@@ -1,16 +1,21 @@
 # さくらVPS（Ubuntu）+ Podman + Quadlet 手順書
 
 ## 目的
+
 - ITDO_ERP4 を 1 台のさくらVPS 上で rootless Podman + Quadlet により常駐運用する。
 - PostgreSQL / backend / frontend を user systemd 管理へ寄せ、再起動後も自動復帰できる状態にする。
 
-試験稼働の Go/No-Go 判定だけを短時間で回したい場合は、別紙の [sakura-vps-trial-checklist](sakura-vps-trial-checklist.md) を使う。
+この手順書は Quadlet stack の詳細手順です。導入前チェック、OS hardening、Secrets、backup、Go/No-Go を含む入口は [sakura-vps-deployment](sakura-vps-deployment.md) を使う。Google Cloud / Drive / OAuth の事前設定は [google-cloud-predeployment](google-cloud-predeployment.md) を先に確認する。試験稼働の Go/No-Go 判定だけを短時間で回したい場合は、別紙の [sakura-vps-trial-checklist](sakura-vps-trial-checklist.md) を使う。
 
 関連資料:
+
+- 導入 Runbook: [sakura-vps-deployment](sakura-vps-deployment.md)
+- Google Cloud 事前設定: [google-cloud-predeployment](google-cloud-predeployment.md)
 - env チェックリスト: [sakura-vps-env-checklist](sakura-vps-env-checklist.md)
 - 試験稼働記録テンプレート: [../test-results/sakura-vps-trial-template.md](../test-results/sakura-vps-trial-template.md)
 
 ## 想定バージョン / 前提
+
 - OS: Ubuntu 24.04 LTS
 - Podman: 4.9 系
 - systemd: 255 系
@@ -23,6 +28,7 @@
   - PostgreSQL: `127.0.0.1:55432/tcp` のみ
 
 補足:
+
 - frontend は nginx コンテナで静的配信します。`vite preview` は常駐運用に使いません。
 - frontend の API 接続先は build-time に `VITE_API_BASE` へ焼き込まれます。
 - backend の本番認証は `AUTH_MODE=jwt_bff` を前提にします。`AUTH_MODE=header` は公開環境では非推奨です。
@@ -30,6 +36,7 @@
 ## 1. OS 初期セットアップ
 
 ### 1-1. 基本更新
+
 ```bash
 sudo apt update
 sudo apt -y upgrade
@@ -37,6 +44,7 @@ sudo apt -y install git curl jq make ca-certificates uidmap slirp4netns passt fu
 ```
 
 ### 1-2. Podman / Node.js
+
 ```bash
 sudo apt -y install podman
 podman --version
@@ -50,18 +58,21 @@ npm -v
 ```
 
 ### 1-3. rootless Podman 前提
+
 ```bash
 id -un
 grep "^$(id -un):" /etc/subuid /etc/subgid
 ```
 
 不足している場合:
+
 ```bash
 echo "deploy:100000:65536" | sudo tee -a /etc/subuid
 echo "deploy:100000:65536" | sudo tee -a /etc/subgid
 ```
 
 boot 後の user service 自動起動を有効化:
+
 ```bash
 sudo loginctl enable-linger "$(id -un)"
 ```
@@ -86,6 +97,7 @@ vi deploy/quadlet/env/erp4-frontend-build.env
 ```
 
 最低限修正する値:
+
 - `VITE_API_BASE`
   - plain HTTP の stack smoke のみ: `http://YOUR_VPS_HOST:3001`
   - Google OIDC を含む受入確認: `https://api.example.com`
@@ -97,16 +109,19 @@ Google OIDC をさくらVPS 実機で使う場合、Google 側へ登録する or
 plain HTTP の `8080/3001` 構成は Podman stack 自体の smoke 確認用です。Google OIDC の実 login / session 維持 / CORS 確認は、HTTPS reverse proxy 導入後の `app.example.com` / `api.example.com` で実施してください。
 
 build 前に frontend build 用 env だけ検証します。
+
 ```bash
 ./scripts/quadlet/check-env.sh --skip-runtime --frontend-build-env deploy/quadlet/env/erp4-frontend-build.env
 ```
 
 build:
+
 ```bash
 ./scripts/quadlet/build-images.sh
 ```
 
 生成されるイメージ:
+
 - `localhost/erp4-backend:latest`
 - `localhost/erp4-frontend:latest`
 
@@ -117,6 +132,7 @@ build:
 ```
 
 配置先:
+
 - `~/.config/containers/systemd/*.container`
 - `~/.config/containers/systemd/*.network`
 - `~/.config/containers/systemd/*.volume`
@@ -126,6 +142,7 @@ build:
 - `~/.config/containers/systemd/erp4-backend.env`
 
 `erp4-postgres.env` の例:
+
 ```dotenv
 POSTGRES_USER=erp4
 POSTGRES_PASSWORD=REPLACE_WITH_STRONG_PASSWORD
@@ -133,6 +150,7 @@ POSTGRES_DB=postgres
 ```
 
 `erp4-backend.env` の最低限（Google OIDC + HTTPS reverse proxy を使う場合の例）:
+
 ```dotenv
 DATABASE_URL=postgresql://erp4:REPLACE_WITH_STRONG_PASSWORD@erp4-postgres:5432/postgres?schema=public
 PORT=3001
@@ -159,18 +177,21 @@ REPORT_STORAGE_DIR=/var/lib/erp4/reports
 ```
 
 補足:
+
 - `DATABASE_URL` の host は `localhost` ではなく Podman network 上の `erp4-postgres` です。
 - `ALLOWED_ORIGINS` には frontend の公開 origin を必ず含めます。
 - backend は `erp4-backend-data.volume` を `/var/lib/erp4` へ mount します。PDF・Evidence archive・添付・report 出力先はこの配下に寄せます。
 - plain HTTP の stack smoke では、この例をそのまま使わず、Google OIDC を伴う受入確認まで行う場合だけ HTTPS/FQDN 前提の値へ切り替えます。
 
 runtime env を編集したら、unit 起動前に検証します。
+
 ```bash
 ./scripts/quadlet/check-env.sh
 ```
 
 任意で backup / prune / DB backup 用の maintenance env を編集します。
 `erp4-maintenance.env` の例:
+
 ```dotenv
 ERP4_REPO_DIR=/opt/itdo/ITDO_ERP4
 QUADLET_BACKUP_DIR=/home/YOUR_USER/.local/share/erp4/quadlet-backups
@@ -184,16 +205,19 @@ ERP4_DB_BACKUP_SKIP_GLOBALS=0
 ## 5. 起動順
 
 通常起動:
+
 ```bash
 ./scripts/quadlet/start-stack.sh
 ```
 
 proxy も起動する場合:
+
 ```bash
 ./scripts/quadlet/start-stack.sh --include-proxy
 ```
 
 手動で分ける場合:
+
 ```bash
 systemctl --user daemon-reload
 systemctl --user enable --now erp4-postgres.service
@@ -203,12 +227,14 @@ systemctl --user enable --now erp4-frontend.service
 ```
 
 まとめて確認:
+
 ```bash
 ./scripts/quadlet/check-stack.sh
 systemctl --user status erp4-postgres.service erp4-migrate.service erp4-backend.service erp4-frontend.service
 ```
 
 稼働状況の一覧確認:
+
 ```bash
 ./scripts/quadlet/status-stack.sh
 ./scripts/quadlet/status-stack.sh --include-proxy
@@ -217,6 +243,7 @@ systemctl --user status erp4-postgres.service erp4-migrate.service erp4-backend.
 `start-stack.sh` は `check-env.sh` による runtime env 検証、user systemd unit の有効化・起動、`check-stack.sh` による post-start 検証を直列で実行します。`--include-proxy` を付け、かつ `--skip-env-check` を付けていない場合は、`check-proxy.sh` による Caddy 設定検証も追加で行ったうえで `erp4-caddy.service` を有効化・起動します。さらに `--skip-stack-check` を付けていない場合は、`status-stack.sh --include-proxy` による `erp4-caddy.service` を含む状態確認まで実行します。公開ドメイン経由の疎通まで確認したい場合は、`check-proxy.sh` または外部からの `curl` probe を別途実行してください。`QUADLET_TARGET_DIR` を設定している場合はその配下を検証対象に使います。手動の `systemctl --user enable --now ...` 群はトラブルシュート用の fallback として残しています。
 
 試験稼働の受入確認を 1 コマンドで回す場合は、次を使います。
+
 ```bash
 ./scripts/quadlet/check-trial-readiness.sh
 ./scripts/quadlet/check-trial-readiness.sh --include-proxy --resolve-ip <VPS_IP>
@@ -225,6 +252,7 @@ systemctl --user status erp4-postgres.service erp4-migrate.service erp4-backend.
 `check-trial-readiness.sh` は `check-host-prereqs.sh` → `check-env.sh` → `check-stack.sh` を順に実行し、`--include-proxy` 指定時だけ `check-https.sh` を追加します。DNS 切替前に公開ドメイン疎通を仮確認したい場合は `--resolve-ip` を使います。
 
 試験稼働の証跡をまとめて採取する場合:
+
 ```bash
 ./scripts/quadlet/collect-trial-evidence.sh --lines 100
 ./scripts/quadlet/collect-trial-evidence.sh --include-proxy --resolve-ip <VPS_IP>
@@ -233,11 +261,13 @@ systemctl --user status erp4-postgres.service erp4-migrate.service erp4-backend.
 `collect-trial-evidence.sh` は `status-stack.sh` / `logs-stack.sh` / `systemctl --user list-timers 'erp4-*'` を timestamp 付きディレクトリへ保存し、`--include-proxy` 指定時だけ `check-https.sh` の結果も追加します。`status-stack.sh` や `check-https.sh` が失敗しても採取自体は継続し、最後に non-zero で終了します。
 
 試験稼働記録のたたき台を生成する場合:
+
 ```bash
 ./scripts/record-sakura-vps-trial.sh
 ```
 
 定期 backup を有効化する場合:
+
 ```bash
 systemctl --user enable --now erp4-config-backup.timer
 systemctl --user list-timers erp4-config-backup.timer
@@ -246,6 +276,7 @@ systemctl --user list-timers erp4-config-backup.timer
 既定では毎日 03:15 に `erp4-config-backup.service` が実行され、`backup-and-check.sh --include-units` が呼ばれます。`ERP4_BACKUP_INCLUDE_PROXY=1` のときだけ proxy 設定も backup に含めます。backup 対象には `erp4-maintenance.env` も含まれ、`--include-units` を付けた実行では `erp4-config-backup.service` / `erp4-config-backup.timer` / `erp4-db-backup.service` / `erp4-db-backup.timer` / `erp4-config-prune.service` / `erp4-config-prune.timer` も archive に含まれます。
 
 定期 DB backup を有効化する場合:
+
 ```bash
 systemctl --user enable --now erp4-db-backup.timer
 systemctl --user list-timers erp4-db-backup.timer
@@ -254,27 +285,32 @@ systemctl --user list-timers erp4-db-backup.timer
 既定では毎日 04:15 に `erp4-db-backup.service` が実行され、`backup-db.sh` が PostgreSQL dump と globals dump を取得します。出力先は `erp4-maintenance.env` の `QUADLET_DB_BACKUP_DIR` で上書きでき、`ERP4_DB_BACKUP_SKIP_GLOBALS=1` を付けると globals dump を省略できます。globals dump にはロール/権限に加えてパスワードハッシュ等の機微情報が含まれる可能性があるため、`QUADLET_DB_BACKUP_DIR` は `0700` などの厳しい権限で管理し、保管/転送時は暗号化とアクセス制御を前提にしてください。現時点では DB backup 用の自動 prune は提供していないため、`enable-maintenance-timers.sh` の既定対象には含めていません。`erp4-db-backup.timer` を有効化する場合は、保持本数/保持日数を別途運用で決め、手動削除または外部ローテーションを併用してください。
 
 定期 prune を有効化する場合:
+
 ```bash
 systemctl --user enable --now erp4-config-prune.timer
 systemctl --user list-timers erp4-config-prune.timer
 ```
 
 backup / prune timer をまとめて有効化する場合:
+
 ```bash
 ./scripts/quadlet/enable-maintenance-timers.sh
 ```
 
 backup / prune timer をまとめて無効化する場合:
+
 ```bash
 ./scripts/quadlet/disable-maintenance-timers.sh
 ```
 
 backup / prune timer の状態を確認する場合:
+
 ```bash
 ./scripts/quadlet/status-maintenance-timers.sh
 ```
 
 backup / prune を手動で 1 回実行する場合:
+
 ```bash
 ./scripts/quadlet/run-maintenance-now.sh --include-units
 ```
@@ -285,10 +321,10 @@ backup / prune を手動で 1 回実行する場合:
 
 `check-stack.sh` は backend health/readiness、frontend、PostgreSQL、および user systemd service を最大 60 秒・2 秒間隔で再試行しながら検証します。HTTP probe には残り時間ベースの timeout をかけているため、到達不能時でも無制限に待機しません。起動直後の偽陰性を避けたい場合は、個別 `curl` / `pg_isready` よりこちらを優先してください。
 
-
 `status-stack.sh` は定常監視や切り分け向けの即時確認コマンドです。`erp4-postgres.service` / `erp4-migrate.service` / `erp4-backend.service` / `erp4-frontend.service` の active 状態を一覧し、必要に応じて `erp4-caddy.service` も含められます。あわせて backend health/readiness、frontend の HTTP HEAD、PostgreSQL の `pg_isready` を 1 回ずつ実行して結果を表示します。`--skip-systemd` を付けると user systemd 依存を外して runtime probe のみ確認できます。
 
 停止する場合:
+
 ```bash
 ./scripts/quadlet/stop-stack.sh
 ./scripts/quadlet/stop-stack.sh --include-proxy
@@ -297,6 +333,7 @@ backup / prune を手動で 1 回実行する場合:
 `stop-stack.sh` は依存の逆順で `erp4-frontend.service` / `erp4-backend.service` / `erp4-migrate.service` / `erp4-postgres.service` を停止します。`--include-proxy` を付けると `erp4-caddy.service` も先に停止します。`systemctl --user` の user bus が利用できない場合は、`sudo loginctl enable-linger <user>` を含む対処メッセージを返します。
 
 再起動する場合:
+
 ```bash
 ./scripts/quadlet/restart-stack.sh
 ./scripts/quadlet/restart-stack.sh --include-proxy
@@ -305,6 +342,7 @@ backup / prune を手動で 1 回実行する場合:
 `restart-stack.sh` は `stop-stack.sh` と `start-stack.sh` を直列実行します。`--include-proxy` を付けると `erp4-caddy.service` も再起動対象に含まれます。さらに `--skip-stack-check` を指定していない場合のみ、post-start 確認として `status-stack.sh --include-proxy` まで実行します。`--skip-env-check` と `--skip-stack-check` は `start-stack.sh` に透過的に渡されるため、`--skip-stack-check` 指定時は proxy を含む post-start の状態確認も省略されます。
 
 自動起動設定ごと停止する場合:
+
 ```bash
 ./scripts/quadlet/disable-stack.sh
 ./scripts/quadlet/disable-stack.sh --include-proxy
@@ -313,6 +351,7 @@ backup / prune を手動で 1 回実行する場合:
 `disable-stack.sh` は stack を停止したうえで、対象 unit の user systemd 自動起動設定も解除します。`--include-proxy` を付けると `erp4-caddy.service` も対象に含め、disable 後に明示停止します。メンテナンス期間中に reboot 後の自動復帰を止めたい場合はこちらを使います。再開時は `start-stack.sh` を実行し、proxy も無効化していた場合は `start-stack.sh --include-proxy` を使ってください。
 
 Quadlet の unit 定義ファイル自体を取り除く場合:
+
 ```bash
 ./scripts/quadlet/uninstall-stack.sh
 ./scripts/quadlet/uninstall-stack.sh --include-proxy
@@ -364,17 +403,20 @@ stack の更新や uninstall 前に、`~/.config/containers/systemd/` 配下の 
 ## 6. 疎通確認
 
 backend:
+
 ```bash
 curl -fsS http://127.0.0.1:3001/healthz
 curl -fsS http://127.0.0.1:3001/readyz
 ```
 
 frontend:
+
 ```bash
 curl -I http://127.0.0.1:8080/
 ```
 
 PostgreSQL:
+
 ```bash
 podman exec erp4-postgres pg_isready -U erp4
 ```
@@ -382,6 +424,7 @@ podman exec erp4-postgres pg_isready -U erp4
 ## 7. 更新手順
 
 アプリ更新:
+
 ```bash
 cd /opt/itdo/ITDO_ERP4
 git fetch origin
@@ -407,17 +450,20 @@ journalctl --user -u erp4-frontend.service -f
 ```
 
 まとめて確認する場合:
+
 ```bash
 ./scripts/quadlet/logs-stack.sh --follow
 ```
 
 個別 unit や proxy を見る場合:
+
 ```bash
 ./scripts/quadlet/logs-stack.sh --service erp4-backend.service --lines 200
 ./scripts/quadlet/logs-stack.sh --service erp4-backend.service --include-proxy --follow
 ```
 
 Podman 側:
+
 ```bash
 podman ps
 podman logs erp4-backend
@@ -426,21 +472,25 @@ podman logs erp4-postgres
 ```
 
 よくある原因:
+
 - `erp4-migrate.service` 失敗: `DATABASE_URL` / Prisma schema 差分 / DB 接続不可
 - `erp4-backend.service` 失敗: `AUTH_MODE=jwt` に対して `JWT_*` が不足
 - frontend だけ起動して API 呼び出しが失敗: `VITE_API_BASE` と `ALLOWED_ORIGINS` の不整合
 
 ローカル smoke:
+
 ```bash
 ./scripts/quadlet/smoke-stack.sh
 ```
 
 起動済み stack を手動確認する場合:
+
 ```bash
 ./scripts/quadlet/check-stack.sh --skip-systemd
 ```
 
 状態を即時確認する場合:
+
 ```bash
 ./scripts/quadlet/status-stack.sh
 ./scripts/quadlet/status-stack.sh --include-proxy
@@ -450,6 +500,7 @@ podman logs erp4-postgres
 ## 9. 品質確認
 
 デプロイ前に最低限実行:
+
 ```bash
 make lint
 make format-check
@@ -460,6 +511,7 @@ make audit
 ```
 
 ## 10. 運用上の制約
+
 - 単一 VPS 構成のため SPOF です。
 - TLS は別の reverse proxy / LB で終端する前提です。
 - PostgreSQL のバックアップ方針は `docs/ops/backup-restore.md` に従って別途設計してください。

--- a/docs/ops/secrets-and-access.md
+++ b/docs/ops/secrets-and-access.md
@@ -127,7 +127,7 @@
 ## 最小権限（例）
 
 - DB: アプリ用ユーザはスキーマ単位で必要権限のみ（DDL/スーパーユーザ不可）
-- ストレージ（Google Drive 等）: 専用フォルダ/専用アカウント、必要スコープ最小化
+- ストレージ（Google Drive 等）: 専用フォルダ/専用アカウント、必要スコープ最小化。さくらVPS導入前のGoogle Cloud / Drive / OAuth確認は [google-cloud-predeployment](google-cloud-predeployment.md) を参照する。
 - GitHub: Fine-grained PAT / Actions Secrets のアクセス範囲を最小化
 
 ### DBユーザ（アプリ用ロール分離）

--- a/packages/backend/package-lock.json
+++ b/packages/backend/package-lock.json
@@ -4497,9 +4497,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- Add a Google Cloud predeployment runbook covering project/IAM, API enablement, Google OIDC, Google Drive attachments, secrets handling, and GitHub Actions automation choices before Sakura VPS rollout.
- Add a Sakura VPS deployment runbook for production-prep flow from VPS provisioning through OS hardening, Quadlet startup, HTTPS/OIDC/Drive checks, backup/restore, monitoring, and Go/No-Go evidence.
- Link the new runbooks from the ops index, existing Quadlet trial guide, env checklist, and secrets/access guidance.
- Update backend lockfile to consume the `fast-uri` audit fix required by the PR security-audit gate.

Closes #1755
Closes #1756

## Verification
- `npx --prefix packages/backend prettier --check docs/ops/google-cloud-predeployment.md docs/ops/sakura-vps-deployment.md docs/ops/index.md docs/ops/sakura-vps-env-checklist.md docs/ops/sakura-vps-podman-trial.md docs/ops/secrets-and-access.md`
- custom relative markdown link existence check for changed docs
- `bash scripts/secret-scan.sh`
- `git diff --check`
- `npm audit --prefix packages/backend --audit-level=high`

## Notes
- OAuth consent and refresh token issuance remain intentionally manual because human consent is required; the new docs scope automation to setup checks and validation.