### PR TITLE
ci(ops): add deployment quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
       - run: npm install --prefix packages/backend
       - run: npm run lint --prefix packages/backend
       - run: npm run format:check --prefix packages/backend
+      - run: ./scripts/check-ops-docs.sh
+      - run: ./scripts/check-ops-scripts.sh
       - run: npm install --prefix packages/frontend
       - run: npm run lint --prefix packages/frontend
       - run: npm run format:check --prefix packages/frontend

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint format-check typecheck build test coverage coverage-auth coverage-frontend coverage-frontend-core e2e ui-evidence mobile-regression-log frontend-dev-api podman-smoke pr-comments audit docs-image-links-check design-system-package-check eslint10-readiness-check eslint10-readiness-record dependabot-alerts-check dependabot-alerts-record dependabot-token-readiness-check dependency-watch-record backup-s3-readiness-check backup-s3-readiness-record po-migration-input-readiness-check po-migration-record po-migration-run-and-record av-staging-evidence av-staging-gate av-staging-readiness action-policy-callsites-report action-policy-callsites-report-json action-policy-required-action-gaps action-policy-required-action-gaps-json action-policy-fallback-report action-policy-fallback-report-json action-policy-phase3-readiness action-policy-phase3-readiness-json action-policy-phase3-readiness-record action-policy-phase3-cutover-record action-policy-phase3-trial-record
+.PHONY: lint format-check typecheck build test coverage coverage-auth coverage-frontend coverage-frontend-core e2e ui-evidence mobile-regression-log frontend-dev-api podman-smoke pr-comments audit docs-image-links-check ops-quality design-system-package-check eslint10-readiness-check eslint10-readiness-record dependabot-alerts-check dependabot-alerts-record dependabot-token-readiness-check dependency-watch-record backup-s3-readiness-check backup-s3-readiness-record po-migration-input-readiness-check po-migration-record po-migration-run-and-record av-staging-evidence av-staging-gate av-staging-readiness action-policy-callsites-report action-policy-callsites-report-json action-policy-required-action-gaps action-policy-required-action-gaps-json action-policy-fallback-report action-policy-fallback-report-json action-policy-phase3-readiness action-policy-phase3-readiness-json action-policy-phase3-readiness-record action-policy-phase3-cutover-record action-policy-phase3-trial-record
 
 lint:
 	npm run lint --prefix packages/backend
@@ -55,6 +55,10 @@ audit:
 
 docs-image-links-check:
 	node scripts/check-doc-image-links.mjs
+
+ops-quality:
+	./scripts/check-ops-docs.sh
+	./scripts/check-ops-scripts.sh
 
 design-system-package-check:
 	./scripts/check-design-system-package.sh

--- a/docs/ops/ops-automation.md
+++ b/docs/ops/ops-automation.md
@@ -217,7 +217,7 @@ make ops-quality
 - `shellcheck` がある環境での shellcheck warning 以上（未導入環境では skip を明示）
 - 各 ops entrypoint の `--help`
 - Google Cloud / Sakura VPS helper の dry-run / check smoke
-- destructive command guard（例: `rm -rf`、`git reset --hard`、`git clean -fd`、`podman volume rm`、Secret Manager の secret value access/delete）
+- destructive or secret-exposing command guard（例: `rm -rf`、`git reset --hard`、`git clean -fd`、`podman volume rm`、Secret Manager の secret value access/delete）
 - `docs/ops/examples/*.env.example` の必須キーと、OAuth client secret / token / webhook など実secretらしい値の混入検出（ログは path:line のみ）
 
 VPSホスト依存の `--check` は、CI runner に Podman / systemd / Quadlet 実体がない場合に controlled failure として扱う。これは「構文や引数処理が壊れていないこと」と「ホスト依存の不足が明示的な診断として出ること」をCIで検証するためであり、本番適用前の実ホスト preflight / verify を代替しない。

--- a/docs/ops/ops-automation.md
+++ b/docs/ops/ops-automation.md
@@ -196,20 +196,31 @@ CHAT_ATTACHMENT_GDRIVE_FOLDER_ID=...
 
 ## 品質チェック
 
-PR作成前に最低限以下を実行する。
+PR作成前に最低限以下を実行する。CI では既存の `CI / lint` job 内で同じチェックを実行し、backend 側の `npm install` 済み環境を再利用して所要時間の増加を抑える。
 
 ```bash
-bash -n scripts/ops/*.sh scripts/ops/lib/*.sh
-npx --prefix packages/backend prettier --check docs/ops/ops-automation.md docs/ops/google-cloud-predeployment.md docs/ops/sakura-vps-deployment.md docs/ops/index.md
+make ops-quality
 ```
 
-`shellcheck` が利用可能な環境では以下も実行する。
+個別に確認する場合は以下を実行する。
 
 ```bash
-shellcheck scripts/ops/*.sh scripts/ops/lib/*.sh
+./scripts/check-ops-docs.sh
+./scripts/check-ops-scripts.sh
 ```
 
-CI組み込みと dry-run の継続検証は Issue #1760 で扱う。
+`check-ops-docs.sh` は導入Runbook系 Markdown / JSON examples に対して Prettier と相対リンク存在確認を行う。外部リンクは既存の `Link Check / lychee` job が検証する。
+
+`check-ops-scripts.sh` は以下を blocking gate とする。
+
+- `scripts/ops/*.sh` と `scripts/ops/lib/*.sh` の `bash -n`
+- `shellcheck` がある環境での shellcheck warning 以上（未導入環境では skip を明示）
+- 各 ops entrypoint の `--help`
+- Google Cloud / Sakura VPS helper の dry-run / check smoke
+- destructive command guard（例: `rm -rf`、`git reset --hard`、`git clean -fd`、`podman volume rm`、Secret Manager の secret value access/delete）
+- `docs/ops/examples/*.env.example` の必須キーと、OAuth client secret / token / webhook など実secretらしい値の混入検出（ログは path:line のみ）
+
+VPSホスト依存の `--check` は、CI runner に Podman / systemd / Quadlet 実体がない場合に controlled failure として扱う。これは「構文や引数処理が壊れていないこと」と「ホスト依存の不足が明示的な診断として出ること」をCIで検証するためであり、本番適用前の実ホスト preflight / verify を代替しない。
 
 ## 関連Runbook
 

--- a/docs/ops/release-checklist.md
+++ b/docs/ops/release-checklist.md
@@ -1,7 +1,9 @@
 # リリースチェックリスト（短縮版）
 
 ## 事前（必須）
+
 - [ ] CI が green（`CI` / リンクチェック）
+- [ ] 導入Runbook / ops scripts に変更がある場合、`make ops-quality` または CI `lint` job 内の ops quality gate が成功している
 - [ ] `security-audit` が許容範囲（High/Critical なし、または例外が Issue 化済み）
 - [ ] DB migration 有無を確認（`packages/backend/prisma/migrations/`）
 - [ ] 過去30日以内に成功した backup と restore verification の証跡を確認（`docs/ops/backup-restore.md`）
@@ -14,13 +16,16 @@
 - [ ] Issue / PR コメントや Runbook には証跡本文を分散させず、証跡ファイルへのリンクのみを記載
 
 ## Go/No-Go 判定（記録必須）
+
 - [ ] `main` の required CI が release 対象コミットで成功している
 - [ ] リンクチェック（現行 job: `lychee`）が成功している
+- [ ] 導入Runbook / ops scripts の変更が release 対象に含まれる場合、ops quality gate の成功ログを確認している
 - [ ] `security-audit` が最新実行で成功、または例外が Issue / 運用記録に明記されている
 - [ ] 既知の運用残課題を解消、または受容判断を記録している
 - [ ] Go/No-Go 判定ログを当日の release Issue または change record に集約している
 
 ## 実施
+
 - [ ] タグ付け（`vX.Y.Z`）
 - [ ] Release workflow 実行（`.github/workflows/release.yml`）
 - [ ] DB migration 適用（必要時）
@@ -28,6 +33,7 @@
 - [ ] frontend 配信（静的アセット）
 
 ## 事後（必須）
+
 - [ ] 手動確認（最小）: `docs/manual/manual-test-checklist.md`
 - [ ] 監視（エラー率/遅延/依存障害）
 - [ ] 問題があれば Feature Flag で無効化、または成果物ロールバック

--- a/scripts/check-ops-docs.sh
+++ b/scripts/check-ops-docs.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ -z "${TMPDIR:-}" || "${TMPDIR}" == "/tmp" || "${TMPDIR}" == /tmp/* ]]; then
+  TMPDIR="$ROOT_DIR/.codex-local/tmp"
+fi
+NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-${npm_config_cache:-$ROOT_DIR/.codex-local/npm-cache}}"
+export TMPDIR NPM_CONFIG_CACHE npm_config_cache="$NPM_CONFIG_CACHE"
+mkdir -p "$TMPDIR" "$NPM_CONFIG_CACHE"
+
+OPS_DOC_TARGETS=(
+  docs/ops/google-cloud-predeployment.md
+  docs/ops/sakura-vps-deployment.md
+  docs/ops/ops-automation.md
+  docs/ops/codex-ops-workflows.md
+  docs/ops/index.md
+  docs/ops/release-checklist.md
+  docs/ops/examples/codex-risk-report.schema.json
+)
+
+printf '==> Checking ops documentation target files exist\n'
+missing=0
+for file in "${OPS_DOC_TARGETS[@]}"; do
+  if [[ ! -f "$file" ]]; then
+    printf 'missing ops documentation target: %s\n' "$file" >&2
+    missing=1
+  fi
+done
+[[ "$missing" -eq 0 ]] || exit 1
+
+prettier=(npm exec --prefix packages/backend -- prettier)
+if [[ -x packages/backend/node_modules/.bin/prettier ]]; then
+  prettier=(packages/backend/node_modules/.bin/prettier)
+fi
+
+printf '==> Checking ops documentation formatting\n'
+"${prettier[@]}" --check "${OPS_DOC_TARGETS[@]}"
+
+printf '==> Validating ops JSON examples\n'
+node -e '
+const fs = require("fs");
+for (const file of process.argv.slice(1)) {
+  JSON.parse(fs.readFileSync(file, "utf8"));
+  console.log(`valid JSON: ${file}`);
+}
+' docs/ops/examples/codex-risk-report.schema.json
+
+printf '==> Checking relative Markdown links in ops documentation targets\n'
+node - "${OPS_DOC_TARGETS[@]}" <<'NODE'
+const fs = require("fs");
+const path = require("path");
+
+const files = process.argv.slice(2).filter((file) => file.endsWith(".md"));
+const repo = process.cwd();
+const failures = [];
+
+function stripTitle(rawTarget) {
+  let target = rawTarget.trim();
+  if (target.startsWith("<") && target.endsWith(">")) {
+    target = target.slice(1, -1).trim();
+  }
+  const titleMatch = target.match(/^(\S+)\s+(?:["'(].*)$/);
+  if (titleMatch) {
+    target = titleMatch[1];
+  }
+  return target;
+}
+
+function isExternalOrAnchor(target) {
+  return (
+    target === "" ||
+    target.startsWith("#") ||
+    /^[a-z][a-z0-9+.-]*:/i.test(target)
+  );
+}
+
+function checkTarget(sourceFile, rawTarget, lineNumber) {
+  let target = stripTitle(rawTarget);
+  if (isExternalOrAnchor(target)) return;
+
+  const withoutFragment = target.split("#", 1)[0];
+  if (!withoutFragment) return;
+
+  let decoded = withoutFragment;
+  try {
+    decoded = decodeURI(withoutFragment);
+  } catch (_error) {
+    // Keep the raw target if it is not a valid URI-encoded path.
+  }
+
+  const resolved = path.resolve(path.dirname(sourceFile), decoded);
+  if (!resolved.startsWith(repo + path.sep) && resolved !== repo) {
+    failures.push(`${sourceFile}:${lineNumber}: link escapes repository: ${target}`);
+    return;
+  }
+  if (!fs.existsSync(resolved)) {
+    failures.push(`${sourceFile}:${lineNumber}: missing relative link target: ${target}`);
+  }
+}
+
+for (const file of files) {
+  const source = fs.readFileSync(file, "utf8");
+  const lines = source.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const lineNumber = index + 1;
+
+    const inlinePattern = /!?\[[^\]]*\]\(([^)]+)\)/g;
+    for (const match of line.matchAll(inlinePattern)) {
+      checkTarget(file, match[1], lineNumber);
+    }
+
+    const referencePattern = /^\s*\[[^\]]+\]:\s*(\S+)/;
+    const referenceMatch = line.match(referencePattern);
+    if (referenceMatch) {
+      checkTarget(file, referenceMatch[1], lineNumber);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error(failures.join("\n"));
+  process.exit(1);
+}
+console.log(`relative Markdown links valid for ${files.length} file(s)`);
+NODE
+
+printf 'Ops documentation checks completed.\n'

--- a/scripts/check-ops-scripts.sh
+++ b/scripts/check-ops-scripts.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ -z "${TMPDIR:-}" || "${TMPDIR}" == "/tmp" || "${TMPDIR}" == /tmp/* ]]; then
+  TMPDIR="$ROOT_DIR/.codex-local/tmp"
+fi
+export TMPDIR
+mkdir -p "$TMPDIR"
+SMOKE_DIR="$(mktemp -d "$TMPDIR/ops-quality.XXXXXX")"
+cleanup() {
+  rm -rf "$SMOKE_DIR"
+}
+trap cleanup EXIT
+
+mapfile -t OPS_SHELL_FILES < <(find scripts/ops -type f -name '*.sh' | sort)
+mapfile -t OPS_ENTRYPOINTS < <(find scripts/ops -maxdepth 1 -type f -name '*.sh' | sort)
+
+printf '==> Checking ops shell script syntax\n'
+for file in "${OPS_SHELL_FILES[@]}"; do
+  bash -n "$file"
+  printf 'syntax ok: %s\n' "$file"
+done
+
+printf '==> Running shellcheck when available\n'
+if command -v shellcheck >/dev/null 2>&1; then
+  shellcheck -S warning "${OPS_SHELL_FILES[@]}"
+else
+  printf 'shellcheck not found; skipped optional shellcheck gate. bash -n remains blocking.\n'
+fi
+
+printf '==> Checking ops script help output\n'
+for script in "${OPS_ENTRYPOINTS[@]}"; do
+  "$script" --help >/dev/null
+  printf 'help ok: %s\n' "$script"
+done
+
+printf '==> Checking destructive command guard\n'
+if grep -RInE '(rm[[:space:]].*(-r|-f|-rf|-fr)|git[[:space:]]+reset[[:space:]].*--hard|git[[:space:]]+clean[[:space:]].*(-f|-d)|podman[[:space:]]+volume[[:space:]]+rm|gcloud[[:space:]]+secrets[[:space:]]+versions[[:space:]]+access|gcloud[[:space:]]+secrets[[:space:]]+delete|gcloud[[:space:]]+projects[[:space:]]+delete|sudo[[:space:]]+(rm|shutdown|reboot))' scripts/ops; then
+  printf 'Potentially destructive command found in scripts/ops. Add an explicit reviewed guard before allowing it.\n' >&2
+  exit 1
+fi
+printf 'destructive command guard ok\n'
+
+require_env_key() {
+  local file="$1"
+  local key="$2"
+  if ! grep -Eq "^[[:space:]]*${key}=" "$file"; then
+    printf 'missing required sample env key: %s in %s\n' "$key" "$file" >&2
+    return 1
+  fi
+  local value
+  value="$(awk -F= -v key="$key" '$1 == key {print substr($0, index($0, "=") + 1); exit}' "$file")"
+  if [[ -z "${value// }" ]]; then
+    printf 'empty required sample env key: %s in %s\n' "$key" "$file" >&2
+    return 1
+  fi
+}
+
+printf '==> Checking sample env keys and secret-like values\n'
+gcp_env="docs/ops/examples/gcp-preflight.env.example"
+vps_env="docs/ops/examples/vps-ops.env.example"
+for key in \
+  GCP_PROJECT_ID \
+  GCP_WIF_POOL \
+  GCP_WIF_PROVIDER \
+  GCP_WIF_LOCATION \
+  GCP_WIF_SERVICE_ACCOUNT \
+  GCP_SECRET_GOOGLE_OIDC_CLIENT_SECRET \
+  GCP_SECRET_CHAT_GDRIVE_CLIENT_SECRET \
+  GCP_SECRET_CHAT_GDRIVE_REFRESH_TOKEN; do
+  require_env_key "$gcp_env" "$key"
+done
+for key in \
+  ERP4_DEPLOY_USER \
+  ERP4_REPO_PARENT \
+  ERP4_REPO_DIR \
+  ERP4_GIT_REMOTE \
+  ERP4_GIT_BRANCH \
+  QUADLET_TARGET_DIR \
+  FRONTEND_BUILD_ENV_FILE \
+  BACKEND_HEALTH_URL \
+  BACKEND_READY_URL \
+  FRONTEND_URL; do
+  require_env_key "$vps_env" "$key"
+done
+
+private_key_pattern='-----''BEGIN (RSA|EC|OPENSSH) PRIVATE KEY-----|-----''BEGIN PRIVATE KEY-----|-----''BEGIN PGP PRIVATE KEY BLOCK-----'
+secret_pattern="(${private_key_pattern}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35}|GOCSPX-[A-Za-z0-9_-]{20,}|sk-[A-Za-z0-9]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{80,}|xox[baprs]-[A-Za-z0-9-]{10,}|https://hooks\.slack\.com/services/[A-Za-z0-9/_-]{20,}|ya29\.[0-9A-Za-z._-]{20,})"
+secret_matches="$SMOKE_DIR/secret-like-matches.txt"
+if grep -RInE "$secret_pattern" docs/ops/examples/*.env.example > "$secret_matches"; then
+  printf 'Sample env file contains a value that looks like a real secret. Locations only are shown to avoid reprinting the value.\n' >&2
+  awk -F: 'NF >= 2 { print $1 ":" $2 }' "$secret_matches" >&2
+  printf 'Replace the value with a placeholder or secret resource name.\n' >&2
+  exit 1
+fi
+printf 'sample env checks ok\n'
+
+run_smoke() {
+  local label="$1"
+  shift
+  printf 'smoke: %s\n' "$label"
+  "$@"
+}
+
+run_controlled_check() {
+  local label="$1"
+  local expected_pattern="$2"
+  shift 2
+  local required_pattern=""
+  if [[ "${1:-}" == "--require" ]]; then
+    required_pattern="$2"
+    shift 2
+  fi
+  local output status
+  printf 'controlled check: %s\n' "$label"
+  set +e
+  output="$({ "$@"; } 2>&1)"
+  status=$?
+  set -e
+  printf '%s\n' "$output"
+  if [[ "$status" -eq 0 ]]; then
+    return 0
+  fi
+  if [[ -n "$required_pattern" ]] && ! grep -Eq "$required_pattern" <<<"$output"; then
+    printf 'unexpected failure in %s: required diagnostic was not found: %s\n' "$label" "$required_pattern" >&2
+    return "$status"
+  fi
+  if grep -Eq "$expected_pattern" <<<"$output"; then
+    printf 'controlled non-zero exit accepted for environment-dependent check: %s\n' "$label"
+    return 0
+  fi
+  printf 'unexpected failure in %s (exit %s)\n' "$label" "$status" >&2
+  return "$status"
+}
+
+gdrive_env="$SMOKE_DIR/gdrive-ci.env"
+cat > "$gdrive_env" <<'ENV'
+CHAT_ATTACHMENT_GDRIVE_CLIENT_ID=placeholder-client-id
+CHAT_ATTACHMENT_GDRIVE_CLIENT_SECRET=placeholder-client-secret
+CHAT_ATTACHMENT_GDRIVE_REFRESH_TOKEN=placeholder-refresh-token
+CHAT_ATTACHMENT_GDRIVE_FOLDER_ID=placeholder-folder-id
+ENV
+chmod 600 "$gdrive_env"
+
+mkdir -p "$SMOKE_DIR/quadlet"
+cp deploy/quadlet/env/erp4-postgres.env.example "$SMOKE_DIR/quadlet/erp4-postgres.env"
+cp deploy/quadlet/env/erp4-backend.env.example "$SMOKE_DIR/quadlet/erp4-backend.env"
+cp deploy/quadlet/env/erp4-frontend-build.env.example "$SMOKE_DIR/frontend-build.env"
+chmod 600 "$SMOKE_DIR/quadlet/erp4-postgres.env" "$SMOKE_DIR/quadlet/erp4-backend.env" "$SMOKE_DIR/frontend-build.env"
+
+run_controlled_check 'gcp-preflight missing-gcloud or unauthenticated safe check' '(gcloud is not installed|Summary: failures=[1-9][0-9]*)' \
+  scripts/ops/gcp-preflight.sh --check --project erp4-ci-smoke --allow-missing-gcloud --markdown-summary "$SMOKE_DIR/gcp-preflight.md"
+run_smoke 'gcp-drive dry-run with placeholder env' \
+  scripts/ops/gcp-drive-check.sh --dry-run --env-file "$gdrive_env" --mode read --markdown-summary "$SMOKE_DIR/gdrive.md"
+run_smoke 'sakura bootstrap dry-run' \
+  scripts/ops/sakura-vps-bootstrap.sh --dry-run --deploy-user deploy --repo-parent "$SMOKE_DIR/repo-parent" --repo-dir "$SMOKE_DIR/repo-parent/ITDO_ERP4" --skip-apt --skip-linger
+run_smoke 'sakura deploy dry-run with all mutating phases skipped' \
+  scripts/ops/sakura-vps-deploy.sh --dry-run --repo-dir "$ROOT_DIR" --target-dir "$SMOKE_DIR/quadlet" --frontend-build-env "$SMOKE_DIR/frontend-build.env" --skip-git-update --skip-npm-ci --skip-build-images --skip-start
+run_controlled_check 'sakura preflight check' 'Summary: failures=[1-9][0-9]*' \
+  scripts/ops/sakura-vps-preflight.sh --check --repo-dir "$ROOT_DIR" --min-memory-mb 1 --min-disk-mb 1 --port 1
+run_controlled_check 'sakura verify check without live stack' '(failed to connect to systemd user bus|http[[:space:]]+backend health[[:space:]]+failed|db[[:space:]]+postgres ready[[:space:]]+failed|verification failed: [1-9][0-9]* step\(s\))' --require 'OK: Quadlet env validation passed' \
+  env TIMEOUT_SECONDS=1 INTERVAL_SECONDS=1 BACKEND_HEALTH_URL=http://127.0.0.1:1/healthz BACKEND_READY_URL=http://127.0.0.1:1/readyz FRONTEND_URL=http://127.0.0.1:1/ \
+  scripts/ops/sakura-vps-verify.sh --check --target-dir "$SMOKE_DIR/quadlet" --frontend-build-env "$SMOKE_DIR/frontend-build.env" --markdown-summary "$SMOKE_DIR/verify.md"
+
+printf 'Ops script checks completed.\n'

--- a/scripts/check-ops-scripts.sh
+++ b/scripts/check-ops-scripts.sh
@@ -37,17 +37,17 @@ for script in "${OPS_ENTRYPOINTS[@]}"; do
   printf 'help ok: %s\n' "$script"
 done
 
-printf '==> Checking destructive command guard\n'
+printf '==> Checking destructive or secret-exposing command guard\n'
 if grep -RInE '(rm[[:space:]].*(-r|-f|-rf|-fr)|git[[:space:]]+reset[[:space:]].*--hard|git[[:space:]]+clean[[:space:]].*(-f|-d)|podman[[:space:]]+volume[[:space:]]+rm|gcloud[[:space:]]+secrets[[:space:]]+versions[[:space:]]+access|gcloud[[:space:]]+secrets[[:space:]]+delete|gcloud[[:space:]]+projects[[:space:]]+delete|sudo[[:space:]]+(rm|shutdown|reboot))' scripts/ops; then
-  printf 'Potentially destructive command found in scripts/ops. Add an explicit reviewed guard before allowing it.\n' >&2
+  printf 'Potentially destructive or secret-exposing command found in scripts/ops. Add an explicit reviewed guard before allowing it.\n' >&2
   exit 1
 fi
-printf 'destructive command guard ok\n'
+printf 'destructive or secret-exposing command guard ok\n'
 
 require_env_key() {
   local file="$1"
   local key="$2"
-  if ! grep -Eq "^[[:space:]]*${key}=" "$file"; then
+  if ! grep -Eq "^${key}=" "$file"; then
     printf 'missing required sample env key: %s in %s\n' "$key" "$file" >&2
     return 1
   fi


### PR DESCRIPTION
## Summary
- Add `scripts/check-ops-docs.sh` for deployment Runbook formatting, JSON example validation, and relative Markdown link checks.
- Add `scripts/check-ops-scripts.sh` for ops shell syntax, optional ShellCheck, `--help`, dry-run/check smoke, destructive/secret-exposing command guard, sample env key validation, and secret-like sample value detection.
- Wire the new checks into `make ops-quality` and the existing CI lint job, and document the quality gate in ops automation / release checklist.

Closes #1760

## Human approval boundary
- This PR does not change production Sakura VPS or Google Cloud resources.
- All new operational verification uses dry-run/check-mode smoke only.
- Real host preflight/verify and any `--apply` operation remain human-approved deployment steps.

## Verification
- `./scripts/check-ops-docs.sh`
- `./scripts/check-ops-scripts.sh`
- `make ops-quality`
- `PATH="$PWD/.codex-local/shellcheck/usr/bin:$PATH" make ops-quality`
- `TMPDIR="$PWD/.codex-local/tmp" SECRET_SCAN_REPORT_PATH="$PWD/.codex-local/tmp/secret-scan-report.tsv" bash scripts/secret-scan.sh`
- `.codex-local/tools/shellcheck-v0.10.0/shellcheck -S warning scripts/check-ops-docs.sh scripts/check-ops-scripts.sh scripts/ops/*.sh scripts/ops/lib/*.sh`
- `git diff --check --cached`

## Review evidence
- `codex review --uncommitted` completed with no blocking findings after staged changes and local verification.
- Copilot generated 2 comments; both were addressed and resolved.