### PR TITLE
feat(ops): add Sakura VPS and Google Cloud automation helpers

### DIFF
--- a/docs/ops/examples/gcp-preflight.env.example
+++ b/docs/ops/examples/gcp-preflight.env.example
@@ -1,0 +1,13 @@
+# Example variables for Google Cloud preflight commands.
+# Do not put secret values in this file.
+
+GCP_PROJECT_ID=erp4-prod
+GCP_WIF_POOL=github-actions
+GCP_WIF_PROVIDER=github
+GCP_WIF_LOCATION=global
+GCP_WIF_SERVICE_ACCOUNT=erp4-deploy@erp4-prod.iam.gserviceaccount.com
+
+# Pass these names with repeated --secret flags.
+GCP_SECRET_GOOGLE_OIDC_CLIENT_SECRET=erp4-google-oidc-client-secret
+GCP_SECRET_CHAT_GDRIVE_CLIENT_SECRET=erp4-chat-gdrive-client-secret
+GCP_SECRET_CHAT_GDRIVE_REFRESH_TOKEN=erp4-chat-gdrive-refresh-token

--- a/docs/ops/examples/vps-ops.env.example
+++ b/docs/ops/examples/vps-ops.env.example
@@ -1,0 +1,15 @@
+# Example variables for Sakura VPS ops scripts.
+# This file contains paths and hostnames only. Put runtime secrets in Quadlet env files.
+
+ERP4_DEPLOY_USER=deploy
+ERP4_REPO_PARENT=/opt/itdo
+ERP4_REPO_DIR=/opt/itdo/ITDO_ERP4
+ERP4_GIT_REMOTE=origin
+ERP4_GIT_BRANCH=main
+QUADLET_TARGET_DIR=/home/deploy/.config/containers/systemd
+FRONTEND_BUILD_ENV_FILE=/opt/itdo/ITDO_ERP4/deploy/quadlet/env/erp4-frontend-build.env
+
+# Optional verification inputs.
+BACKEND_HEALTH_URL=http://127.0.0.1:3001/healthz
+BACKEND_READY_URL=http://127.0.0.1:3001/readyz
+FRONTEND_URL=http://127.0.0.1:8080/

--- a/docs/ops/google-cloud-predeployment.md
+++ b/docs/ops/google-cloud-predeployment.md
@@ -89,6 +89,30 @@ gcloud services list --enabled --filter='name:drive.googleapis.com OR name:secre
 gcloud services enable drive.googleapis.com secretmanager.googleapis.com
 ```
 
+### 2-1. gcloud preflight wrapper
+
+手順漏れを抑えるため、`scripts/ops/gcp-preflight.sh` で account / project / API / billing / secret metadata / WIF を確認できる。詳細は [ops-automation](ops-automation.md) を参照する。
+
+読み取り専用の確認:
+
+```bash
+./scripts/ops/gcp-preflight.sh --check \
+  --project erp4-prod \
+  --secret erp4-google-oidc-client-secret \
+  --secret erp4-chat-gdrive-refresh-token \
+  --markdown-summary docs/test-results/gcp-preflight-YYYY-MM-DD.md
+```
+
+API有効化を自動化する場合は `--apply` と `--confirm-project` を必須にする。
+
+```bash
+./scripts/ops/gcp-preflight.sh --apply \
+  --project erp4-prod \
+  --confirm-project erp4-prod
+```
+
+この wrapper は secret値を読み取らず、Secret Manager の secret名と version metadata のみを確認する。
+
 ## 3. Google OIDC ログイン設定
 
 詳細手順は [google-oidc-google-cloud-console](google-oidc-google-cloud-console.md) を正とする。この Runbook では導入前の完了条件だけを管理する。
@@ -170,7 +194,14 @@ GDRIVE_CHECK_MODE=write \
   npx --prefix packages/backend ts-node --project packages/backend/tsconfig.json scripts/check-chat-gdrive.ts
 ```
 
-証跡には成功/失敗と時刻だけを残し、secret 値は残さない。
+wrapper を使う場合:
+
+```bash
+./scripts/ops/gcp-drive-check.sh --env-file ./.env.gdrive --mode read
+./scripts/ops/gcp-drive-check.sh --env-file ./.env.gdrive --mode write
+```
+
+`--mode write` はテストファイルを作成し、削除または trash する。証跡には成功/失敗と時刻だけを残し、secret 値は残さない。
 
 ## 5. Secrets 保管方針
 

--- a/docs/ops/index.md
+++ b/docs/ops/index.md
@@ -10,6 +10,7 @@
 
 - ローカル/PoC 起動: [deploy-start](deploy-start.md)
 - さくらVPS 導入 Runbook（本番準備レベル）: [sakura-vps-deployment](sakura-vps-deployment.md)
+  - 導入自動化スクリプト: [ops-automation](ops-automation.md)
   - Google Cloud 事前設定: [google-cloud-predeployment](google-cloud-predeployment.md)
   - Quadlet 詳細手順: [sakura-vps-podman-trial](sakura-vps-podman-trial.md)
   - env チェックリスト: [sakura-vps-env-checklist](sakura-vps-env-checklist.md)

--- a/docs/ops/ops-automation.md
+++ b/docs/ops/ops-automation.md
@@ -1,0 +1,220 @@
+# 導入自動化スクリプト Runbook
+
+## 目的
+
+さくらVPS導入と Google Cloud / Google Drive 事前確認を、手作業だけでなく再実行可能な補助スクリプトとして実行する。各スクリプトは安全側の既定値を採用し、`--check` / `--dry-run` と `--apply` を分離する。
+
+## スクリプト一覧
+
+| スクリプト                            | 目的                                                                                             | 既定の安全性                                                         |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `scripts/ops/sakura-vps-preflight.sh` | VPSのOS/arch/必須コマンド/メモリ/ディスク/port（80/443/3001/4173/8080/55432）/rootless前提を診断 | `--check` のみ。読み取り専用                                         |
+| `scripts/ops/sakura-vps-bootstrap.sh` | apt package、repo配置先、backup dir、linger、rootless low port設定を補助                         | 既定は `--check`。変更は `--apply` 明示時のみ                        |
+| `scripts/ops/sakura-vps-deploy.sh`    | git更新、`npm ci`、Quadlet build/install/start/updateを補助                                      | 既定は `--check`。実行は `--apply` 明示時のみ                        |
+| `scripts/ops/sakura-vps-verify.sh`    | Quadlet env/stack/HTTPS/Drive疎通を証跡化                                                        | 読み取り中心。Drive write test は `--gdrive-mode write` 明示時のみ   |
+| `scripts/ops/gcp-preflight.sh`        | gcloud account/project/API/billing/secret metadata/WIFを確認                                     | 既定は `--check`。API有効化は `--apply --confirm-project` 明示時のみ |
+| `scripts/ops/gcp-drive-check.sh`      | 既存 `check-chat-gdrive.ts` / `provision-chat-gdrive-folder.ts` の安全な wrapper                 | secret値は表示しない。write test は `--mode write` 明示時のみ        |
+
+## さくらVPS: 推奨実行順
+
+### 1. 事前診断
+
+```bash
+./scripts/ops/sakura-vps-preflight.sh --check
+```
+
+`--strict` を付けると、port 使用中などの警告も失敗として扱う。
+
+```bash
+./scripts/ops/sakura-vps-preflight.sh --check --strict
+```
+
+### 2. bootstrap dry-run
+
+```bash
+./scripts/ops/sakura-vps-bootstrap.sh --dry-run \
+  --deploy-user deploy \
+  --repo-dir /opt/itdo/ITDO_ERP4
+```
+
+実行内容を確認してから `--apply` に切り替える。
+
+```bash
+./scripts/ops/sakura-vps-bootstrap.sh --apply \
+  --deploy-user deploy \
+  --repo-dir /opt/itdo/ITDO_ERP4
+```
+
+Caddy を rootless Podman で 80/443 に bind する場合のみ、別途承認して low port 設定を入れる。
+
+```bash
+./scripts/ops/sakura-vps-bootstrap.sh --apply \
+  --deploy-user deploy \
+  --repo-dir /opt/itdo/ITDO_ERP4 \
+  --set-unprivileged-port-start
+```
+
+### 3. deploy check / dry-run / apply
+
+本番値を編集したあと、まず読み取り専用で検証する。
+
+```bash
+./scripts/ops/sakura-vps-deploy.sh --check \
+  --repo-dir /opt/itdo/ITDO_ERP4 \
+  --include-proxy
+```
+
+変更内容を確認する。
+
+```bash
+./scripts/ops/sakura-vps-deploy.sh --dry-run \
+  --repo-dir /opt/itdo/ITDO_ERP4 \
+  --branch main \
+  --include-proxy
+```
+
+初回起動:
+
+```bash
+./scripts/ops/sakura-vps-deploy.sh --apply \
+  --repo-dir /opt/itdo/ITDO_ERP4 \
+  --branch main \
+  --include-proxy
+```
+
+既存稼働中の更新では `--update-existing` を付ける。
+
+```bash
+./scripts/ops/sakura-vps-deploy.sh --apply \
+  --repo-dir /opt/itdo/ITDO_ERP4 \
+  --branch main \
+  --include-proxy \
+  --update-existing
+```
+
+### 4. verify / 証跡化
+
+```bash
+./scripts/ops/sakura-vps-verify.sh --check \
+  --include-proxy \
+  --markdown-summary docs/test-results/sakura-vps-verify-YYYY-MM-DD.md
+```
+
+DNS反映前に VPS IP へ解決させる場合:
+
+```bash
+./scripts/ops/sakura-vps-verify.sh --check \
+  --include-proxy \
+  --resolve-ip <VPS_IP>
+```
+
+Google Drive 連携を採用している場合は read test を加える。
+
+```bash
+./scripts/ops/sakura-vps-verify.sh --check \
+  --include-proxy \
+  --gdrive-mode read \
+  --markdown-summary docs/test-results/sakura-vps-verify-YYYY-MM-DD.md
+```
+
+`--gdrive-mode write` はテストファイルの作成/削除を伴うため、導入当日の Go/No-Go 判断時などに限定する。
+
+## Google Cloud: 推奨実行順
+
+### 1. preflight check
+
+```bash
+./scripts/ops/gcp-preflight.sh --check \
+  --project erp4-prod \
+  --secret erp4-google-oidc-client-secret \
+  --secret erp4-chat-gdrive-refresh-token \
+  --markdown-summary docs/test-results/gcp-preflight-YYYY-MM-DD.md
+```
+
+このコマンドは secret の値を読み取らず、secret metadata と version 状態のみを確認する。
+
+### 2. API有効化を自動化する場合
+
+`--apply` は不足APIの有効化だけを行う。project誤りを防ぐため、`--confirm-project` が `--project` と一致しない場合は停止する。
+
+```bash
+./scripts/ops/gcp-preflight.sh --apply \
+  --project erp4-prod \
+  --confirm-project erp4-prod
+```
+
+### 3. WIF / service account確認
+
+```bash
+./scripts/ops/gcp-preflight.sh --check \
+  --project erp4-prod \
+  --wif-pool github-actions \
+  --wif-provider github \
+  --wif-service-account erp4-deploy@erp4-prod.iam.gserviceaccount.com
+```
+
+### 4. Drive folder / read-write check
+
+初回 folder 作成:
+
+```bash
+./scripts/ops/gcp-drive-check.sh \
+  --env-file ./.env.gdrive \
+  --provision-folder \
+  --mode read
+```
+
+read test:
+
+```bash
+./scripts/ops/gcp-drive-check.sh --env-file ./.env.gdrive --mode read
+```
+
+write test:
+
+```bash
+./scripts/ops/gcp-drive-check.sh --env-file ./.env.gdrive --mode write
+```
+
+`.env.gdrive` には以下の値を置く。wrapper はこのうち許可された key だけを読み取り、任意の shell command としては実行しない。file mode は `chmod 600` を推奨する。
+
+```dotenv
+CHAT_ATTACHMENT_GDRIVE_CLIENT_ID=...
+CHAT_ATTACHMENT_GDRIVE_CLIENT_SECRET=...
+CHAT_ATTACHMENT_GDRIVE_REFRESH_TOKEN=...
+CHAT_ATTACHMENT_GDRIVE_FOLDER_ID=...
+```
+
+## 安全設計
+
+- destructive command（DB reset、OS再インストール、secret destroy）は含めない。
+- `--apply` なしで Google Cloud API 有効化やVPS変更は行わない。
+- secret値、refresh token、client secret、DB password は stdout/stderr へ出さない。
+- env file の file mode が緩い場合は warning を出す。
+- Drive write test は明示フラグ時のみ実行する。
+- rootless 80/443 用 sysctl は `--set-unprivileged-port-start` 明示時のみ変更する。
+
+## 品質チェック
+
+PR作成前に最低限以下を実行する。
+
+```bash
+bash -n scripts/ops/*.sh scripts/ops/lib/*.sh
+npx --prefix packages/backend prettier --check docs/ops/ops-automation.md docs/ops/google-cloud-predeployment.md docs/ops/sakura-vps-deployment.md docs/ops/index.md
+```
+
+`shellcheck` が利用可能な環境では以下も実行する。
+
+```bash
+shellcheck scripts/ops/*.sh scripts/ops/lib/*.sh
+```
+
+CI組み込みと dry-run の継続検証は Issue #1760 で扱う。
+
+## 関連Runbook
+
+- [google-cloud-predeployment](google-cloud-predeployment.md)
+- [sakura-vps-deployment](sakura-vps-deployment.md)
+- [sakura-vps-podman-trial](sakura-vps-podman-trial.md)
+- [sakura-vps-https-proxy](sakura-vps-https-proxy.md)
+- [secrets-and-access](secrets-and-access.md)

--- a/docs/ops/sakura-vps-deployment.md
+++ b/docs/ops/sakura-vps-deployment.md
@@ -22,6 +22,21 @@ ERP4 を 1 台のさくらVPSで小規模本番相当または長期試験稼働
 11. Go/No-Go 記録
 ```
 
+## 補助スクリプト
+
+手順漏れと証跡不足を抑えるため、以下の wrapper を利用できる。詳細は [ops-automation](ops-automation.md) を参照する。
+
+| フェーズ      | コマンド                                                                                                                          | 変更有無                      |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| 事前診断      | `./scripts/ops/sakura-vps-preflight.sh --check`                                                                                   | 読み取り専用                  |
+| bootstrap確認 | `./scripts/ops/sakura-vps-bootstrap.sh --dry-run --deploy-user deploy --repo-dir /opt/itdo/ITDO_ERP4`                             | 変更なし                      |
+| bootstrap実行 | `./scripts/ops/sakura-vps-bootstrap.sh --apply --deploy-user deploy --repo-dir /opt/itdo/ITDO_ERP4`                               | apt/install/dir/linger を変更 |
+| deploy確認    | `./scripts/ops/sakura-vps-deploy.sh --check --repo-dir /opt/itdo/ITDO_ERP4 --include-proxy`                                       | 読み取り専用                  |
+| deploy実行    | `./scripts/ops/sakura-vps-deploy.sh --apply --repo-dir /opt/itdo/ITDO_ERP4 --include-proxy`                                       | git/build/Quadlet を変更      |
+| 導入後確認    | `./scripts/ops/sakura-vps-verify.sh --check --include-proxy --markdown-summary docs/test-results/sakura-vps-verify-YYYY-MM-DD.md` | 読み取り中心                  |
+
+rootless Podman で Caddy を 80/443 に bind する sysctl 変更は、`sakura-vps-bootstrap.sh --apply --set-unprivileged-port-start` を明示した場合だけ実行する。DB reset やOS再インストールのような破壊的操作はこれらのスクリプトに含めない。
+
 ## 0. 導入前提
 
 | 項目          | 推奨値                    | 備考                                            |
@@ -170,6 +185,13 @@ podman --version
 node -v || true
 ```
 
+補助スクリプトで事前確認する場合:
+
+```bash
+./scripts/ops/sakura-vps-preflight.sh --check
+./scripts/ops/sakura-vps-bootstrap.sh --dry-run --deploy-user deploy --repo-dir /opt/itdo/ITDO_ERP4
+```
+
 Node.js は nvm または運用で選んだ方式で 20 LTS に固定する。
 
 ```bash
@@ -209,6 +231,13 @@ cd /opt/itdo/ITDO_ERP4
 git fetch origin main
 git checkout main
 git pull --ff-only origin main
+```
+
+更新を自動化する場合は、事前に `--dry-run` を確認してから `--apply --update-existing` を使う。
+
+```bash
+./scripts/ops/sakura-vps-deploy.sh --dry-run --repo-dir /opt/itdo/ITDO_ERP4 --include-proxy --update-existing
+./scripts/ops/sakura-vps-deploy.sh --apply --repo-dir /opt/itdo/ITDO_ERP4 --include-proxy --update-existing
 ```
 
 証跡:
@@ -305,6 +334,7 @@ Google OIDC / Drive を使う場合:
 - `/auth/google/start` から Google 認証へ遷移する。
 - callback後にERP4へ戻る。
 - `scripts/check-chat-gdrive.ts` の read/write が成功する。
+- wrapper として `./scripts/ops/gcp-drive-check.sh --mode read` / `--mode write` を使える。
 - 失敗時は [google-cloud-predeployment](google-cloud-predeployment.md) のトラブルシュートへ戻る。
 
 ## 9. backup / restore / rollback

--- a/scripts/ops/gcp-drive-check.sh
+++ b/scripts/ops/gcp-drive-check.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+MODE="read"
+DRY_RUN=0
+ENV_FILE=""
+PROVISION_FOLDER=0
+MARKDOWN_SUMMARY=""
+REQUIRED_ENV=(CHAT_ATTACHMENT_GDRIVE_CLIENT_ID CHAT_ATTACHMENT_GDRIVE_CLIENT_SECRET CHAT_ATTACHMENT_GDRIVE_REFRESH_TOKEN)
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Wrapper for ERP4 Google Drive setup checks. Secret values are never printed by this
+wrapper. --mode write creates and deletes/trashes a test file via scripts/check-chat-gdrive.ts.
+
+Options:
+  --mode read|write           Drive check mode (default: read)
+  --dry-run                   Print the command without executing it
+  --env-file FILE             Source env vars from FILE (warns if not chmod 600)
+  --provision-folder          Run scripts/provision-chat-gdrive-folder.ts first
+  --markdown-summary FILE     Write secret-free Markdown summary
+  -h, --help                  Show this help message
+USAGE
+}
+
+load_env_file() {
+  local key value
+  local allowed_env=(
+    CHAT_ATTACHMENT_GDRIVE_CLIENT_ID
+    CHAT_ATTACHMENT_GDRIVE_CLIENT_SECRET
+    CHAT_ATTACHMENT_GDRIVE_REFRESH_TOKEN
+    CHAT_ATTACHMENT_GDRIVE_FOLDER_ID
+    CHAT_ATTACHMENT_GDRIVE_FOLDER_NAME
+  )
+  [[ -n "$ENV_FILE" ]] || return 0
+  [[ -f "$ENV_FILE" ]] || ops_fail "env file not found: $ENV_FILE"
+  ops_check_private_file_mode "$ENV_FILE" || true
+  for key in "${allowed_env[@]}"; do
+    value="$(ops_read_env_value "$ENV_FILE" "$key")"
+    if [[ -n "$value" ]]; then
+      export "$key=$value"
+    fi
+  done
+}
+
+require_envs() {
+  local key value missing=0
+  for key in "${REQUIRED_ENV[@]}"; do
+    value="${!key:-}"
+    if [[ -z "${value// }" ]]; then
+      ops_error "missing required env: $key"
+      missing=1
+    else
+      ops_info "$key is set"
+    fi
+  done
+  if [[ "$PROVISION_FOLDER" -eq 0 ]]; then
+    value="${CHAT_ATTACHMENT_GDRIVE_FOLDER_ID:-}"
+    if [[ -z "${value// }" ]]; then
+      ops_error 'missing required env: CHAT_ATTACHMENT_GDRIVE_FOLDER_ID'
+      missing=1
+    else
+      ops_info "CHAT_ATTACHMENT_GDRIVE_FOLDER_ID is set"
+    fi
+  fi
+  [[ "$missing" -eq 0 ]] || exit 1
+}
+
+write_summary() {
+  [[ -n "$MARKDOWN_SUMMARY" ]] || return 0
+  {
+    printf '# ERP4 Google Drive check\n\n'
+    printf -- '- Date: `%s`\n' "$(ops_timestamp)"
+    printf -- '- Mode: `%s`\n' "$MODE"
+    printf -- '- Provision folder: `%s`\n' "$PROVISION_FOLDER"
+    printf -- '- Env file used: `%s`\n' "${ENV_FILE:-no}"
+    printf '\nSecret values are intentionally omitted.\n'
+  } > "$MARKDOWN_SUMMARY"
+}
+
+run_ts_node() {
+  local script="$1"
+  shift || true
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf '[ops][dry-run] '
+    ops_quote_command npx --prefix packages/backend ts-node --project packages/backend/tsconfig.json "$script" "$@"
+  else
+    (cd "$ROOT_DIR" && npx --prefix packages/backend ts-node --project packages/backend/tsconfig.json "$script" "$@")
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      ops_require_arg "$1" "${2:-}"
+      MODE="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --env-file)
+      ops_require_arg "$1" "${2:-}"
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    --provision-folder)
+      PROVISION_FOLDER=1
+      shift
+      ;;
+    --markdown-summary)
+      ops_require_arg "$1" "${2:-}"
+      MARKDOWN_SUMMARY="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      ops_fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+case "$MODE" in read|write) ;; *) ops_fail '--mode must be read or write' ;; esac
+load_env_file
+require_envs
+if [[ "$PROVISION_FOLDER" -eq 1 ]]; then
+  run_ts_node scripts/provision-chat-gdrive-folder.ts
+fi
+export GDRIVE_CHECK_MODE="$MODE"
+run_ts_node scripts/check-chat-gdrive.ts
+write_summary

--- a/scripts/ops/gcp-drive-check.sh
+++ b/scripts/ops/gcp-drive-check.sh
@@ -89,7 +89,9 @@ run_ts_node() {
   local script="$1"
   shift || true
   if [[ "$DRY_RUN" -eq 1 ]]; then
-    printf '[ops][dry-run] '
+    printf '[ops][dry-run] cd '
+    printf '%q' "$ROOT_DIR"
+    printf ' && '
     ops_quote_command npx --prefix packages/backend ts-node --project packages/backend/tsconfig.json "$script" "$@"
   else
     (cd "$ROOT_DIR" && npx --prefix packages/backend ts-node --project packages/backend/tsconfig.json "$script" "$@")

--- a/scripts/ops/gcp-preflight.sh
+++ b/scripts/ops/gcp-preflight.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+MODE="check"
+PROJECT="${GCP_PROJECT_ID:-}"
+CONFIRM_PROJECT=""
+BILLING_REQUIRED=0
+ALLOW_MISSING_GCLOUD=0
+MARKDOWN_SUMMARY=""
+WIF_POOL=""
+WIF_PROVIDER=""
+WIF_LOCATION="global"
+WIF_SERVICE_ACCOUNT=""
+REQUIRED_APIS=(drive.googleapis.com secretmanager.googleapis.com iamcredentials.googleapis.com serviceusage.googleapis.com)
+SECRET_NAMES=()
+SUMMARY_LINES=()
+WARNINGS=0
+FAILURES=0
+MISSING_APIS=()
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [--check | --apply] --project PROJECT [options]
+
+Google Cloud preflight for ERP4 Sakura VPS deployments. --check is read-only.
+--apply only enables missing APIs and requires --confirm-project PROJECT.
+Secret values are never read or printed.
+
+Options:
+  --check                         Read-only preflight (default)
+  --apply                         Enable missing required APIs only
+  --project PROJECT               Google Cloud project id
+  --confirm-project PROJECT       Required with --apply; must match --project
+  --api SERVICE                   Add required API service name; can be repeated
+  --secret NAME                   Check Secret Manager secret metadata; can be repeated
+  --billing-required              Fail when billing is not enabled or cannot be confirmed
+  --wif-pool POOL                 Workload Identity Pool id to check
+  --wif-provider PROVIDER         Workload Identity Provider id to check with --wif-pool
+  --wif-location LOCATION         WIF location (default: global)
+  --wif-service-account EMAIL     Service account used by WIF/GitHub Actions
+  --allow-missing-gcloud          Return success with skip summary when gcloud is missing
+  --markdown-summary FILE         Write secret-free Markdown summary
+  -h, --help                      Show this help message
+USAGE
+}
+
+add_summary() {
+  SUMMARY_LINES+=("$1")
+}
+
+ok() {
+  printf 'OK: %s\n' "$*"
+  add_summary "- ✅ $*"
+}
+
+warn() {
+  WARNINGS=$((WARNINGS + 1))
+  printf 'WARN: %s\n' "$*" >&2
+  add_summary "- ⚠️ $*"
+}
+
+fail_item() {
+  FAILURES=$((FAILURES + 1))
+  printf 'FAIL: %s\n' "$*" >&2
+  add_summary "- ❌ $*"
+}
+
+write_summary() {
+  [[ -n "$MARKDOWN_SUMMARY" ]] || return 0
+  {
+    printf '# ERP4 Google Cloud preflight\n\n'
+    printf -- '- Date: `%s`\n' "$(ops_timestamp)"
+    printf -- '- Project: `%s`\n' "${PROJECT:-unknown}"
+    printf -- '- Mode: `%s`\n\n' "$MODE"
+    printf '## Results\n\n'
+    printf '%s\n' "${SUMMARY_LINES[@]}"
+  } > "$MARKDOWN_SUMMARY"
+}
+
+require_gcloud() {
+  if ops_command_exists gcloud; then
+    return 0
+  fi
+  if [[ "$ALLOW_MISSING_GCLOUD" -eq 1 ]]; then
+    warn 'gcloud is not installed; skipped Google Cloud checks by explicit --allow-missing-gcloud'
+    write_summary
+    exit 0
+  fi
+  ops_fail 'gcloud is required; install Google Cloud CLI or use --allow-missing-gcloud only for local syntax/CI smoke checks'
+}
+
+resolve_project() {
+  local active_project
+  active_project="$(gcloud config get-value project 2>/dev/null || true)"
+  if [[ -z "$PROJECT" || "$PROJECT" == "(unset)" ]]; then
+    PROJECT="$active_project"
+  fi
+  [[ -n "$PROJECT" && "$PROJECT" != "(unset)" ]] || ops_fail '--project is required when no active gcloud project is set'
+  if [[ -n "$active_project" && "$active_project" != "(unset)" && "$active_project" != "$PROJECT" ]]; then
+    warn "active gcloud project ($active_project) differs from requested project ($PROJECT)"
+  else
+    ok "gcloud project confirmed: $PROJECT"
+  fi
+}
+
+check_account() {
+  local account
+  account="$(gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>/dev/null | head -n 1 || true)"
+  if [[ -z "$account" ]]; then
+    fail_item 'no active gcloud account; run gcloud auth login or configure workload identity'
+  else
+    ok "active gcloud account: $account"
+  fi
+}
+
+check_billing() {
+  local billing
+  billing="$(gcloud billing projects describe "$PROJECT" --format='value(billingEnabled)' 2>/dev/null || true)"
+  if [[ "$billing" == "True" || "$billing" == "true" ]]; then
+    ok 'billing enabled'
+  elif [[ "$BILLING_REQUIRED" -eq 1 ]]; then
+    fail_item 'billing is not enabled or cannot be confirmed'
+  else
+    warn 'billing is not enabled or cannot be confirmed; confirm manually if paid APIs are required'
+  fi
+}
+
+load_enabled_apis() {
+  gcloud services list --enabled --project "$PROJECT" --format='value(config.name)' 2>/dev/null || true
+}
+
+check_apis() {
+  local enabled api found
+  enabled="$(load_enabled_apis)"
+  for api in "${REQUIRED_APIS[@]}"; do
+    found=0
+    if grep -Fxq "$api" <<<"$enabled"; then
+      found=1
+    fi
+    if [[ "$found" -eq 1 ]]; then
+      ok "API enabled: $api"
+    else
+      MISSING_APIS+=("$api")
+      if [[ "$MODE" == "apply" ]]; then
+        warn "API will be enabled by --apply: $api"
+      else
+        fail_item "API not enabled: $api"
+      fi
+    fi
+  done
+}
+
+apply_missing_apis() {
+  if [[ "${#MISSING_APIS[@]}" -eq 0 ]]; then
+    return 0
+  fi
+  [[ "$MODE" == "apply" ]] || return 0
+  [[ -n "$CONFIRM_PROJECT" && "$CONFIRM_PROJECT" == "$PROJECT" ]] || ops_fail '--apply requires --confirm-project matching --project'
+  ops_run apply gcloud services enable --project "$PROJECT" "${MISSING_APIS[@]}"
+  MISSING_APIS=()
+  SUMMARY_LINES+=("- ✅ enabled missing APIs with explicit --apply for project $PROJECT")
+  check_apis
+}
+
+check_secret() {
+  local name="$1" states
+  if gcloud secrets describe "$name" --project "$PROJECT" --format='value(name)' >/dev/null 2>&1; then
+    ok "secret exists: $name"
+    states="$(gcloud secrets versions list "$name" --project "$PROJECT" --format='value(name,state)' 2>/dev/null | tr '\n' ';' || true)"
+    if [[ -n "$states" ]]; then
+      ok "secret versions metadata available: $name"
+    else
+      warn "secret has no visible versions or versions cannot be listed: $name"
+    fi
+  else
+    fail_item "secret not found or not accessible: $name"
+  fi
+}
+
+check_wif() {
+  if [[ -n "$WIF_SERVICE_ACCOUNT" ]]; then
+    if gcloud iam service-accounts describe "$WIF_SERVICE_ACCOUNT" --project "$PROJECT" --format='value(email)' >/dev/null 2>&1; then
+      ok "WIF service account exists: $WIF_SERVICE_ACCOUNT"
+    else
+      fail_item "WIF service account not found or not accessible: $WIF_SERVICE_ACCOUNT"
+    fi
+  fi
+  if [[ -n "$WIF_POOL" || -n "$WIF_PROVIDER" ]]; then
+    [[ -n "$WIF_POOL" && -n "$WIF_PROVIDER" ]] || ops_fail '--wif-pool and --wif-provider must be provided together'
+    if gcloud iam workload-identity-pools providers describe "$WIF_PROVIDER" --project "$PROJECT" --location "$WIF_LOCATION" --workload-identity-pool "$WIF_POOL" --format='value(name)' >/dev/null 2>&1; then
+      ok "WIF provider exists: pool=$WIF_POOL provider=$WIF_PROVIDER location=$WIF_LOCATION"
+    else
+      fail_item "WIF provider not found or not accessible: pool=$WIF_POOL provider=$WIF_PROVIDER location=$WIF_LOCATION"
+    fi
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      MODE="check"
+      shift
+      ;;
+    --apply)
+      MODE="apply"
+      shift
+      ;;
+    --project)
+      ops_require_arg "$1" "${2:-}"
+      PROJECT="$2"
+      shift 2
+      ;;
+    --confirm-project)
+      ops_require_arg "$1" "${2:-}"
+      CONFIRM_PROJECT="$2"
+      shift 2
+      ;;
+    --api)
+      ops_require_arg "$1" "${2:-}"
+      REQUIRED_APIS+=("$2")
+      shift 2
+      ;;
+    --secret)
+      ops_require_arg "$1" "${2:-}"
+      SECRET_NAMES+=("$2")
+      shift 2
+      ;;
+    --billing-required)
+      BILLING_REQUIRED=1
+      shift
+      ;;
+    --wif-pool)
+      ops_require_arg "$1" "${2:-}"
+      WIF_POOL="$2"
+      shift 2
+      ;;
+    --wif-provider)
+      ops_require_arg "$1" "${2:-}"
+      WIF_PROVIDER="$2"
+      shift 2
+      ;;
+    --wif-location)
+      ops_require_arg "$1" "${2:-}"
+      WIF_LOCATION="$2"
+      shift 2
+      ;;
+    --wif-service-account)
+      ops_require_arg "$1" "${2:-}"
+      WIF_SERVICE_ACCOUNT="$2"
+      shift 2
+      ;;
+    --allow-missing-gcloud)
+      ALLOW_MISSING_GCLOUD=1
+      shift
+      ;;
+    --markdown-summary)
+      ops_require_arg "$1" "${2:-}"
+      MARKDOWN_SUMMARY="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      ops_fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+require_gcloud
+resolve_project
+check_account
+check_billing
+check_apis
+apply_missing_apis
+for secret in "${SECRET_NAMES[@]}"; do
+  check_secret "$secret"
+done
+check_wif
+write_summary
+printf 'Summary: failures=%s warnings=%s missingApis=%s\n' "$FAILURES" "$WARNINGS" "${#MISSING_APIS[@]}"
+if (( FAILURES > 0 )); then
+  exit 1
+fi

--- a/scripts/ops/lib/common.sh
+++ b/scripts/ops/lib/common.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Shared helpers for ERP4 ops automation scripts.
+
+if [[ -n "${ERP4_OPS_COMMON_SOURCED:-}" ]]; then
+  return 0
+fi
+ERP4_OPS_COMMON_SOURCED=1
+
+ops_timestamp() {
+  date -u +'%Y-%m-%dT%H:%M:%SZ'
+}
+
+ops_info() {
+  printf '[ops][info] %s\n' "$*"
+}
+
+ops_warn() {
+  printf '[ops][warn] %s\n' "$*" >&2
+}
+
+ops_error() {
+  printf '[ops][error] %s\n' "$*" >&2
+}
+
+ops_fail() {
+  ops_error "$*"
+  exit 1
+}
+
+ops_require_arg() {
+  local option="$1"
+  local value="${2:-}"
+  [[ -n "$value" ]] || ops_fail "$option requires a non-empty argument"
+}
+
+ops_command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+ops_quote_command() {
+  local first=1
+  local arg
+  for arg in "$@"; do
+    if [[ "$first" -eq 0 ]]; then
+      printf ' '
+    fi
+    printf '%q' "$arg"
+    first=0
+  done
+  printf '\n'
+}
+
+ops_run() {
+  local mode="$1"
+  shift
+  if [[ "$mode" == "dry-run" ]]; then
+    printf '[ops][dry-run] '
+    ops_quote_command "$@"
+    return 0
+  fi
+  printf '[ops][run] '
+  ops_quote_command "$@"
+  "$@"
+}
+
+ops_is_positive_integer() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]]
+}
+
+ops_read_env_value() {
+  local file="$1"
+  local key="$2"
+  awk -v key="$key" '
+    $0 ~ /^[[:space:]]*#/ { next }
+    $0 ~ /^[[:space:]]*$/ { next }
+    {
+      pos = index($0, "=")
+      if (pos == 0) next
+      k = substr($0, 1, pos - 1)
+      sub(/^[[:space:]]+/, "", k)
+      sub(/[[:space:]]+$/, "", k)
+      if (k == key) {
+        v = substr($0, pos + 1)
+        sub(/^[[:space:]]+/, "", v)
+        sub(/[[:space:]]+$/, "", v)
+        gsub(/^"|"$/, "", v)
+        print v
+        exit
+      }
+    }
+  ' "$file"
+}
+
+ops_mask_tail() {
+  local value="${1:-}"
+  local keep="${2:-4}"
+  if [[ -z "$value" ]]; then
+    printf '<empty>\n'
+  elif (( ${#value} <= keep )); then
+    printf '***\n'
+  else
+    printf '***%s\n' "${value: -keep}"
+  fi
+}
+
+ops_check_private_file_mode() {
+  local file="$1"
+  local mode
+  [[ -e "$file" ]] || return 0
+  mode="$(stat -c '%a' "$file" 2>/dev/null || stat -f '%Lp' "$file" 2>/dev/null || true)"
+  [[ -n "$mode" ]] || return 0
+  if (( 10#$mode > 600 )); then
+    ops_warn "$file should normally be chmod 600 or stricter (current: $mode)"
+    return 1
+  fi
+  return 0
+}

--- a/scripts/ops/lib/common.sh
+++ b/scripts/ops/lib/common.sh
@@ -109,8 +109,8 @@ ops_check_private_file_mode() {
   [[ -e "$file" ]] || return 0
   mode="$(stat -c '%a' "$file" 2>/dev/null || stat -f '%Lp' "$file" 2>/dev/null || true)"
   [[ -n "$mode" ]] || return 0
-  if (( 10#$mode > 600 )); then
-    ops_warn "$file should normally be chmod 600 or stricter (current: $mode)"
+  if (( (8#$mode & 8#077) != 0 )); then
+    ops_warn "$file should not be readable, writable, or executable by group/other (current: $mode)"
     return 1
   fi
   return 0

--- a/scripts/ops/sakura-vps-bootstrap.sh
+++ b/scripts/ops/sakura-vps-bootstrap.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+MODE="check"
+DEPLOY_USER="${ERP4_DEPLOY_USER:-deploy}"
+REPO_PARENT="${ERP4_REPO_PARENT:-/opt/itdo}"
+REPO_DIR="${ERP4_REPO_DIR:-/opt/itdo/ITDO_ERP4}"
+SKIP_APT=0
+SKIP_LINGER=0
+SET_LOW_PORTS=0
+PACKAGES=(git curl jq make ca-certificates unzip ufw fail2ban unattended-upgrades podman uidmap slirp4netns passt fuse-overlayfs)
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [--check | --dry-run | --apply] [options]
+
+Bootstrap helper for a Sakura VPS host. --check and --dry-run do not modify the host.
+--apply can install packages, create directories, and enable linger; low-port sysctl changes
+require the additional --set-unprivileged-port-start flag.
+
+Options:
+  --check                         Validate current host state only (default)
+  --dry-run                       Print commands that would be executed
+  --apply                         Execute non-destructive bootstrap steps
+  --deploy-user USER              Deploy user for ownership/linger (default: $DEPLOY_USER)
+  --repo-parent DIR               Parent directory for repository (default: $REPO_PARENT)
+  --repo-dir DIR                  Repository path for evidence output (default: $REPO_DIR)
+  --skip-apt                      Skip apt update/install
+  --skip-linger                   Skip loginctl enable-linger
+  --set-unprivileged-port-start   With --apply, set net.ipv4.ip_unprivileged_port_start=80
+  -h, --help                      Show this help message
+USAGE
+}
+
+require_sudo_for_apply() {
+  if [[ "$MODE" == "apply" ]] && ! sudo -n true 2>/dev/null; then
+    ops_warn 'sudo may prompt for a password during --apply'
+  fi
+}
+
+check_state() {
+  printf '# ERP4 Sakura VPS bootstrap check (%s)\n' "$(ops_timestamp)"
+  printf 'deploy_user=%s\nrepo_parent=%s\nrepo_dir=%s\n' "$DEPLOY_USER" "$REPO_PARENT" "$REPO_DIR"
+  if id "$DEPLOY_USER" >/dev/null 2>&1; then
+    ops_info "deploy user exists: $DEPLOY_USER"
+  else
+    ops_warn "deploy user does not exist yet: $DEPLOY_USER"
+  fi
+  if [[ -d "$REPO_PARENT" ]]; then
+    ops_info "repo parent exists: $REPO_PARENT"
+  else
+    ops_warn "repo parent does not exist yet: $REPO_PARENT"
+  fi
+  for cmd in sudo apt-get install loginctl podman git curl; do
+    if ops_command_exists "$cmd"; then
+      ops_info "command available: $cmd"
+    else
+      ops_warn "command not found: $cmd"
+    fi
+  done
+  "$SCRIPT_DIR/sakura-vps-preflight.sh" --check --repo-dir "$(dirname "$REPO_PARENT")" || true
+}
+
+run_apply_or_dry_run() {
+  require_sudo_for_apply
+
+  if [[ "$SKIP_APT" -eq 0 ]]; then
+    ops_run "$MODE" sudo apt-get update
+    ops_run "$MODE" sudo apt-get install -y "${PACKAGES[@]}"
+  else
+    ops_info 'skipping apt package installation'
+  fi
+
+  ops_run "$MODE" sudo install -d -m 0775 -o "$DEPLOY_USER" -g "$DEPLOY_USER" "$REPO_PARENT"
+  ops_run "$MODE" install -d -m 0700 "$HOME/.local/share/erp4" "$HOME/.local/share/erp4/quadlet-backups" "$HOME/.local/share/erp4/db-backups"
+
+  if [[ "$SKIP_LINGER" -eq 0 ]]; then
+    ops_run "$MODE" sudo loginctl enable-linger "$DEPLOY_USER"
+  else
+    ops_info 'skipping loginctl enable-linger'
+  fi
+
+  if [[ "$SET_LOW_PORTS" -eq 1 ]]; then
+    if [[ "$MODE" == "dry-run" ]]; then
+      printf '[ops][dry-run] echo %q | sudo tee /etc/sysctl.d/90-itdo-rootless-ports.conf\n' 'net.ipv4.ip_unprivileged_port_start=80'
+    else
+      printf 'net.ipv4.ip_unprivileged_port_start=80\n' | sudo tee /etc/sysctl.d/90-itdo-rootless-ports.conf >/dev/null
+    fi
+    ops_run "$MODE" sudo sysctl --system
+  else
+    ops_warn 'not changing net.ipv4.ip_unprivileged_port_start; pass --set-unprivileged-port-start with --apply only after confirming rootless 80/443 requirements'
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      MODE="check"
+      shift
+      ;;
+    --dry-run)
+      MODE="dry-run"
+      shift
+      ;;
+    --apply)
+      MODE="apply"
+      shift
+      ;;
+    --deploy-user)
+      ops_require_arg "$1" "${2:-}"
+      DEPLOY_USER="$2"
+      shift 2
+      ;;
+    --repo-parent)
+      ops_require_arg "$1" "${2:-}"
+      REPO_PARENT="$2"
+      shift 2
+      ;;
+    --repo-dir)
+      ops_require_arg "$1" "${2:-}"
+      REPO_DIR="$2"
+      REPO_PARENT="$(dirname "$2")"
+      shift 2
+      ;;
+    --skip-apt)
+      SKIP_APT=1
+      shift
+      ;;
+    --skip-linger)
+      SKIP_LINGER=1
+      shift
+      ;;
+    --set-unprivileged-port-start)
+      SET_LOW_PORTS=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      ops_fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+case "$MODE" in
+  check)
+    check_state
+    ;;
+  dry-run|apply)
+    run_apply_or_dry_run
+    ;;
+  *)
+    ops_fail "unknown mode: $MODE"
+    ;;
+esac

--- a/scripts/ops/sakura-vps-deploy.sh
+++ b/scripts/ops/sakura-vps-deploy.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+MODE="check"
+REPO_DIR="${ERP4_REPO_DIR:-$ROOT_DIR}"
+REMOTE="${ERP4_GIT_REMOTE:-origin}"
+BRANCH="${ERP4_GIT_BRANCH:-main}"
+TARGET_DIR="${QUADLET_TARGET_DIR:-$HOME/.config/containers/systemd}"
+FRONTEND_BUILD_ENV="${FRONTEND_BUILD_ENV_FILE:-$REPO_DIR/deploy/quadlet/env/erp4-frontend-build.env}"
+INCLUDE_PROXY=0
+SKIP_NPM_CI=0
+SKIP_BUILD_IMAGES=0
+SKIP_START=0
+SKIP_GIT_UPDATE=0
+UPDATE_EXISTING=0
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [--check | --dry-run | --apply] [options]
+
+Deploy/update helper for ERP4 on Sakura VPS. --check validates prerequisites only.
+--dry-run prints commands. --apply performs git update, dependency install, image build,
+Quadlet install, and stack start/update unless skipped.
+
+Options:
+  --check                         Validate repo/env without changing state (default)
+  --dry-run                       Print commands that would be executed
+  --apply                         Execute deployment steps
+  --repo-dir DIR                  Repository directory (default: $REPO_DIR)
+  --remote NAME                   Git remote (default: $REMOTE)
+  --branch NAME                   Git branch (default: $BRANCH)
+  --target-dir DIR                Quadlet target directory (default: $TARGET_DIR)
+  --frontend-build-env FILE       Frontend build env file
+  --include-proxy                 Include Caddy/proxy validation and start/update
+  --update-existing               Use scripts/quadlet/update-stack.sh instead of start-stack.sh
+  --skip-git-update               Do not run git fetch/checkout/pull
+  --skip-npm-ci                   Do not run npm ci for backend/frontend
+  --skip-build-images             Do not build Podman images
+  --skip-start                    Do not install/start/update Quadlet units
+  -h, --help                      Show this help message
+USAGE
+}
+
+check_no_placeholders() {
+  local file="$1"
+  [[ -f "$file" ]] || ops_fail "required file not found: $file"
+  if grep -Eq 'REPLACE_ME|REPLACE_WITH|YOUR_|example\.com' "$file"; then
+    ops_fail "$file still contains placeholder values"
+  fi
+  ops_check_private_file_mode "$file" || true
+}
+
+run_check() {
+  printf '# ERP4 Sakura VPS deploy check (%s)\n' "$(ops_timestamp)"
+  [[ -d "$REPO_DIR/.git" ]] || ops_fail "repo-dir is not a git checkout: $REPO_DIR"
+  ops_info "repo HEAD: $(git -C "$REPO_DIR" rev-parse --short HEAD)"
+  git -C "$REPO_DIR" status --short --branch
+
+  check_no_placeholders "$FRONTEND_BUILD_ENV"
+  check_no_placeholders "$TARGET_DIR/erp4-postgres.env"
+  check_no_placeholders "$TARGET_DIR/erp4-backend.env"
+  if [[ "$INCLUDE_PROXY" -eq 1 ]]; then
+    check_no_placeholders "$TARGET_DIR/erp4-caddy.env"
+    [[ -f "$TARGET_DIR/erp4-caddy.Caddyfile" ]] || ops_fail "required file not found: $TARGET_DIR/erp4-caddy.Caddyfile"
+  fi
+  if [[ -f "$TARGET_DIR/erp4-maintenance.env" ]]; then
+    check_no_placeholders "$TARGET_DIR/erp4-maintenance.env"
+  else
+    ops_warn "maintenance env not found yet: $TARGET_DIR/erp4-maintenance.env"
+  fi
+
+  "$REPO_DIR/scripts/quadlet/check-env.sh" --target-dir "$TARGET_DIR" --frontend-build-env "$FRONTEND_BUILD_ENV"
+  if [[ "$INCLUDE_PROXY" -eq 1 ]]; then
+    "$REPO_DIR/scripts/quadlet/check-proxy.sh" --target-dir "$TARGET_DIR"
+    "$REPO_DIR/scripts/quadlet/check-host-prereqs.sh"
+  fi
+}
+
+run_deploy() {
+  if [[ "$SKIP_GIT_UPDATE" -eq 0 ]]; then
+    ops_run "$MODE" git -C "$REPO_DIR" fetch "$REMOTE" "$BRANCH"
+    ops_run "$MODE" git -C "$REPO_DIR" checkout "$BRANCH"
+    ops_run "$MODE" git -C "$REPO_DIR" pull --ff-only "$REMOTE" "$BRANCH"
+  fi
+
+  if [[ "$SKIP_NPM_CI" -eq 0 ]]; then
+    ops_run "$MODE" npm ci --prefix "$REPO_DIR/packages/backend"
+    ops_run "$MODE" npm ci --prefix "$REPO_DIR/packages/frontend"
+  fi
+
+  ops_run "$MODE" "$REPO_DIR/scripts/quadlet/check-env.sh" --skip-runtime --frontend-build-env "$FRONTEND_BUILD_ENV"
+  if [[ "$SKIP_BUILD_IMAGES" -eq 0 ]]; then
+    ops_run "$MODE" "$REPO_DIR/scripts/quadlet/build-images.sh"
+  fi
+
+  if [[ "$SKIP_START" -eq 0 ]]; then
+    ops_run "$MODE" "$REPO_DIR/scripts/quadlet/install-user-units.sh"
+    local stack_cmd
+    if [[ "$UPDATE_EXISTING" -eq 1 ]]; then
+      stack_cmd="$REPO_DIR/scripts/quadlet/update-stack.sh"
+      if [[ "$INCLUDE_PROXY" -eq 1 ]]; then
+        ops_run "$MODE" "$stack_cmd" --include-proxy --skip-build
+      else
+        ops_run "$MODE" "$stack_cmd" --skip-build
+      fi
+    else
+      stack_cmd="$REPO_DIR/scripts/quadlet/start-stack.sh"
+      if [[ "$INCLUDE_PROXY" -eq 1 ]]; then
+        ops_run "$MODE" "$stack_cmd" --include-proxy
+      else
+        ops_run "$MODE" "$stack_cmd"
+      fi
+    fi
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      MODE="check"
+      shift
+      ;;
+    --dry-run)
+      MODE="dry-run"
+      shift
+      ;;
+    --apply)
+      MODE="apply"
+      shift
+      ;;
+    --repo-dir)
+      ops_require_arg "$1" "${2:-}"
+      REPO_DIR="$2"
+      FRONTEND_BUILD_ENV="${FRONTEND_BUILD_ENV_FILE:-$REPO_DIR/deploy/quadlet/env/erp4-frontend-build.env}"
+      shift 2
+      ;;
+    --remote)
+      ops_require_arg "$1" "${2:-}"
+      REMOTE="$2"
+      shift 2
+      ;;
+    --branch)
+      ops_require_arg "$1" "${2:-}"
+      BRANCH="$2"
+      shift 2
+      ;;
+    --target-dir)
+      ops_require_arg "$1" "${2:-}"
+      TARGET_DIR="$2"
+      shift 2
+      ;;
+    --frontend-build-env)
+      ops_require_arg "$1" "${2:-}"
+      FRONTEND_BUILD_ENV="$2"
+      shift 2
+      ;;
+    --include-proxy)
+      INCLUDE_PROXY=1
+      shift
+      ;;
+    --update-existing)
+      UPDATE_EXISTING=1
+      shift
+      ;;
+    --skip-git-update)
+      SKIP_GIT_UPDATE=1
+      shift
+      ;;
+    --skip-npm-ci)
+      SKIP_NPM_CI=1
+      shift
+      ;;
+    --skip-build-images)
+      SKIP_BUILD_IMAGES=1
+      shift
+      ;;
+    --skip-start)
+      SKIP_START=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      ops_fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+case "$MODE" in
+  check)
+    run_check
+    ;;
+  dry-run|apply)
+    run_deploy
+    ;;
+  *)
+    ops_fail "unknown mode: $MODE"
+    ;;
+esac

--- a/scripts/ops/sakura-vps-deploy.sh
+++ b/scripts/ops/sakura-vps-deploy.sh
@@ -95,25 +95,25 @@ run_deploy() {
 
   ops_run "$MODE" "$REPO_DIR/scripts/quadlet/check-env.sh" --skip-runtime --frontend-build-env "$FRONTEND_BUILD_ENV"
   if [[ "$SKIP_BUILD_IMAGES" -eq 0 ]]; then
-    ops_run "$MODE" "$REPO_DIR/scripts/quadlet/build-images.sh"
+    ops_run "$MODE" env FRONTEND_BUILD_ENV_FILE="$FRONTEND_BUILD_ENV" "$REPO_DIR/scripts/quadlet/build-images.sh"
   fi
 
   if [[ "$SKIP_START" -eq 0 ]]; then
-    ops_run "$MODE" "$REPO_DIR/scripts/quadlet/install-user-units.sh"
+    ops_run "$MODE" env QUADLET_TARGET_DIR="$TARGET_DIR" "$REPO_DIR/scripts/quadlet/install-user-units.sh"
     local stack_cmd
     if [[ "$UPDATE_EXISTING" -eq 1 ]]; then
       stack_cmd="$REPO_DIR/scripts/quadlet/update-stack.sh"
       if [[ "$INCLUDE_PROXY" -eq 1 ]]; then
-        ops_run "$MODE" "$stack_cmd" --include-proxy --skip-build
+        ops_run "$MODE" env QUADLET_TARGET_DIR="$TARGET_DIR" "$stack_cmd" --include-proxy --skip-build
       else
-        ops_run "$MODE" "$stack_cmd" --skip-build
+        ops_run "$MODE" env QUADLET_TARGET_DIR="$TARGET_DIR" "$stack_cmd" --skip-build
       fi
     else
       stack_cmd="$REPO_DIR/scripts/quadlet/start-stack.sh"
       if [[ "$INCLUDE_PROXY" -eq 1 ]]; then
-        ops_run "$MODE" "$stack_cmd" --include-proxy
+        ops_run "$MODE" env QUADLET_TARGET_DIR="$TARGET_DIR" "$stack_cmd" --include-proxy
       else
-        ops_run "$MODE" "$stack_cmd"
+        ops_run "$MODE" env QUADLET_TARGET_DIR="$TARGET_DIR" "$stack_cmd"
       fi
     fi
   fi

--- a/scripts/ops/sakura-vps-deploy.sh
+++ b/scripts/ops/sakura-vps-deploy.sh
@@ -93,7 +93,7 @@ run_deploy() {
     ops_run "$MODE" npm ci --prefix "$REPO_DIR/packages/frontend"
   fi
 
-  ops_run "$MODE" "$REPO_DIR/scripts/quadlet/check-env.sh" --skip-runtime --frontend-build-env "$FRONTEND_BUILD_ENV"
+  ops_run "$MODE" env QUADLET_TARGET_DIR="$TARGET_DIR" "$REPO_DIR/scripts/quadlet/check-env.sh" --target-dir "$TARGET_DIR" --skip-runtime --frontend-build-env "$FRONTEND_BUILD_ENV"
   if [[ "$SKIP_BUILD_IMAGES" -eq 0 ]]; then
     ops_run "$MODE" env FRONTEND_BUILD_ENV_FILE="$FRONTEND_BUILD_ENV" "$REPO_DIR/scripts/quadlet/build-images.sh"
   fi

--- a/scripts/ops/sakura-vps-preflight.sh
+++ b/scripts/ops/sakura-vps-preflight.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+MODE="check"
+STRICT=0
+MIN_MEMORY_MB=1900
+MIN_DISK_MB=10240
+REPO_DIR="${ERP4_REPO_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+PORTS=(80 443 3001 4173 8080 55432)
+REQUIRED_COMMANDS=(git curl jq make podman node npm systemctl loginctl)
+WARNINGS=0
+FAILURES=0
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [--check] [options]
+
+Read-only diagnostics for Sakura VPS hosts before ERP4 bootstrap/deploy.
+
+Options:
+  --check                 Run diagnostics only (default)
+  --strict                Treat warnings such as bound ports as failures
+  --repo-dir DIR          Directory used for disk-space checks (default: current repo)
+  --min-memory-mb N       Recommended memory threshold (default: $MIN_MEMORY_MB)
+  --min-disk-mb N         Recommended free disk threshold (default: $MIN_DISK_MB)
+  --port PORT             Add a TCP port to availability checks; can be repeated
+  -h, --help              Show this help message
+USAGE
+}
+
+record_ok() {
+  printf 'OK: %s\n' "$*"
+}
+
+record_warn() {
+  WARNINGS=$((WARNINGS + 1))
+  printf 'WARN: %s\n' "$*" >&2
+}
+
+record_fail() {
+  FAILURES=$((FAILURES + 1))
+  printf 'FAIL: %s\n' "$*" >&2
+}
+
+check_command() {
+  local cmd="$1"
+  if ops_command_exists "$cmd"; then
+    record_ok "command available: $cmd"
+  else
+    record_fail "required command not found: $cmd"
+  fi
+}
+
+check_os() {
+  local os_id="unknown" version_id="unknown" pretty="unknown"
+  if [[ -r /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    source /etc/os-release
+    os_id="${ID:-unknown}"
+    version_id="${VERSION_ID:-unknown}"
+    pretty="${PRETTY_NAME:-$os_id $version_id}"
+  fi
+  record_ok "OS: $pretty"
+  if [[ "$os_id" != "ubuntu" ]]; then
+    record_warn "Ubuntu 24.04 LTS is the documented baseline; current ID is $os_id"
+  elif [[ "$version_id" != "24.04" && "$version_id" != "22.04" ]]; then
+    record_warn "Ubuntu 24.04 LTS is recommended; current version is $version_id"
+  fi
+}
+
+check_arch() {
+  local arch
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64|aarch64|arm64)
+      record_ok "architecture: $arch"
+      ;;
+    *)
+      record_warn "untested architecture: $arch"
+      ;;
+  esac
+}
+
+check_memory() {
+  local mem_kb mem_mb
+  if [[ ! -r /proc/meminfo ]]; then
+    record_warn 'cannot read /proc/meminfo'
+    return
+  fi
+  mem_kb="$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)"
+  mem_mb=$((mem_kb / 1024))
+  if (( mem_mb < MIN_MEMORY_MB )); then
+    record_warn "memory is below recommendation: ${mem_mb}MB < ${MIN_MEMORY_MB}MB"
+  else
+    record_ok "memory: ${mem_mb}MB"
+  fi
+}
+
+check_disk() {
+  local free_mb mount
+  if [[ ! -d "$REPO_DIR" ]]; then
+    record_warn "repo-dir does not exist yet: $REPO_DIR"
+    return
+  fi
+  free_mb="$(df -Pm "$REPO_DIR" | awk 'NR == 2 {print $4}')"
+  mount="$(df -Pm "$REPO_DIR" | awk 'NR == 2 {print $6}')"
+  if [[ -z "$free_mb" ]]; then
+    record_warn "cannot determine free disk for $REPO_DIR"
+  elif (( free_mb < MIN_DISK_MB )); then
+    record_warn "free disk is below recommendation on $mount: ${free_mb}MB < ${MIN_DISK_MB}MB"
+  else
+    record_ok "free disk on $mount: ${free_mb}MB"
+  fi
+}
+
+check_port() {
+  local port="$1" output=""
+  if ops_command_exists ss; then
+    output="$(ss -ltnH "( sport = :$port )" 2>/dev/null || true)"
+  elif ops_command_exists netstat; then
+    output="$(netstat -ltn 2>/dev/null | awk -v port="$port" '
+      NR > 2 {
+        local_address = $4
+        local_port = local_address
+        sub(/^.*:/, "", local_port)
+        if (local_port == port) print
+      }
+    ' || true)"
+  else
+    record_warn 'neither ss nor netstat is available; skipping port diagnostics'
+    return
+  fi
+
+  if [[ -n "$output" ]]; then
+    if [[ "$STRICT" -eq 1 ]]; then
+      record_fail "TCP $port is already bound"
+    else
+      record_warn "TCP $port is already bound"
+    fi
+    printf '%s\n' "$output" >&2
+  else
+    record_ok "TCP $port is free"
+  fi
+}
+
+check_linger() {
+  local user output
+  if ! ops_command_exists loginctl; then
+    record_warn 'loginctl not found; cannot check user linger'
+    return
+  fi
+  user="$(id -un)"
+  if output="$(loginctl show-user "$user" --property=Linger --value 2>/dev/null)" && [[ "$output" == "yes" ]]; then
+    record_ok "loginctl linger enabled for $user"
+  else
+    record_warn "loginctl enable-linger $user is not enabled or cannot be queried"
+  fi
+}
+
+check_unprivileged_ports() {
+  local value
+  if ! ops_command_exists sysctl; then
+    record_warn 'sysctl not found; cannot check rootless low-port setting'
+    return
+  fi
+  value="$(sysctl -n net.ipv4.ip_unprivileged_port_start 2>/dev/null || true)"
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    record_warn 'cannot read net.ipv4.ip_unprivileged_port_start'
+  elif (( value > 80 )); then
+    record_warn "rootless Podman cannot bind 80/443 until net.ipv4.ip_unprivileged_port_start is 80 or lower (current: $value)"
+  else
+    record_ok "net.ipv4.ip_unprivileged_port_start=$value"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      MODE="check"
+      shift
+      ;;
+    --strict)
+      STRICT=1
+      shift
+      ;;
+    --repo-dir)
+      ops_require_arg "$1" "${2:-}"
+      REPO_DIR="$2"
+      shift 2
+      ;;
+    --min-memory-mb)
+      ops_require_arg "$1" "${2:-}"
+      ops_is_positive_integer "$2" || ops_fail '--min-memory-mb must be a positive integer'
+      MIN_MEMORY_MB="$2"
+      shift 2
+      ;;
+    --min-disk-mb)
+      ops_require_arg "$1" "${2:-}"
+      ops_is_positive_integer "$2" || ops_fail '--min-disk-mb must be a positive integer'
+      MIN_DISK_MB="$2"
+      shift 2
+      ;;
+    --port)
+      ops_require_arg "$1" "${2:-}"
+      [[ "$2" =~ ^[0-9]+$ ]] || ops_fail '--port must be numeric'
+      PORTS+=("$2")
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      ops_fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ "$MODE" == "check" ]] || ops_fail 'only --check is supported by this script'
+
+printf '# ERP4 Sakura VPS preflight (%s)\n' "$(ops_timestamp)"
+check_os
+check_arch
+for cmd in "${REQUIRED_COMMANDS[@]}"; do
+  check_command "$cmd"
+done
+check_memory
+check_disk
+check_linger
+check_unprivileged_ports
+for port in "${PORTS[@]}"; do
+  check_port "$port"
+done
+
+printf 'Summary: failures=%s warnings=%s\n' "$FAILURES" "$WARNINGS"
+if (( FAILURES > 0 )); then
+  exit 1
+fi
+if [[ "$STRICT" -eq 1 && "$WARNINGS" -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/ops/sakura-vps-verify.sh
+++ b/scripts/ops/sakura-vps-verify.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+MODE="check"
+TARGET_DIR="${QUADLET_TARGET_DIR:-$HOME/.config/containers/systemd}"
+FRONTEND_BUILD_ENV="${FRONTEND_BUILD_ENV_FILE:-$ROOT_DIR/deploy/quadlet/env/erp4-frontend-build.env}"
+INCLUDE_PROXY=0
+RESOLVE_IP=""
+INSECURE=0
+GDRIVE_MODE="skip"
+MARKDOWN_SUMMARY=""
+SUMMARY_LINES=()
+FAILURES=0
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [--check] [options]
+
+Read-only verification helper for ERP4 Sakura VPS deployments. Google Drive write
+verification is opt-in via --gdrive-mode write and creates/deletes a test file.
+
+Options:
+  --check                         Run verification (default)
+  --target-dir DIR                Quadlet target directory
+  --frontend-build-env FILE       Frontend build env file
+  --include-proxy                 Verify HTTPS proxy as well
+  --resolve-ip ADDR               Pass to check-https.sh before DNS propagation
+  --insecure                      Pass -k to HTTPS verification
+  --gdrive-mode skip|read|write   Drive check mode (default: skip)
+  --markdown-summary FILE         Write secret-free Markdown summary
+  -h, --help                      Show this help message
+USAGE
+}
+
+add_summary() {
+  SUMMARY_LINES+=("$1")
+}
+
+run_step() {
+  local label="$1"
+  shift
+  printf '==> %s\n' "$label"
+  if "$@"; then
+    add_summary "- ✅ $label"
+  else
+    FAILURES=$((FAILURES + 1))
+    add_summary "- ❌ $label"
+    return 1
+  fi
+}
+
+write_summary() {
+  [[ -n "$MARKDOWN_SUMMARY" ]] || return 0
+  {
+    printf '# ERP4 Sakura VPS verification\n\n'
+    printf -- '- Date: `%s`\n' "$(ops_timestamp)"
+    printf -- '- Target dir: `%s`\n' "$TARGET_DIR"
+    printf -- '- Include proxy: `%s`\n' "$INCLUDE_PROXY"
+    printf -- '- Google Drive mode: `%s`\n\n' "$GDRIVE_MODE"
+    printf '## Results\n\n'
+    printf '%s\n' "${SUMMARY_LINES[@]}"
+  } > "$MARKDOWN_SUMMARY"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      MODE="check"
+      shift
+      ;;
+    --target-dir)
+      ops_require_arg "$1" "${2:-}"
+      TARGET_DIR="$2"
+      shift 2
+      ;;
+    --frontend-build-env)
+      ops_require_arg "$1" "${2:-}"
+      FRONTEND_BUILD_ENV="$2"
+      shift 2
+      ;;
+    --include-proxy)
+      INCLUDE_PROXY=1
+      shift
+      ;;
+    --resolve-ip)
+      ops_require_arg "$1" "${2:-}"
+      RESOLVE_IP="$2"
+      shift 2
+      ;;
+    --insecure)
+      INSECURE=1
+      shift
+      ;;
+    --gdrive-mode)
+      ops_require_arg "$1" "${2:-}"
+      GDRIVE_MODE="$2"
+      shift 2
+      ;;
+    --markdown-summary)
+      ops_require_arg "$1" "${2:-}"
+      MARKDOWN_SUMMARY="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      ops_fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ "$MODE" == "check" ]] || ops_fail 'only --check is supported by this script'
+case "$GDRIVE_MODE" in skip|read|write) ;; *) ops_fail '--gdrive-mode must be skip, read, or write' ;; esac
+
+run_step 'Quadlet env validation' "$ROOT_DIR/scripts/quadlet/check-env.sh" --target-dir "$TARGET_DIR" --frontend-build-env "$FRONTEND_BUILD_ENV" || true
+run_step 'Quadlet stack readiness' "$ROOT_DIR/scripts/quadlet/check-stack.sh" || true
+run_step 'Quadlet stack status' "$ROOT_DIR/scripts/quadlet/status-stack.sh" || true
+if [[ "$INCLUDE_PROXY" -eq 1 ]]; then
+  https_args=(--target-dir "$TARGET_DIR")
+  [[ -z "$RESOLVE_IP" ]] || https_args+=(--resolve-ip "$RESOLVE_IP")
+  [[ "$INSECURE" -eq 0 ]] || https_args+=(--insecure)
+  run_step 'HTTPS proxy verification' "$ROOT_DIR/scripts/quadlet/check-https.sh" "${https_args[@]}" || true
+fi
+if [[ "$GDRIVE_MODE" != "skip" ]]; then
+  run_step "Google Drive ${GDRIVE_MODE} verification" "$ROOT_DIR/scripts/ops/gcp-drive-check.sh" --mode "$GDRIVE_MODE" || true
+fi
+
+write_summary
+if (( FAILURES > 0 )); then
+  ops_fail "verification failed: $FAILURES step(s)"
+fi
+ops_info 'verification completed'


### PR DESCRIPTION
## Summary
- Add safe `scripts/ops/*` helpers for Sakura VPS preflight/bootstrap/deploy/verify with `--check` / `--dry-run` / `--apply` separation.
- Add Google Cloud preflight and Google Drive wrapper scripts that avoid printing secret values and require explicit confirmation for API enablement.
- Add `docs/ops/ops-automation.md`, example non-secret env files, and links from the Google Cloud / Sakura VPS runbooks.
- Reuse the existing Quadlet/Caddy templates under `deploy/quadlet` rather than introducing duplicate systemd templates.

Closes #1757
Closes #1758

## Verification
- `bash -n scripts/ops/*.sh scripts/ops/lib/*.sh`
- `for s in scripts/ops/*.sh; do "$s" --help >/dev/null; done`
- `scripts/ops/gcp-preflight.sh --check --project dummy --allow-missing-gcloud --markdown-summary .codex-local/tmp/gcp-preflight.md`
- `scripts/ops/gcp-drive-check.sh --dry-run --env-file .codex-local/tmp/gdrive.env --mode read --markdown-summary .codex-local/tmp/gdrive.md`
- `scripts/ops/sakura-vps-bootstrap.sh --dry-run --skip-apt --skip-linger`
- `scripts/ops/sakura-vps-deploy.sh --dry-run --skip-git-update --skip-npm-ci --skip-build-images --skip-start`
- Targeted review-fix smoke: `sakura-vps-deploy.sh --dry-run` confirms `FRONTEND_BUILD_ENV_FILE=` and `QUADLET_TARGET_DIR=` propagation.
- Targeted review-fix smoke: `gcp-drive-check.sh --dry-run` prints `cd <repo> && npx ...` to match real execution cwd.
- `npx --prefix packages/backend prettier --check docs/ops/ops-automation.md docs/ops/google-cloud-predeployment.md docs/ops/sakura-vps-deployment.md docs/ops/index.md`
- custom relative markdown link existence check for changed docs
- `bash scripts/secret-scan.sh`
- `git diff --check`
- `npm audit --prefix packages/backend --audit-level=high`

## Notes
- `shellcheck` is documented and was attempted locally, but the command is not installed in this environment. CI gating for shell scripts remains part of #1760.