### PR TITLE
fix(auth): require explicit delegated actor marker

### DIFF
--- a/docs/requirements/agent-delegated-auth.md
+++ b/docs/requirements/agent-delegated-auth.md
@@ -23,13 +23,23 @@
 - `JWT_SCOPE_CLAIM=scp`
 - `JWT_TOKEN_ID_CLAIM=jti`
 
+## 明示的な委任 marker
+
+`jwt_bff` mode では、bearer token を委任エージェント呼び出しとして扱うために明示的な actor marker を必須とする。
+
+- `act.sub` が存在し、かつ `sub`（principal）と異なる場合のみ委任トークンとして扱う。
+- `scp` に scope が含まれているだけの通常ユーザートークンは委任トークンとして扱わない。
+- `act.sub` が未指定、空文字、または `sub` と同一の場合は、BFF session cookie 経路を要求する通常ユーザー認証として扱う。
+
 ## スコープ表現
 
 MVPでは次の3段階を扱う。
 
-- `read-only`（同義語: `read`, `agent:read-only`, `agent:read`）
-- `write-limited`（同義語: `write`, `agent:write-limited`, `agent:write`）
+- `read-only`（同義語: `agent:read-only`, `agent:read`）
+- `write-limited`（同義語: `agent:write-limited`, `agent:write`）
 - `approval-required`（同義語: `agent:approval-required`）
+
+`read` / `write` のような汎用scope名は、通常ユーザーJWTに含まれる可能性があるため既定の委任scopeには含めない。既存IdPとの互換目的で利用する場合は、`AUTH_AGENT_READ_SCOPES` / `AUTH_AGENT_WRITE_SCOPES` に明示的に追加し、専用audience/client等と組み合わせる。
 
 ### 判定ルール
 

--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -110,10 +110,7 @@ const JWT_REVOKED_JTI = new Set(
     .filter(Boolean),
 );
 const AGENT_SCOPE_READ = new Set(
-  (
-    process.env.AUTH_AGENT_READ_SCOPES ||
-    'read-only,read,agent:read-only,agent:read'
-  )
+  (process.env.AUTH_AGENT_READ_SCOPES || 'read-only,agent:read-only,agent:read')
     .split(',')
     .map((value) => value.trim())
     .filter(Boolean),
@@ -121,7 +118,7 @@ const AGENT_SCOPE_READ = new Set(
 const AGENT_SCOPE_WRITE = new Set(
   (
     process.env.AUTH_AGENT_WRITE_SCOPES ||
-    'write-limited,write,agent:write-limited,agent:write'
+    'write-limited,agent:write-limited,agent:write'
   )
     .split(',')
     .map((value) => value.trim())
@@ -626,7 +623,7 @@ function buildUserContext(payload: JWTPayload): UserContext | null {
       : undefined;
   const audience = normalizeAudience(resolveClaim(payload, 'aud'));
   const expiresAt = normalizeExpiresAt(resolveClaim(payload, 'exp'));
-  const delegated = actorUserId !== principalUserId || scopes.length > 0;
+  const delegated = actorUserId !== principalUserId;
   const tokenIssuer = resolveClaim(payload, 'iss');
   const roles = expandRoles(
     normalizeList(resolveClaim(payload, JWT_ROLE_CLAIM)),

--- a/packages/backend/test/authDelegated.test.js
+++ b/packages/backend/test/authDelegated.test.js
@@ -27,6 +27,35 @@ test('buildUserContextFromJwtPayload: principal/actor/scopes are mapped', () => 
   assert.equal(user?.auth?.delegated, true);
 });
 
+test('buildUserContextFromJwtPayload: scopes alone do not mark JWT as delegated', () => {
+  const user = buildUserContextFromJwtPayload({
+    sub: 'principal-user',
+    scp: ['read'],
+    roles: ['user'],
+    jti: 'tok-scoped-user',
+  });
+
+  assert.equal(user?.auth?.principalUserId, 'principal-user');
+  assert.equal(user?.auth?.actorUserId, 'principal-user');
+  assert.deepEqual(user?.auth?.scopes, ['read']);
+  assert.equal(user?.auth?.delegated, false);
+});
+
+test('buildUserContextFromJwtPayload: same actor/principal is not delegated even with scopes', () => {
+  const user = buildUserContextFromJwtPayload({
+    sub: 'principal-user',
+    act: { sub: 'principal-user' },
+    scp: ['write'],
+    roles: ['user'],
+    jti: 'tok-self-actor',
+  });
+
+  assert.equal(user?.auth?.principalUserId, 'principal-user');
+  assert.equal(user?.auth?.actorUserId, 'principal-user');
+  assert.deepEqual(user?.auth?.scopes, ['write']);
+  assert.equal(user?.auth?.delegated, false);
+});
+
 test('evaluateDelegatedScope: read-only scope allows GET', () => {
   const decision = evaluateDelegatedScope(
     {

--- a/packages/backend/test/envValidation.test.js
+++ b/packages/backend/test/envValidation.test.js
@@ -456,6 +456,61 @@ test('auth plugin: production + AUTH_MODE=jwt_bff rejects direct non-delegated b
   assert.equal(body.error?.details?.reason, 'missing_session');
 });
 
+test('auth plugin: production + AUTH_MODE=jwt_bff rejects scoped bearer auth without delegated actor', () => {
+  const result = runDelegatedJwtRequest({
+    overrides: {
+      NODE_ENV: 'production',
+      AUTH_MODE: 'jwt_bff',
+      GOOGLE_OIDC_CLIENT_SECRET: 'secret',
+      GOOGLE_OIDC_REDIRECT_URI: 'https://app.example.com/auth/google/callback',
+      AUTH_FRONTEND_ORIGIN: 'https://app.example.com',
+    },
+    payload: {
+      sub: 'principal-user',
+      scp: ['read'],
+      roles: ['user'],
+      jti: 'tok-scoped-direct-jwt-bff',
+    },
+    method: 'GET',
+    url: '/me',
+    stubDb: true,
+  });
+
+  assert.equal(result.status, 0);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.statusCode, 401);
+  const body = JSON.parse(payload.body);
+  assert.equal(body.error?.details?.reason, 'missing_session');
+});
+
+test('auth plugin: production + AUTH_MODE=jwt_bff rejects scoped bearer auth with same actor and principal', () => {
+  const result = runDelegatedJwtRequest({
+    overrides: {
+      NODE_ENV: 'production',
+      AUTH_MODE: 'jwt_bff',
+      GOOGLE_OIDC_CLIENT_SECRET: 'secret',
+      GOOGLE_OIDC_REDIRECT_URI: 'https://app.example.com/auth/google/callback',
+      AUTH_FRONTEND_ORIGIN: 'https://app.example.com',
+    },
+    payload: {
+      sub: 'principal-user',
+      act: { sub: 'principal-user' },
+      scp: ['write'],
+      roles: ['user'],
+      jti: 'tok-self-actor-jwt-bff',
+    },
+    method: 'GET',
+    url: '/me',
+    stubDb: true,
+  });
+
+  assert.equal(result.status, 0);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.statusCode, 401);
+  const body = JSON.parse(payload.body);
+  assert.equal(body.error?.details?.reason, 'missing_session');
+});
+
 test('auth plugin: production + AUTH_MODE=jwt_bff allows SCIM route-level bearer auth', () => {
   const result = runInjectedRequest({
     overrides: {


### PR DESCRIPTION
## Summary
- Require an explicit delegated actor marker (`act.sub` different from `sub`) before a JWT is treated as delegated.
- Remove generic `read` / `write` from the default delegated agent scope aliases while keeping `read-only` / `write-limited` and agent-prefixed aliases.
- Add regression coverage for scoped but non-delegated `jwt_bff` bearer tokens.

Closes #1771

## Validity assessment
The finding is valid on current `origin/main`: `buildUserContext` marked a JWT as delegated when scopes were present even if no delegated actor marker existed, allowing `jwt_bff` bearer-token handling to proceed to scope checks. The fix makes actor delegation explicit and documents the updated scope default.

## Verification
- `npm ci --prefix packages/backend`
- `XDG_CACHE_HOME="$PWD/.codex-local/cache" TMPDIR="$PWD/.codex-local/tmp" DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public npx --prefix packages/backend prisma generate --config packages/backend/prisma.config.ts`
- `npm run format:check --prefix packages/backend`
- `npm run lint --prefix packages/backend`
- `XDG_CACHE_HOME="$PWD/.codex-local/cache" TMPDIR="$PWD/.codex-local/tmp" DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public npm run build --prefix packages/backend`
- `XDG_CACHE_HOME="$PWD/.codex-local/cache" TMPDIR="$PWD/.codex-local/tmp" DATABASE_URL=postgresql://user:pass@localhost:5432/postgres?schema=public node --test packages/backend/test/authDelegated.test.js packages/backend/test/envValidation.test.js`
- `git diff --check`